### PR TITLE
Show unicode characters by default for arrows keys instead of icons

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -47,6 +47,13 @@
 		<!-- should support normal, key_type_feedback, action_done, action_done+key_type_feedback, action_search, action_search+key_type_feedback, action_go, action_go+key_type_feedback  -->
 		<item name="iconKeyAction">@drawable/dark_key_action_set</item>
 		<!-- should support normal, feedback -->
+		<item name="iconKeyMic">@drawable/dark_key_mic_set</item>
+		<!-- should support normal, feedback -->
+		<item name="iconKeySettings">@drawable/dark_key_settings_set</item>
+    </style>
+
+    <style name="GingerbreadKeyIconTheme">
+		<!-- should support normal, feedback -->
 		<item name="iconKeyArrowRight">@drawable/dark_key_arrow_right_set</item>
 		<!-- should support normal, feedback -->
 		<item name="iconKeyArrowLeft">@drawable/dark_key_arrow_left_set</item>
@@ -54,11 +61,8 @@
 		<item name="iconKeyArrowUp">@drawable/dark_key_arrow_up_set</item>
 		<!-- should support normal, feedback -->
 		<item name="iconKeyArrowDown">@drawable/dark_key_arrow_down_set</item>
-		<!-- should support normal, feedback -->
-		<item name="iconKeyMic">@drawable/dark_key_mic_set</item>
-		<!-- should support normal, feedback -->
-		<item name="iconKeySettings">@drawable/dark_key_settings_set</item>
     </style>
+
     <style name="AnyKeyboardBaseTheme">
         <item name="android:background">@drawable/dark_background</item>
         <item name="keyboardWallpaper">@drawable/ask_wallpaper</item>

--- a/res/xml/keyboard_themes.xml
+++ b/res/xml/keyboard_themes.xml
@@ -23,7 +23,7 @@
         nameResId="@string/gingerbread_keyboard_theme_name"
         themeRes="@style/Gingerbread"
         popupThemeRes="@style/GingerbreadPopup"
-        iconsThemeRes="@style/AnyKeyboardBaseKeyIconTheme"
+        iconsThemeRes="@style/GingerbreadKeyIconTheme"
         themeScreenshot="@drawable/gingerbread_theme_screenshot"
         description="@string/gingerbread_keyboard_theme_description"
         index="3"/>

--- a/src/com/anysoftkeyboard/keyboards/views/AnyKeyboardBaseView.java
+++ b/src/com/anysoftkeyboard/keyboards/views/AnyKeyboardBaseView.java
@@ -495,7 +495,7 @@ public class AnyKeyboardBaseView extends View implements
 		}
 		a.recycle();
 		// taking missing icons
-		int fallbackIconSetStyleId = fallbackTheme.getIconsThemeResId();
+		int fallbackIconSetStyleId = R.style.AnyKeyboardBaseKeyIconTheme;
 		Log.d(TAG,
 				"Will use keyboard fallback icons theme "
 						+ fallbackTheme.getName() + " id "
@@ -1867,6 +1867,14 @@ public class AnyKeyboardBaseView extends View implements
 			return getContext().getText(R.string.label_home_key);
 		case KeyCodes.MOVE_END:
 			return getContext().getText(R.string.label_end_key);
+		case KeyCodes.ARROW_DOWN:
+			return "\u2193";
+		case KeyCodes.ARROW_LEFT:
+			return "\u2190";
+		case KeyCodes.ARROW_RIGHT:
+			return "\u2192";
+		case KeyCodes.ARROW_UP:
+			return "\u2191";
 		default:
 			return null;
 		}
@@ -1990,9 +1998,8 @@ public class AnyKeyboardBaseView extends View implements
 		int popupWidth = 0;
 		int popupHeight = 0;
 		// Should not draw hint icon in key preview
-		CharSequence label = tracker.getPreviewText(key, mKeyboard.isShifted());
-		if (TextUtils.isEmpty(label)) {
-			Drawable iconToDraw = getIconToDrawForKey(key, true);
+		Drawable iconToDraw = getIconToDrawForKey(key, true);
+		if (iconToDraw != null) {
 			//Here's an annoying bug for you (explaination at the end of the hack)
 			mPreviewIcon.setImageState(iconToDraw.getState(), false);
 			//end of hack. You see, the drawable comes with a state, this state is overriden by the ImageView. Nomore.
@@ -2005,6 +2012,10 @@ public class AnyKeyboardBaseView extends View implements
 					.max(mPreviewIcon.getMeasuredHeight(), key.height);
 			mPreviewText.setText(null);
 		} else {
+			CharSequence label = tracker.getPreviewText(key, mKeyboard.isShifted());
+			if (TextUtils.isEmpty(label)) {
+				label = guessLabelForKey((AnyKey)key);
+			}
 			mPreviewIcon.setImageDrawable(null);
 			mPreviewText.setTextColor(mPreviewKeyTextColor);
 			setKeyPreviewText(key, label);


### PR DESCRIPTION
Previous versions of ASK used Unicode arrow characters for arrow keys by default. I think they're much more cute than current gingerbread-like rounded icons. And the main problem is that now no theme can return to the old look and use characters again, because the code takes that icons as a default!
The issue was previously here: http://code.google.com/p/softkeyboard/issues/detail?id=984
Now I've rebased it against your new version.
Also it changes fallbackIconSetStyleId from fallbackTheme.getIconsThemeResId() (which is the default theme id) to just hardcoded R.style.AnyKeyboardBaseKeyIconTheme.
I assume it's more correct because in theory any theme may be selected as default, and for example if you'll select gingerbread one, with previous code you'll again lose the ability to return back to unicode arrows.

So please review and merge this change! :-)
