### PR TITLE
Add a few additional short smileys

### DIFF
--- a/app/src/main/res/xml/popup_smileys.xml
+++ b/app/src/main/res/xml/popup_smileys.xml
@@ -7,8 +7,10 @@
         <Key android:keyLabel=":-)" android:keyOutputText=":)\u0020" />
         <Key android:keyLabel=";-)" android:keyOutputText=";)\u0020" />
         <Key android:keyLabel=":-(" android:keyOutputText=":(\u0020" />
+        <Key android:keyLabel=":-D" android:keyOutputText=":D\u0020" />
         <Key android:keyLabel="x-D" android:keyOutputText="xD\u0020" />
         <Key android:keyLabel=":-P" android:keyOutputText=":P\u0020" />
+        <Key android:keyLabel="B-)" android:keyOutputText="B)\u0020" />
         <Key android:keyLabel=":-*" android:keyOutputText=":*\u0020" />
         <Key android:keyLabel=":-/" android:keyOutputText=":/\u0020" />
         <Key android:keyLabel=":-S" android:keyOutputText=":S\u0020" />
@@ -20,6 +22,7 @@
         <Key android:keyLabel="&lt;-3" android:keyOutputText="&lt;3\u0020" />
         <Key android:keyLabel="&lt;/3" android:keyOutputText="&lt;/3\u0020" />
         <Key android:keyLabel=":-o" android:keyOutputText=":o\u0020" />
+        <Key android:keyLabel=":-O" android:keyOutputText=":O\u0020" />
         <Key android:keyLabel=":-x" android:keyOutputText=":x\u0020" />
         <Key android:keyLabel=":-))" android:keyOutputText=":))\u0020" />
         <Key android:keyLabel="O_Q" android:keyOutputText="O_Q\u0020" />

--- a/app/src/main/res/xml/popup_smileys_short.xml
+++ b/app/src/main/res/xml/popup_smileys_short.xml
@@ -7,8 +7,10 @@
         <Key android:keyLabel=":)" android:keyOutputText=":)\u0020" />
         <Key android:keyLabel=";)" android:keyOutputText=";)\u0020" />
         <Key android:keyLabel=":(" android:keyOutputText=":(\u0020" />
+        <Key android:keyLabel=":D" android:keyOutputText=":D\u0020" />
         <Key android:keyLabel="xD" android:keyOutputText="xD\u0020" />
         <Key android:keyLabel=":P" android:keyOutputText=":P\u0020" />
+        <Key android:keyLabel="B)" android:keyOutputText="B)\u0020" />
         <Key android:keyLabel=":*" android:keyOutputText=":*\u0020" />
         <Key android:keyLabel=":/" android:keyOutputText=":/\u0020" />
         <Key android:keyLabel=":S" android:keyOutputText=":S\u0020" />
@@ -20,6 +22,7 @@
         <Key android:keyLabel="&lt;3" android:keyOutputText="&lt;3\u0020" />
         <Key android:keyLabel="&lt;/3" android:keyOutputText="&lt;/3\u0020" />
         <Key android:keyLabel=":o" android:keyOutputText=":o\u0020" />
+        <Key android:keyLabel=":O" android:keyOutputText=":O\u0020" />
         <Key android:keyLabel=":x" android:keyOutputText=":x\u0020" />
         <Key android:keyLabel=":))" android:keyOutputText=":))\u0020" />
         <Key android:keyLabel="O_Q" android:keyOutputText="O_Q\u0020" />

--- a/jnidictionaryv1/src/main/jni/source/dictionary.cpp
+++ b/jnidictionaryv1/src/main/jni/source/dictionary.cpp
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <fcntl.h>
+#include <string.h>
 
 #include "basechars.h"
 #include "lowerchars.h"


### PR DESCRIPTION
This PR adds support for `:D` `B)` and `:O`, which are fairly common smileys (to me, at least) but missing form the stock text smileys. 

I also had to make a small change to get this to compile at all, let me know if that shouldn't be added and I'll trash that commit.

One more point, shouldn't the 'long form' of smileys print out long smileys? Pressing on `:-)` prints out `:)` on the debug build (and that makes sense, since that's how it's listed out in the field), but I have a phone with the stable release that /sometimes/ works? I'm not really sure what's going on there. It doesn't matter too much to me, because shorter smileys rule `:)`

Let me know if anything should be changed, or if you spot anything amiss.
