### PR TITLE
When typing really fast, autotext is late to the party of "pickDefaultSuggestion"

### DIFF
--- a/src/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/src/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -2677,14 +2677,16 @@ public class AnySoftKeyboard extends InputMethodService implements
     }
 
     private boolean pickDefaultSuggestion() {
-        final CharSequence bestWord = mWord.getPreferredWord();
-        if (DEBUG)
-            Log.d(TAG, "pickDefaultSuggestion: bestWord:" + bestWord);
+
         // Complete any pending candidate query first
         if (mHandler.hasMessages(MSG_UPDATE_SUGGESTIONS)) {
             performUpdateSuggestions();
         }
 
+        final CharSequence bestWord = mWord.getPreferredWord();
+        if (DEBUG)
+            Log.d(TAG, "pickDefaultSuggestion: bestWord:" + bestWord);
+        
         if (!TextUtils.isEmpty(bestWord)) {
             final CharSequence typedWord = mWord.getTypedWord();
             TextEntryState.acceptedDefault(typedWord, bestWord);


### PR DESCRIPTION
Autotext suggest a correction and is picked if _displayed_ when pressing space. But in real usage, if you type really fast, the autotext is not _displayed_ and when pressing space, the best _match_ (aka getPreferredWord) is different than the autocorrection.. (defeating the purpose of autotext)

For example... with default installation if you type "aber" it will suggest "ages". If you type "aber" really fast, a lot of times.. (as in real usage) you will be able to _commit_ "aber" and autotext will miss the correction..

I _think_ this fix it, as I'm unable to type "aber" because is always autocorrected to my setting.
