### PR TITLE
Switch capitalisation of highlighted word

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1557,6 +1557,33 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
         }
     }
 
+    private void toggleCaseOfSelectedCharacters() {
+        InputConnection ic = getCurrentInputConnection();
+        if(ic == null) return;
+
+        CharSequence selectedText = ic.getSelectedText(0);
+        if(selectedText == null) return;
+
+        ExtractedText et = ic.getExtractedText(new ExtractedTextRequest(), 0);
+        if(et == null) return;
+        int selectionStart = et.selectionStart;
+        int selectionEnd = et.selectionEnd;
+
+        if(selectedText.length() > 0) {
+            ic.beginBatchEdit();
+            String selectedTextString = selectedText.toString();
+            if(selectedTextString.compareTo(selectedTextString.toUpperCase(getCurrentAlphabetKeyboard().getLocale())) == 0) {
+                // Convert to lower case
+                ic.setComposingText(selectedTextString.toLowerCase(getCurrentAlphabetKeyboard().getLocale()), 0);
+            } else {
+                // Convert to upper case
+                ic.setComposingText(selectedTextString.toUpperCase(getCurrentAlphabetKeyboard().getLocale()), 0);
+            }
+            ic.setSelection(selectionStart, selectionEnd);
+            ic.endBatchEdit();
+        }
+    }
+
     @Override
     protected void abortCorrectionAndResetPredictionState(boolean forever) {
         super.abortCorrectionAndResetPredictionState(forever);
@@ -2031,6 +2058,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
         if (primaryCode == KeyCodes.SHIFT) {
             mShiftKeyState.onPress();
+            // Toggle case on selected characters
+            toggleCaseOfSelectedCharacters();
             handleShift();
         } else {
             mShiftKeyState.onOtherKeyPressed();

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1561,13 +1561,14 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
         InputConnection ic = getCurrentInputConnection();
         if(ic == null) return;
 
-        CharSequence selectedText = ic.getSelectedText(0);
-        if(selectedText == null) return;
-
-        ExtractedText et = ic.getExtractedText(new ExtractedTextRequest(), 0);
+        ExtractedText et = ic.getExtractedText(EXTRACTED_TEXT_REQUEST, 0);
         if(et == null) return;
         int selectionStart = et.selectionStart;
         int selectionEnd = et.selectionEnd;
+
+        if(et.text == null) return;
+        CharSequence selectedText = et.text.subSequence(selectionStart, selectionEnd);
+        if(selectedText == null) return;
 
         if(selectedText.length() > 0) {
             ic.beginBatchEdit();
@@ -1579,8 +1580,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 // Convert to upper case
                 ic.setComposingText(selectedTextString.toUpperCase(getCurrentAlphabetKeyboard().getLocale()), 0);
             }
-            ic.setSelection(selectionStart, selectionEnd);
             ic.endBatchEdit();
+            ic.setSelection(selectionStart, selectionEnd);
         }
     }
 

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardCapitalizeSelectionWhenShiftPressedTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardCapitalizeSelectionWhenShiftPressedTest.java
@@ -1,0 +1,71 @@
+package com.anysoftkeyboard;
+
+import com.anysoftkeyboard.api.KeyCodes;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AnySoftKeyboardRobolectricTestRunner.class)
+public class AnySoftKeyboardCapitalizeSelectionWhenShiftPressedTest extends AnySoftKeyboardBaseTest {
+
+    @Test
+    public void testCapitalizeEntireInput() {
+        TestInputConnection inputConnection = (TestInputConnection) mAnySoftKeyboardUnderTest.getCurrentInputConnection();
+        final String expectedText = "THIS SHOULD ALL BE CAPS";
+        inputConnection.commitText(expectedText.toLowerCase(), 1);
+        inputConnection.setSelection(0, expectedText.length());
+        // To uppercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals(expectedText, inputConnection.getSelectedText(0).toString());
+
+        // Back to lowercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals(expectedText.toLowerCase(), inputConnection.getSelectedText(0).toString());
+    }
+
+    @Test
+    public void testCapitalizeSingleWord() {
+        TestInputConnection inputConnection = (TestInputConnection) mAnySoftKeyboardUnderTest.getCurrentInputConnection();
+        final String inputText = "this SHOULD not all be caps";
+        inputConnection.commitText(inputText.toLowerCase(), 1);
+        inputConnection.setSelection("this ".length(), "this should".length());
+        // To uppercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("SHOULD", inputConnection.getSelectedText(0).toString());
+
+        // Back to lowercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("should", inputConnection.getSelectedText(0).toString());
+    }
+
+    @Test
+    public void testCapitalizeSingleLetter() {
+        TestInputConnection inputConnection = (TestInputConnection) mAnySoftKeyboardUnderTest.getCurrentInputConnection();
+        final String inputText = "this shOuld not all be caps";
+        inputConnection.commitText(inputText.toLowerCase(), 1);
+        inputConnection.setSelection("this sh".length(), "this sho".length());
+        // To uppercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("O", inputConnection.getSelectedText(0).toString());
+
+        // Back to lowercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("o", inputConnection.getSelectedText(0).toString());
+    }
+
+    @Test
+    public void testCapitalizeMixedCaseWord() {
+        TestInputConnection inputConnection = (TestInputConnection) mAnySoftKeyboardUnderTest.getCurrentInputConnection();
+        final String inputText = "this sHoUlD not all be caps";
+        inputConnection.commitText(inputText.toLowerCase(), 1);
+        inputConnection.setSelection("this ".length(), "this should".length());
+        // To uppercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("SHOULD", inputConnection.getSelectedText(0).toString());
+
+        // Back to lowercase
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("should", inputConnection.getSelectedText(0).toString());
+    }
+}

--- a/app/src/test/java/com/anysoftkeyboard/TestInputConnection.java
+++ b/app/src/test/java/com/anysoftkeyboard/TestInputConnection.java
@@ -66,8 +66,9 @@ public class TestInputConnection extends BaseInputConnection {
     public ExtractedText getExtractedText(ExtractedTextRequest request, int flags) {
         ExtractedText extracted = new ExtractedText();
         extracted.startOffset = 0;
+        extracted.text = mInputText.subSequence(0, mInputText.length());
         extracted.selectionStart = mCursorPosition;
-        extracted.selectionEnd = mCursorPosition;
+        extracted.selectionEnd = mSelectionEndPosition;
 
         return extracted;
     }


### PR DESCRIPTION
Pressing the shift key with characters highlighted toggles the characters from uppercase to lowercase, based on whether or not they are currently uppercase or lowercase.

I'm not sure if there should be a preferences toggle to enabled/disable this. If there should be, then that's something I can look into adding.