### PR TITLE
Create variant of Yochees Dark theme with hints

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,6 +413,7 @@
     <string name="lean_dark_gray_keyboard_theme_description">Dark Gray theme, with minimal UI elements</string>
     <string name="yochees_dark_keyboard_theme_name">Yochees Dark</string>
     <string name="yochees_dark_keyboard_theme_description">Dark theme by Algimantas.</string>
+    <string name="yochees_dark_2_keyboard_theme_name">Yochees Dark - Option 2</string>
     <string name="yochees_light_keyboard_theme_name">Yochees Light</string>
     <string name="yochees_light_keyboard_theme_description">Light theme by Algimantas.</string>
     <!-- extension keyboard type -->

--- a/app/src/main/res/values/styles_yochees_keyboard_theme.xml
+++ b/app/src/main/res/values/styles_yochees_keyboard_theme.xml
@@ -141,4 +141,14 @@
         <item name="keyTextColor">#FFFFFF</item>
     </style>
 
+    <style name="YocheesDark2Theme" parent="@style/YocheesDarkTheme">
+        <item name="keyTextSize">@dimen/lean_key_text_size</item>
+        <item name="keyTextStyle">bold</item>
+        <item name="hintTextSize">@dimen/key_hint_text_size</item>
+    </style>
+
+    <style name="YocheesDark2Popup" parent="@style/YocheesDarkPopup">
+        <item name="keyTextSize">@dimen/lean_key_text_size</item>
+        <item name="keyTextStyle">bold</item>
+    </style>
 </resources>

--- a/app/src/main/res/xml/keyboard_themes.xml
+++ b/app/src/main/res/xml/keyboard_themes.xml
@@ -115,4 +115,12 @@
         description="@string/yochees_light_keyboard_theme_description"
         devOnly="true"
         index="20"/>
+    <KeyboardTheme
+        id="bdecfba3-a937-4ee6-be50-e7793ff239fb"
+        nameResId="@string/yochees_dark_2_keyboard_theme_name"
+        themeRes="@style/YocheesDark2Theme"
+        popupThemeRes="@style/YocheesDark2Popup"
+        iconsThemeRes="@style/YocheesDarkKeyIconTheme"
+        description="@string/yochees_dark_keyboard_theme_description"
+        index="21"/>
 </KeyboardThemes>

--- a/app/src/test/java/com/anysoftkeyboard/addons/AddOnsFactoryTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/addons/AddOnsFactoryTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RunWith(AnySoftKeyboardTestRunner.class)
 public class AddOnsFactoryTest {
 
-    private static final int STABLE_THEMES_COUNT = 11;
+    private static final int STABLE_THEMES_COUNT = 12;
     private static final int UNSTABLE_THEMES_COUNT = 2;
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Adds a variant of Yochees Dark theme with hints. Similar to Lean Dark - Option 2

![screenshot_20170528-155000](https://cloud.githubusercontent.com/assets/6550543/26531730/7506bbac-43bd-11e7-9af8-158b9b4a322e.png)
