### PR TITLE
Fix Keyboard not Closing when Emojis open

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1093,6 +1093,9 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 break;
             case KeyCodes.CANCEL:
                 mCancelKeyPressed = true;
+                if(mUtilityKeyboardShown) {
+                    mUtilityKeyboardShown = false;
+                }
                 hideWindow();
                 break;
             case KeyCodes.SETTINGS:
@@ -1124,6 +1127,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 }
                 break;
             case KeyCodes.UTILITY_KEYBOARD:
+                mUtilityKeyboardShown = true;
                 getInputView().openUtilityKeyboard();
                 break;
             case KeyCodes.MODE_ALPHABET_POPUP:

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1092,6 +1092,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 }
                 break;
             case KeyCodes.CANCEL:
+                mCancelKeyPressed = true;
                 hideWindow();
                 break;
             case KeyCodes.SETTINGS:

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -64,6 +64,7 @@ public abstract class AnySoftKeyboardBase
     protected boolean mCancelKeyPressed = false;
     protected boolean mBackKeyPressed = false;
     protected boolean mQuickTextKeyboardShown = false;
+    protected boolean mUtilityKeyboardShown = false;
 
     @NonNull
     protected final CompositeDisposable mInputSessionDisposables = new CompositeDisposable();
@@ -242,6 +243,9 @@ public abstract class AnySoftKeyboardBase
             mOptionsDialog.dismiss();
             mOptionsDialog = null;
             return true;
+        } else if(mUtilityKeyboardShown) {
+            super.hideWindow();
+            return false;
         } else {
             return false;
         }

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -61,6 +61,8 @@ public abstract class AnySoftKeyboardBase
     protected int mGlobalCursorPosition = 0;
     protected int mGlobalSelectionStartPosition = 0;
 
+    protected boolean mCancelKeyPressed = false;
+
     @NonNull
     protected final CompositeDisposable mInputSessionDisposables = new CompositeDisposable();
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -62,6 +62,8 @@ public abstract class AnySoftKeyboardBase
     protected int mGlobalSelectionStartPosition = 0;
 
     protected boolean mCancelKeyPressed = false;
+    protected boolean mBackKeyPressed = false;
+    protected boolean mQuickTextKeyboardShown = false;
 
     @NonNull
     protected final CompositeDisposable mInputSessionDisposables = new CompositeDisposable();

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -100,6 +100,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
              * END of SPECIAL translated HW keys code section
              */
             case KeyEvent.KEYCODE_BACK:
+                mBackKeyPressed = true;
                 if (event.getRepeatCount() == 0 && getInputView() != null) {
                     if (getInputView().handleBack()) {
                         // consuming the meta keys
@@ -110,6 +111,11 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
                         mMetaState = 0;
                         return true;
                     }
+                }
+                if(mQuickTextKeyboardShown) {
+                    hideWindow();
+                    // Swallow the event to prevent InputMethodService from handling it
+                    return true;
                 }
                 break;
             case 0x000000cc:// API 14: KeyEvent.KEYCODE_LANGUAGE_SWITCH

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -101,6 +101,9 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
              */
             case KeyEvent.KEYCODE_BACK:
                 mBackKeyPressed = true;
+                if(mUtilityKeyboardShown) {
+                    mUtilityKeyboardShown = false;
+                }
                 if (event.getRepeatCount() == 0 && getInputView() != null) {
                     if (getInputView().handleBack()) {
                         // consuming the meta keys

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
@@ -80,6 +80,12 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardHardwa
             if (reshowStandardKeyboard) {
                 View standardKeyboardView = (View) getInputView();
                 standardKeyboardView.setVisibility(View.VISIBLE);
+
+                if(mCancelKeyPressed) {
+                    mCancelKeyPressed = false;
+                } else {
+                    super.hideWindow();
+                }
             }
             return true;
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
@@ -53,6 +53,7 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardHardwa
     }
 
     private void switchToQuickTextKeyboard() {
+        mQuickTextKeyboardShown = true;
         abortCorrectionAndResetPredictionState(false);
         setCandidatesViewShown(false);
 
@@ -83,6 +84,8 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardHardwa
 
                 if(mCancelKeyPressed) {
                     mCancelKeyPressed = false;
+                } else if (mBackKeyPressed) {
+                    mBackKeyPressed = false;
                 } else {
                     super.hideWindow();
                 }
@@ -95,6 +98,7 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardHardwa
 
     @Override
     protected boolean handleCloseRequest() {
+        mQuickTextKeyboardShown = false;
         return super.handleCloseRequest() || cleanUpQuickTextKeyboard(true);
     }
 }

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardQuickTextTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardQuickTextTest.java
@@ -1,5 +1,6 @@
 package com.anysoftkeyboard;
 
+import android.view.KeyEvent;
 import android.view.View;
 
 import com.anysoftkeyboard.api.KeyCodes;
@@ -175,7 +176,9 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
 
         Assert.assertEquals(View.GONE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
 
-        mAnySoftKeyboardUnderTest.hideWindow();
+        long time = 0;
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_BACK, new AnySoftKeyboardPhysicalKeyboardTest.TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_BACK, new AnySoftKeyboardPhysicalKeyboardTest.TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
 
         Assert.assertEquals(View.VISIBLE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
@@ -185,12 +188,28 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals(View.GONE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
 
-        mAnySoftKeyboardUnderTest.hideWindow();
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_BACK, new AnySoftKeyboardPhysicalKeyboardTest.TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_BACK, new AnySoftKeyboardPhysicalKeyboardTest.TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
 
         Assert.assertEquals(View.VISIBLE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
 
         mAnySoftKeyboardUnderTest.hideWindow();
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
+    }
+
+    @Test
+    public void testHomeOnQuickTextKeyClosesKeyboard() {
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
+
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.QUICK_TEXT_POPUP);
+
+        Assert.assertEquals(View.GONE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
+
+        // hideWindow() is now essentially the same as pressing the HOME hardware key
+        mAnySoftKeyboardUnderTest.hideWindow();
+
+        Assert.assertEquals(View.VISIBLE, ((View) mAnySoftKeyboardUnderTest.getInputView()).getVisibility());
         Assert.assertTrue(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
     }
 


### PR DESCRIPTION
Fix for problem described in #1278

This changes the behaviour of the keyboard slightly when the emoji keyboard is up and hardware back/home buttons are pressed.