### PR TITLE
Unicode Emoticons for qick text

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -414,6 +414,7 @@
   <string name="eng_dictionary">Englisch</string>
   <string name="simley_key_name">Smiley-Taste</string>
   <string name="default_quick_text_key_name">Einfache Emoticons</string>
+  <string name="unicode_quick_text_key_name">Unicode Emoticons</string>
   <string name="multitap_timeout_title">Multi-Tap-Timeout</string>
   <string name="multitap_timeout_summary">Timeout zwischen den Tippvorgängen</string>
   <string name="settings_multitap_timeout_disabled">Deaktiviert</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -645,6 +645,7 @@
 
     <string name="simley_key_name">Smiley key</string>
     <string name="default_quick_text_key_name">Simple Emoticons</string>
+    <string name="unicode_quick_text_key_name">Unicode Emoticons</string>
 
     <string name="multitap_timeout_title">Multi-tap timeout</string>
     <string name="multitap_timeout_summary">Timeout between key taps</string>

--- a/res/values/strings_dont_translate.xml
+++ b/res/values/strings_dont_translate.xml
@@ -4,6 +4,7 @@
 
     <string name="quick_text_smiley_key_label">:-)</string>
     <string name="quick_text_smiley_key_output">:-)\u0020</string>
+    <string name="quick_text_smiley_key_unicode_output">\uD83D\uDE0A\u0020</string><!-- SMILING FACE WITH SMILING EYES (U+1F60A) -->
 
     <string name="copyright_owner">Menny Even-Danan</string>
 

--- a/res/xml/popup_unicode_quick_text.xml
+++ b/res/xml/popup_unicode_quick_text.xml
@@ -7,71 +7,68 @@
     <Row android:rowEdgeFlags="top">
         <Key
                 android:keyEdgeFlags="left"
-                android:keyLabel="\\m/"
-                android:keyOutputText="\\m/\u0020"/>
+                android:keyLabel="\uD83D\uDE1B"
+                android:keyOutputText="\uD83D\uDE1B\u0020"/><!-- FACE WITH STUCK-OUT TONGUE (U+1F61B) -->
         <Key
-                android:keyLabel="O_Q"
-                android:keyOutputText="O_Q\u0020"
-                ask:shiftedKeyLabel="O_Q"/>
+                android:keyLabel="\uD83D\uDE20"
+                android:keyOutputText="\uD83D\uDE20\u0020"/><!-- ANGRY FACE (U+1F620) -->
         <Key
-                android:keyLabel="o_O"
-                android:keyOutputText="o_O\u0020"
-                ask:shiftedKeyLabel="o_O"/>
+                android:keyLabel="\uD83C\uDF39"
+                android:keyOutputText="\uD83C\uDF39\u0020"/><!-- ROSE (U+1F339) -->
         <Key
-                android:keyLabel="(^_^)"
-                android:keyOutputText="(^_^)\u0020"/>
+                android:keyLabel="\uD83D\uDC4D"
+                android:keyOutputText="\uD83D\uDC4D\u0020"/><!-- THUMBS UP SIGN (U+1F44D) -->
         <Key
-                android:keyLabel="(ToT)"
-                android:keyOutputText="(ToT)\u0020"/>
+                android:keyLabel="\uD83D\uDC11"
+                android:keyOutputText="\uD83D\uDC11\u0020"/><!-- SHEEP (U+1F411) -->
         <Key
                 android:keyEdgeFlags="right"
-                android:keyLabel="rose"
-                android:keyOutputText="\@}-;-&apos;--\u0020"
-                ask:shiftedKeyLabel="rose"/>
+                android:keyLabel="\uD83D\uDCA8"
+                android:keyOutputText="\uD83D\uDCA8\u0020"/><!-- DASH SYMBOL (U+1F4A8) -->
     </Row>
     <Row>
         <Key
                 android:keyEdgeFlags="left"
-                android:keyLabel="♥"
-                android:keyOutputText="♥"/>
+                android:keyLabel="\uD83D\uDE20"
+                android:keyOutputText="\uD83D\uDE20\u0020"/><!-- ANGRY FACE (U+1F620) -->
         <Key
-                android:keyLabel=":-*"
-                android:keyOutputText=":-*\u0020"/>
+                android:keyLabel="\uD83D\uDE17"
+                android:keyOutputText="\uD83D\uDE17\u0020"/><!-- KISSING FACE (U+1F617) -->
         <Key
