### PR TITLE
Allow plugin extension keyboards

### DIFF
--- a/src/main/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactory.java
+++ b/src/main/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactory.java
@@ -123,7 +123,7 @@ public class KeyboardExtensionFactory extends AddOnsFactory<KeyboardExtension> {
         super("ASK_EKF", "com.anysoftkeyboard.plugin.EXTENSION_KEYBOARD",
                 "com.anysoftkeyboard.plugindata.extensionkeyboard",
                 "ExtensionKeyboards", "ExtensionKeyboard",
-                R.xml.extension_keyboards, false);// At this point in time, I do
+                R.xml.extension_keyboards, true);// At this point in time, I do
         // not allow external packs
     }
 


### PR DESCRIPTION
Hi, is there a reason why plugin extension keyboards are not allowed or could this just be switched to true?
