### PR TITLE
Add dash variations and square root symbol to symbol tables

### DIFF
--- a/src/main/res/xml/symbols.xml
+++ b/src/main/res/xml/symbols.xml
@@ -39,7 +39,7 @@
         <Key android:codes="58" android:keyLabel=":" android:popupCharacters=";"/>
         <Key android:codes="63" android:keyLabel="\?"/>
         <Key android:codes="47" android:keyLabel="/"/>
-        <Key android:codes="45" android:keyLabel="-"/>
+        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="–—"/>
         <Key android:codes="61" android:keyLabel="="/>
         <Key android:codes="43" android:keyLabel="+"/>
         <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>

--- a/src/main/res/xml/symbols_alt.xml
+++ b/src/main/res/xml/symbols_alt.xml
@@ -9,7 +9,7 @@
         <Key android:codes="126" android:keyLabel="~"/>
         <Key android:codes="177" android:keyLabel="±"/>
         <Key android:codes="215" android:keyLabel="×"/>
-        <Key android:codes="247" android:keyLabel="÷"/>
+        <Key android:codes="247" android:keyLabel="÷" android:popupCharacters="&#8730;"/>
         <Key android:codes="91" android:keyLabel="["/>
         <Key android:codes="93" android:keyLabel="]"/>
         <Key android:codes="123" android:keyLabel="{"/>
@@ -23,7 +23,7 @@
         <Key android:codes="191" android:keyLabel="¿"/>
         <Key android:codes="9829" android:keyLabel="&#9829;" android:popupCharacters="&#9830;&#9827;&#9824;&#9733;"/>
         <Key android:codes="169" android:keyLabel="©"/>
-        <Key android:codes="174" android:keyLabel="®"/>
+        <Key android:codes="174" android:keyLabel="®" android:popupCharacters="&#8482;"/>
         <Key android:codes="@integer/key_code_arrow_left"/>
         <Key android:codes="@integer/key_code_arrow_up"/>
         <Key android:codes="@integer/key_code_arrow_down"/>


### PR DESCRIPTION
Adding the square root symbol required moving the division symbol to the multiplication symbol key to make room.