### PR TITLE
Fix caps lock when gesture typing

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -819,6 +819,12 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
     }
 
     @Override
+    public void pickLastSuggestion() {
+        if (mCandidateView.getSuggestions().size() > 0)
+            pickSuggestionManually(0, mCandidateView.getSuggestions().get(0));
+    }
+
+    @Override
     public boolean onEvaluateFullscreenMode() {
         if (getCurrentInputEditorInfo() != null) {
             final EditorInfo editorInfo = getCurrentInputEditorInfo();
@@ -1233,6 +1239,11 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
     @Override
     public void onKey(int primaryCode, Key key, int multiTapIndex, int[] nearByKeyCodes, boolean fromUI) {
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
+
+        if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
+            pickLastSuggestion();
+        }
+
         if (primaryCode > 0) {
             onNonFunctionKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -12,6 +12,7 @@ import com.menny.android.anysoftkeyboard.R;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWithQuickText {
 
@@ -57,8 +58,8 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     }
 
     public abstract void setSuggestions(List<? extends CharSequence> suggestions,
-                                        boolean completions, boolean typedWordValid,
-                                        boolean haveMinimalSuggestion);
+            boolean completions, boolean typedWordValid,
+            boolean haveMinimalSuggestion);
 
     public abstract void pickLastSuggestion();
 
@@ -97,11 +98,20 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
             final boolean isShifted = mShiftKeyState.isActive();
             final boolean isCapsLocked = mShiftKeyState.isLocked();
 
-            if (isShifted || isCapsLocked) {
-                for (int i=0; i<gestureTypingPossibilities.size(); ++i) {
-                    String capitalized = gestureTypingPossibilities.get(i).substring(0,1).toUpperCase()
-                            + gestureTypingPossibilities.get(i).substring(1);
-                    gestureTypingPossibilities.set(i, capitalized);
+            final Locale locale = getCurrentAlphabetKeyboard().getLocale();
+            if (locale != null && (isShifted || isCapsLocked)) {
+
+                StringBuilder builder = new StringBuilder();
+                for (int i = 0; i < gestureTypingPossibilities.size(); ++i) {
+                    final String word = gestureTypingPossibilities.get(i);
+                    if (isCapsLocked) {
+                        gestureTypingPossibilities.set(i, word.toUpperCase(locale));
+                    } else {
+                        builder.append(word.substring(0, 1).toUpperCase(locale));
+                        builder.append(word.substring(1));
+                        gestureTypingPossibilities.set(i, builder.toString());
+                        builder.setLength(0);
+                    }
                 }
             }
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -93,6 +93,14 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
             final boolean isShifted = mShiftKeyState.isActive();
             final boolean isCapsLocked = mShiftKeyState.isLocked();
 
+            if (isShifted || isCapsLocked) {
+                for (int i=0; i<gestureTypingPossibilities.size(); ++i) {
+                    String capitalized = gestureTypingPossibilities.get(i).substring(0,1).toUpperCase()
+                            + gestureTypingPossibilities.get(i).substring(1);
+                    gestureTypingPossibilities.set(i, capitalized);
+                }
+            }
+
             if (gestureTypingPossibilities.size() > 0) {
                 ic.beginBatchEdit();
                 final boolean alsoAddSpace = TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE;
@@ -119,7 +127,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
                     setSuggestions(gestureTypingPossibilities, false, true, true);
                 } else {
                     //clearing any suggestion shown
-                    setSuggestions(Collections.<CharSequence>emptyList(), false, false, false);
+                    setSuggestions(Collections.emptyList(), false, false, false);
                 }
 
                 ic.endBatchEdit();

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -60,6 +60,8 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
                                         boolean completions, boolean typedWordValid,
                                         boolean haveMinimalSuggestion);
 
+    public abstract void pickLastSuggestion();
+
     @Override
     public boolean isValidGestureTypingStart(int x, int y) {
         if (!getGestureTypingEnabled()) return false;
@@ -85,6 +87,8 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     @Override
     public void onGestureTypingInputDone() {
         if (!getGestureTypingEnabled()) return;
+        pickLastSuggestion();
+
         InputConnection ic = getCurrentInputConnection();
 
         if (getGestureTypingEnabled() && ic != null) {
@@ -103,13 +107,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
 
             if (gestureTypingPossibilities.size() > 0) {
                 ic.beginBatchEdit();
-                final boolean alsoAddSpace = TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE;
                 abortCorrectionAndResetPredictionState(false);
-
-                if (alsoAddSpace) {
-                    //adding space automatically
-                    ic.commitText(" ", 1);
-                }
 
                 CharSequence word = gestureTypingPossibilities.get(0);
 
@@ -118,7 +116,8 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
                 mWord.setAutoCapitalized(isShifted || isCapsLocked);
                 mWord.simulateTypedWord(word);
 
-                commitWordToInput(mWord.getTypedWord(), false);
+                mWord.setPreferredWord(mWord.getTypedWord());
+                ic.setComposingText(mWord.getTypedWord(), 1);
 
                 TextEntryState.performedGesture();
 

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
@@ -356,7 +356,7 @@ public class CandidateView extends View {
         return true;
     }
 
-    /* package */List<CharSequence> getSuggestions() {
+    public List<CharSequence> getSuggestions() {
         return mSuggestions;
     }
 


### PR DESCRIPTION
TODO:
- [x] Fix auto capitalization
- [x] Fix manual selection of suggestions
- [x] Fix issue where manually typing a word and then gesturing does not input a space
- [ ] Inputting a space after a gesture should not finish the sentence
- [ ] Backspace after a gesture should remove the whole word
- [ ] Do not re-create the key cache for minor changes to keyboard (ex: url bar in chrome)