-                android:keyLabel="★"
-                android:keyOutputText="★"/>
+                android:keyLabel="\uD83D\uDE18"
+                android:keyOutputText="\uD83D\uDE18\u0020"/><!-- FACE THROWING A KISS (U+1F618) -->
         <Key
-                android:keyLabel="♬"
-                android:keyOutputText="♬"/>
+                android:keyLabel="\uD83D\uDE08"
+                android:keyOutputText="\uD83D\uDE08"/><!-- SMILING FACE WITH HORNS (U+1F608) -->
         <Key
-                android:keyLabel="ヅ"
-                android:keyOutputText="ヅ"/>
+                android:keyLabel="\uD83D\uDE2E"
+                android:keyOutputText="\uD83D\uDE2E\u0020"/><!-- FACE WITH OPEN MOUTH (U+1F62E) -->
         <Key
                 android:keyEdgeFlags="right"
-                android:keyLabel=":-/﻿"
-                android:keyOutputText=":-/﻿\u0020"/>
+                android:keyLabel="\uD83D\uDE31"
+                android:keyOutputText="\uD83D\uDE31\u0020"/><!-- FACE SCREAMING IN FEAR (U+1F631) -->
     </Row>
     <Row android:rowEdgeFlags="bottom">
         <Key
                 android:keyEdgeFlags="left"
-                android:keyLabel=":-("
-                android:keyOutputText=":-(\u0020"/>
+                android:keyLabel="\uD83D\uDE1E"
+                android:keyOutputText="\uD83D\uDE1E\u0020"/><!-- DISAPPOINTED FACE (U+1F61E) -->
         <Key
-                android:keyLabel=":_("
-                android:keyOutputText=":_(\u0020"/>
+                android:keyLabel="\uD83D\uDE09"
+                android:keyOutputText="\uD83D\uDE09\u0020"/><!-- WINKING FACE (U+1F609) -->
         <Key
-                android:keyLabel=";-)"
-                android:keyOutputText=";-)\u0020"/>
+                android:keyLabel="\uD83D\uDE22"
+                android:keyOutputText="\uD83D\uDE22\u0020"/><!-- CRYING FACE (U+1F622) -->
         <Key
-                android:keyLabel=":-D"
-                android:keyOutputText=":-D\u0020"/>
+                android:keyLabel="\uD83D\uDE03"
+                android:keyOutputText="\uD83D\uDE03\u0020"/><!-- SMILING FACE WITH OPEN MOUTH (U+1F603) -->
         <Key
-                android:keyLabel=":-O"
-                android:keyOutputText=":-O\u0020"/>
+                android:keyLabel="\uD83D\uDE02"
+                android:keyOutputText="\uD83D\uDE02\u0020"/><!-- FACE WITH TEARS OF JOY (U+1F602) -->
         <Key
                 android:keyEdgeFlags="right"
-                android:keyLabel="}-]"
-                android:keyOutputText="}-]\u0020"/>
+                android:keyLabel="\uD83D\uDE32"
+                android:keyOutputText="\uD83D\uDE32\u0020"/><!-- ASTONISHED FACE (U+1F632) -->
     </Row>
 
 </Keyboard>

--- a/res/xml/quick_text_keys.xml
+++ b/res/xml/quick_text_keys.xml
@@ -18,4 +18,13 @@
             keyOutputText="@string/quick_text_smiley_key_output"
             description=""
             index="2"/>
+    <QuickTextKey
+            id="698b8c20-19df-11e1-bddb-0800200c9a67"
+            nameResId="@string/unicode_quick_text_key_name"
+            popupKeyboard="@xml/popup_unicode_quick_text"
+            keyIcon="@drawable/sym_keyboard_smiley"
+            keyLabel="@string/quick_text_smiley_key_label"
+            keyOutputText="@string/quick_text_smiley_key_unicode_output"
+            description=""
+            index="3"/>
 </QuickTextKeys>


### PR DESCRIPTION
Using Unicode Emoticons instead of the plain-text ones. This is useful for 4.4+ androids, since some apps (like text secure) disabled their own icon system in this case.

I really don't know, what this id-stuff in  res/xml/quick_text_keys.xml#22 means, I simply increased the number by 1.
