### PR TITLE
Delete whole word when deleting a gestured word

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -527,9 +527,9 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
             Logger.d(TAG, "onUpdateSelection: I am in ACCEPTED_DEFAULT state, time to store the position - I can only undo-commit from here.");
             mUndoCommitCursorPosition = newSelStart;
         }
-        if (!mJustAddedAutoSpace) {
+        if (!mJustExitedGestureFromShift) {
             updateShiftStateNow();
-        } else mJustAddedAutoSpace = false;
+        } else mJustExitedGestureFromShift = false;
 
         final boolean isExpectedEvent = SystemClock.uptimeMillis() < mExpectingSelectionUpdateBy;
         mExpectingSelectionUpdateBy = NEVER_TIME_STAMP;
@@ -1251,7 +1251,6 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
 
         if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
-            boolean isActive = mShiftKeyState.isActive();
             pickLastSuggestion();
 
             if (primaryCode == KeyCodes.SHIFT) {

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1252,16 +1252,18 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
         if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
             boolean isActive = mShiftKeyState.isActive();
-            System.out.println("*************** Performed gesture pick last suggestion: " + isActive + " keycode: " + primaryCode);
             pickLastSuggestion();
 
             if (primaryCode == KeyCodes.SHIFT) {
                 mJustExitedGestureFromShift = true;
             }
 
-            if (primaryCode == KeyCodes.SPACE || primaryCode == KeyCodes.SHIFT
+            if (primaryCode == KeyCodes.SPACE) {
+                if (mAutoSpace) return;
+            }
+            else if (primaryCode == KeyCodes.SHIFT
                 || primaryCode == KeyCodes.SHIFT_LOCK) return;
-            TextEntryState.performedGesture();
+            else TextEntryState.performedGesture();
         }
 
         if (primaryCode > 0) {
@@ -1571,7 +1573,6 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
     private void handleShift() {
         if (getInputView() != null) {
-            new Exception().printStackTrace();
             Logger.d(TAG, "shift Setting UI active:%s, locked: %s", mShiftKeyState.isActive(), mShiftKeyState.isLocked());
             getInputView().setShifted(mShiftKeyState.isActive());
             getInputView().setShiftLocked(mShiftKeyState.isLocked());

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1687,7 +1687,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
             pickDefaultSuggestion(isAutoCorrect() && !newLine);
             // Picked the suggestion by a space/punctuation character: we will treat it
             // as "added an auto space".
-            mJustAddedAutoSpace = !newLine;
+            mJustAddedAutoSpace = mAutoSpace && !newLine;
         } else if (separatorInsideWord) {
             // when putting a separator in the middle of a word, there is no
             // need to do correction, or keep knowledge
@@ -1855,9 +1855,13 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
         return false;
     }
 
-    @Override
     public void pickSuggestionManually(int index, CharSequence suggestion) {
-        super.pickSuggestionManually(index, suggestion);
+        pickSuggestionManually(index, suggestion, mAutoSpace);
+    }
+
+    @Override
+    public void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
+        super.pickSuggestionManually(index, suggestion, withAutoSpaceEnabled);
         final String typedWord = mWord.getTypedWord().toString();
 
         if (mWord.isAtTagsSearchState()) {
@@ -1895,7 +1899,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
             TextEntryState.acceptedSuggestion(mWord.getTypedWord(), suggestion);
             // Follow it with a space
-            if (mAutoSpace && (index == 0 || !mWord.isAtTagsSearchState())) {
+            if (withAutoSpaceEnabled && (index == 0 || !mWord.isAtTagsSearchState())) {
                 sendKeyChar((char) KeyCodes.SPACE);
                 mJustAddedAutoSpace = true;
                 setSpaceTimeStamp(true);

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1249,6 +1249,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
         if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
             pickLastSuggestion();
+            if (primaryCode == KeyCodes.SPACE) return;
             TextEntryState.performedGesture();
         }
 

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -963,6 +963,13 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 {
                     break;
                 }
+                if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
+                    // Delete the space added by picking the last suggestion
+                    handleDeleteLastCharacter(false);
+                    // Then, delete the last word
+                    handleBackWord(ic);
+                    break;
+                }
                 // we do backword if the shift is pressed while pressing
                 // backspace (like in a PC)
                 if (mUseBackWord && mShiftKeyState.isPressed() && !mShiftKeyState.isLocked()) {
@@ -1242,6 +1249,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
         if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
             pickLastSuggestion();
+            TextEntryState.performedGesture();
         }
 
         if (primaryCode > 0) {

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -135,7 +135,6 @@ public class TextEntryState {
 
     private static State getNextStateOnBackSpace(State currentState) {
         switch (currentState) {
-            case PERFORMED_GESTURE:
             case ACCEPTED_DEFAULT:
             case SPACE_AFTER_ACCEPTED:
             case PUNCTUATION_AFTER_ACCEPTED:
@@ -146,6 +145,7 @@ public class TextEntryState {
             case PUNCTUATION_AFTER_PICKED:
                 return State.UNKNOWN;
             case UNDO_COMMIT:
+            case PERFORMED_GESTURE:
                 return State.IN_WORD;
             default:
                 return currentState;
@@ -191,7 +191,7 @@ public class TextEntryState {
     }
 
     public static boolean isPredicting() {
-        return sPredictionOn && sState == State.IN_WORD;
+        return sPredictionOn && (sState == State.IN_WORD || sState == State.PERFORMED_GESTURE);
     }
 
     public static boolean isReadyToPredict() {

--- a/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -325,4 +325,8 @@ public class GestureTypingDetector {
 
         return false;
     }
+
+    public boolean isPerformingGesture() {
+        return !mXs.isEmpty();
+    }
 }

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -274,7 +274,7 @@ public abstract class AnySoftKeyboardBase
 
     protected abstract boolean isSuggestionAffectingCharacter(int code);
 
-    public abstract void pickSuggestionManually(int index, CharSequence suggestion);
+    public abstract void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled);
 
     @CallSuper
     protected void abortCorrectionAndResetPredictionState(boolean forever) {

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSwitchedListener.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSwitchedListener.java
@@ -110,14 +110,29 @@ public abstract class AnySoftKeyboardKeyboardSwitchedListener extends AnySoftKey
         return mInAlphabetKeyboardMode;
     }
 
+    /**
+     * Returns the last set alphabet keyboard. Notice: this may be null if the
+     * keyboard was not loaded it (say, in the start up of the IME service).
+     */
+    @Nullable
     protected final AnyKeyboard getCurrentAlphabetKeyboard() {
         return mCurrentAlphabetKeyboard;
     }
 
+    /**
+     * Returns the last set symbols keyboard. Notice: this may be null if the
+     * keyboard was not loaded it (say, in the start up of the IME service).
+     */
+    @Nullable
     protected final AnyKeyboard getCurrentSymbolsKeyboard() {
         return mCurrentSymbolsKeyboard;
     }
 
+    /**
+     * Returns the last set symbols keyboard for the current mode (alphabet or symbols). Notice: this may be null if the
+     * keyboard was not loaded it (say, in the start up of the IME service).
+     */
+    @Nullable
     protected final AnyKeyboard getCurrentKeyboard() {
         return mInAlphabetKeyboardMode ? mCurrentAlphabetKeyboard : mCurrentSymbolsKeyboard;
     }

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardPopText.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardPopText.java
@@ -72,7 +72,7 @@ public abstract class AnySoftKeyboardPopText extends AnySoftKeyboardKeyboardTags
 
     @Override
     @CallSuper
-    public void pickSuggestionManually(int index, CharSequence suggestion) {
+    public void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
         //we do not want to pop text when user picks from the suggestions bar
         mLastKey = null;
     }

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.view.inputmethod.InputConnection;
 
+import com.anysoftkeyboard.api.KeyCodes;
 import com.anysoftkeyboard.dictionaries.TextEntryState;
 import com.anysoftkeyboard.gesturetyping.GestureTypingDetector;
 import com.anysoftkeyboard.keyboards.AnyKeyboard;
@@ -90,7 +91,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
         //we can call this as many times as we want, it has a short-circuit check.
         setCandidatesViewShown(true/*we need candidates-view to be shown, since we are going to show suggestions*/);
 
-        confirmLastGesture();
+        confirmLastGesture(mPrefsAutoSpace);
 
         mGestureTypingDetector.clearGesture();
         mGestureTypingDetector.addPoint(x, y, eventTime);
@@ -106,16 +107,16 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     public void onKey(int primaryCode, Keyboard.Key key, int multiTapIndex, int[] nearByKeyCodes, boolean fromUI) {
         if (getGestureTypingEnabled() && TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
             if (primaryCode > 0 /*printable character*/) {
-                confirmLastGesture();
+                confirmLastGesture(primaryCode != KeyCodes.SPACE && mPrefsAutoSpace);
             }
         }
 
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
     }
 
-    private void confirmLastGesture() {
+    private void confirmLastGesture(boolean withAutoSpace) {
         if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
-            pickSuggestionManually(0, mWord.getTypedWord());
+            pickSuggestionManually(0, mWord.getTypedWord(), withAutoSpace);
         }
     }
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -145,4 +145,10 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
             mGestureTypingDetector.clearGesture();
         }
     }
+
+    @Override
+    public boolean isPerformingGesture() {
+        return getGestureTypingEnabled() && mGestureTypingDetector.isPerformingGesture();
+
+    }
 }

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/MiniKeyboardActionListener.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/MiniKeyboardActionListener.java
@@ -94,4 +94,9 @@ public final class MiniKeyboardActionListener implements OnKeyboardActionListene
 
     @Override
     public void onGestureTypingInputDone() {}
+
+    @Override
+    public boolean isPerformingGesture() {
+        return false;
+    }
 }

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/OnKeyboardActionListener.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/OnKeyboardActionListener.java
@@ -120,4 +120,6 @@ public interface OnKeyboardActionListener {
     void onGestureTypingInput(int x, int y, long eventTime);
 
     void onGestureTypingInputDone();
+
+    boolean isPerformingGesture();
 }

--- a/app/src/main/java/com/anysoftkeyboard/quicktextkeys/ui/RecordHistoryKeyboardActionListener.java
+++ b/app/src/main/java/com/anysoftkeyboard/quicktextkeys/ui/RecordHistoryKeyboardActionListener.java
@@ -101,4 +101,9 @@ import com.anysoftkeyboard.quicktextkeys.HistoryQuickTextKey;
 
     @Override
     public void onGestureTypingInputDone() {}
+
+    @Override
+    public boolean isPerformingGesture() {
+        return false;
+    }
 }

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGestureTypingTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGestureTypingTest.java
@@ -1,0 +1,176 @@
+package com.anysoftkeyboard;
+
+import com.anysoftkeyboard.api.KeyCodes;
+import com.anysoftkeyboard.keyboards.Keyboard;
+import com.anysoftkeyboard.test.SharedPrefsHelper;
+import com.menny.android.anysoftkeyboard.R;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.shadows.ShadowSystemClock;
+
+@RunWith(AnySoftKeyboardRobolectricTestRunner.class)
+public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
+
+    @Before
+    @Override
+    public void setUpForAnySoftKeyboardBase() throws Exception {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_gesture_typing, true);
+        super.setUpForAnySoftKeyboardBase();
+        Robolectric.flushBackgroundThreadScheduler();
+        Robolectric.flushForegroundThreadScheduler();
+    }
+
+    @Test
+    public void testDoesNotOutputIfGestureTypingIsDisabled() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_gesture_typing, false);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        //it's null, because it was forcibly cleared
+        Assert.assertNull(verifyAndCaptureSuggestion(true));
+    }
+
+    @Test
+    public void testOutputPrimarySuggestionOnGestureDone() {
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGesturesWhenPrintableKeyIsPressed() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress('a');
+        Assert.assertEquals("hello a", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDoesNotConfirmLastGesturesWhenNonePrintableKeyIsPressed() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGesturesOnNextGestureStarts() {
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+
+    }
+
+    @Test
+    public void testDeleteGesturedWordOneCharacterAtTime() {
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello welcom", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello welco", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello welc", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello wel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello we", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello w", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hell", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("he", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+
+    @Test
+    public void testRewriteGesturedWord() {
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hell", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress('p');
+        Assert.assertEquals("help", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("help ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("help welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("help welcom", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("ing");
+        Assert.assertEquals("help welcoming", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testSpaceAfterGestureJustConfirms() {
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("you");
+        Assert.assertEquals("hello you", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("all");
+        Assert.assertEquals("hello you all", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDeleteGesturedWordOnWholeWord() {
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    private void simulateGestureProcess(String pathKeys) {
+        long time = ShadowSystemClock.currentTimeMillis();
+        Keyboard.Key startKey = mAnySoftKeyboardUnderTest.findKeyWithPrimaryKeyCode(pathKeys.charAt(0));
+        mAnySoftKeyboardUnderTest.onPress(startKey.getPrimaryCode());
+        mAnySoftKeyboardUnderTest.onGestureTypingInputStart(startKey.x + 2, startKey.y + 2, time);
+        for (int keyIndex = 1; keyIndex < pathKeys.length(); keyIndex++) {
+            final Keyboard.Key followingKey = mAnySoftKeyboardUnderTest.findKeyWithPrimaryKeyCode(pathKeys.charAt(keyIndex));
+            //simulating gesture from startKey to followingKey
+            final float xStep = startKey.width / 3;
+            final float yStep = startKey.height / 3;
+
+            final float xDistance = followingKey.x - startKey.x;
+            final float yDistance = followingKey.y - startKey.y;
+            int callsToMake = (int) Math.ceil(((xDistance + yDistance) / 2) / ((xStep + yStep) / 2));
+
+            final long timeStep = 16;
+
+            float currentX = startKey.x;
+            float currentY = startKey.y;
+
+            ShadowSystemClock.sleep(timeStep);
+            time = ShadowSystemClock.currentTimeMillis();
+            mAnySoftKeyboardUnderTest.onGestureTypingInput(startKey.x + 2, startKey.y + 2, time);
+
+            while (callsToMake > 0) {
+                callsToMake--;
+                currentX += xStep;
+                currentY += yStep;
+                ShadowSystemClock.sleep(timeStep);
+                time = ShadowSystemClock.currentTimeMillis();
+                mAnySoftKeyboardUnderTest.onGestureTypingInput((int) currentX + 2, (int) currentY + 2, time);
+            }
+
+            startKey = followingKey;
+        }
+        mAnySoftKeyboardUnderTest.onGestureTypingInputDone();
+    }
+}

--- a/app/src/test/java/com/anysoftkeyboard/TestableAnySoftKeyboard.java
+++ b/app/src/test/java/com/anysoftkeyboard/TestableAnySoftKeyboard.java
@@ -11,6 +11,8 @@ import android.view.inputmethod.InputMethodSubtype;
 import com.anysoftkeyboard.addons.AddOn;
 import com.anysoftkeyboard.dictionaries.WordComposer;
 import com.anysoftkeyboard.dictionaries.Suggest;
+import com.anysoftkeyboard.gesturetyping.GestureTypingDetector;
+import com.anysoftkeyboard.gesturetyping.GestureTypingDetectorTest;
 import com.anysoftkeyboard.ime.InputViewBinder;
 import com.anysoftkeyboard.keyboards.AnyKeyboard;
 import com.anysoftkeyboard.keyboards.GenericKeyboard;
@@ -103,6 +105,14 @@ public class TestableAnySoftKeyboard extends SoftKeyboard {
     protected Suggest createSuggest() {
         Assert.assertNull(mSpiedSuggest);
         return mSpiedSuggest = Mockito.spy(new TestableSuggest(this));
+    }
+
+    @NonNull
+    @Override
+    protected GestureTypingDetector createGestureTypingDetector() {
+        return new GestureTypingDetectorTest.TestableGestureTypingDetector(Arrays.asList(
+                "hello", "welcome", "is", "you", "good", "bye", "one", "two", "three"
+        ));
     }
 
     public TestableKeyboardSwitcher getKeyboardSwitcherForTests() {

--- a/app/src/test/java/com/anysoftkeyboard/dictionaries/TextEntryStateTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/dictionaries/TextEntryStateTest.java
@@ -130,4 +130,29 @@ public class TextEntryStateTest {
         Assert.assertFalse(TextEntryState.isPredicting());
         Assert.assertEquals(TextEntryState.State.SPACE_AFTER_ACCEPTED, TextEntryState.getState());
     }
+
+    @Test
+    public void testGestureHappyPath() throws Exception {
+        Assert.assertFalse(TextEntryState.isPredicting());
+        TextEntryState.performedGesture();
+        Assert.assertTrue(TextEntryState.isPredicting());
+        Assert.assertEquals(TextEntryState.State.PERFORMED_GESTURE, TextEntryState.getState());
+        TextEntryState.acceptedDefault("hello");
+        Assert.assertFalse(TextEntryState.isPredicting());
+        Assert.assertEquals(TextEntryState.State.ACCEPTED_DEFAULT, TextEntryState.getState());
+
+        TextEntryState.performedGesture();
+        Assert.assertTrue(TextEntryState.isPredicting());
+        TextEntryState.typedCharacter(' ', true);
+        Assert.assertFalse(TextEntryState.isPredicting());
+        Assert.assertEquals(TextEntryState.State.SPACE_AFTER_PICKED, TextEntryState.getState());
+    }
+
+    @Test
+    public void testGestureAndBackspace() throws Exception {
+        TextEntryState.performedGesture();
+        TextEntryState.backspace();
+        Assert.assertTrue(TextEntryState.isPredicting());
+        Assert.assertEquals(TextEntryState.State.IN_WORD, TextEntryState.getState());
+    }
 }

--- a/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -1,0 +1,48 @@
+package com.anysoftkeyboard.gesturetyping;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.anysoftkeyboard.AnySoftKeyboardRobolectricTestRunner;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(AnySoftKeyboardRobolectricTestRunner.class)
+public class GestureTypingDetectorTest {
+    public static class TestableGestureTypingDetector extends GestureTypingDetector {
+        private final List<CharSequence> mWordsToLoad;
+
+        public TestableGestureTypingDetector(@NonNull List<CharSequence> wordsToLoad) {
+            mWordsToLoad = wordsToLoad;
+        }
+
+        @Override
+        public void loadResources(Context context) {
+            mWords.addAll(mWordsToLoad);
+        }
+    }
+
+    @Test
+    public void testCalculatesCornersInBackground() {
+        Robolectric.getBackgroundThreadScheduler().pause();
+        TestableGestureTypingDetector detector = new TestableGestureTypingDetector(Arrays.asList("hello", "welcome"));
+        Assert.assertEquals(GestureTypingDetector.LoadingState.NOT_LOADED, detector.getLoadingState());
+        detector.loadResources(RuntimeEnvironment.application);
+        Assert.assertEquals(GestureTypingDetector.LoadingState.NOT_LOADED, detector.getLoadingState());
+        detector.setKeys(Collections.emptyList(), 100, 100);
+        Assert.assertEquals(GestureTypingDetector.LoadingState.LOADING, detector.getLoadingState());
+
+        Robolectric.getBackgroundThreadScheduler().unPause();
+        Robolectric.flushBackgroundThreadScheduler();
+
+        Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, detector.getLoadingState());
+    }
+}


### PR DESCRIPTION
Deleting a word after an incorrect gesture to try again should now be one keypress away!

TODO:
- [x] Deleting after a gesture deletes whole word
- [x] Inputting a space after a gesture should not finish the sentence
- [x] Inputting a space when autocorrect does not auto insert one should work (ex: chromium url bar)
- [x] Manually pressing shift after a gesture should work