### PR TITLE
Fix spacing delete and shift for various combinations of typing and gesturing

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1237,6 +1237,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
     public void onKey(int primaryCode, Key key, int multiTapIndex, int[] nearByKeyCodes, boolean fromUI) {
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
 
+        if (super.handleKeyAfterGesture(primaryCode)) return;
+
         if (primaryCode > 0) {
             onNonFunctionKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
         } else {
@@ -1476,7 +1478,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
         ic.deleteSurroundingText(inputLength - idx, 0);// it is always > 0 !
     }
 
-    private void handleDeleteLastCharacter(boolean forMultiTap) {
+    @Override
+    protected void handleDeleteLastCharacter(boolean forMultiTap) {
         InputConnection ic = getCurrentInputConnection();
         final boolean isPredicting = TextEntryState.isPredicting();
         final TextEntryState.State newState = TextEntryState.backspace();

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1881,6 +1881,9 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
     @Override
     public void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
+        if (mCandidateView.getSuggestions().isEmpty()) return;
+        withAutoSpaceEnabled = withAutoSpaceEnabled && mAutoSpace;
+
         super.pickSuggestionManually(index, suggestion, withAutoSpaceEnabled);
         final String typedWord = mWord.getTypedWord().toString();
 

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -593,6 +593,11 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
                 postRestartWordSuggestion();
             }
         }
+
+        if (shouldBeShiftedAfterGesture()) {
+            mShiftKeyState.setActiveState(true);
+            handleShift();
+        }
     }
 
     private void postRestartWordSuggestion() {
@@ -1883,8 +1888,6 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
 
     @Override
     public void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
-        if (mCandidateView.getSuggestions().isEmpty()) return;
-
         super.pickSuggestionManually(index, suggestion, withAutoSpaceEnabled);
         final String typedWord = mWord.getTypedWord().toString();
 

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -136,7 +136,6 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
      * is out-side completions needed
      */
     private boolean mCompletionOn;
-    private boolean mAutoSpace;
     private boolean mInputFieldSupportsAutoPick;
     private boolean mAutoCorrectOn;
     private boolean mAllowSuggestionsRestart = true;
@@ -1885,7 +1884,6 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardWithGestureTyping {
     @Override
     public void pickSuggestionManually(int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
         if (mCandidateView.getSuggestions().isEmpty()) return;
-        withAutoSpaceEnabled = withAutoSpaceEnabled && mAutoSpace;
 
         super.pickSuggestionManually(index, suggestion, withAutoSpaceEnabled);
         final String typedWord = mWord.getTypedWord().toString();

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -135,6 +135,7 @@ public class TextEntryState {
 
     private static State getNextStateOnBackSpace(State currentState) {
         switch (currentState) {
+            case PERFORMED_GESTURE:
             case ACCEPTED_DEFAULT:
             case SPACE_AFTER_ACCEPTED:
             case PUNCTUATION_AFTER_ACCEPTED:
@@ -145,7 +146,6 @@ public class TextEntryState {
             case PUNCTUATION_AFTER_PICKED:
                 return State.UNKNOWN;
             case UNDO_COMMIT:
-            case PERFORMED_GESTURE:
                 return State.IN_WORD;
             default:
                 return currentState;

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -191,7 +191,7 @@ public class TextEntryState {
     }
 
     public static boolean isPredicting() {
-        return sPredictionOn && (sState == State.IN_WORD || sState == State.PERFORMED_GESTURE);
+        return sPredictionOn && sState == State.IN_WORD;
     }
 
     public static boolean isReadyToPredict() {

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -187,6 +187,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
     }
 
     protected abstract void handleDeleteLastCharacter(boolean forMultiTouch);
+
     protected abstract void handleBackWord(InputConnection ic);
 
     @Override

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -23,6 +23,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
     private boolean mUseKeyRepeat;
     protected boolean mUseBackWord;
 
+
     @Override
     public void onCreate() {
         super.onCreate();

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -185,6 +185,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardSoundEffect
         return super.onKeyDown(keyEventKeyCode, event);
     }
 
+    protected abstract void handleDeleteLastCharacter(boolean forMultiTouch);
     protected abstract void handleBackWord(InputConnection ic);
 
     @Override

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
@@ -21,6 +21,7 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardBase {
     private final SharedPreferences.OnSharedPreferenceChangeListener mGeneralShardPrefChangedListener = (sharedPreferences, key) -> onSharedPreferenceChange(key);
 
     protected boolean mPrefsAutoSpace;
+    protected boolean mAutoSpace;
     protected boolean mHideKeyboardWhenPhysicalKeyboardUsed;
     protected boolean mUseFullScreenInputInLandscape;
     protected boolean mUseFullScreenInputInPortrait;
@@ -42,7 +43,7 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardBase {
         addDisposable(mRxPrefs.getString(R.string.settings_key_force_locale, R.string.settings_default_force_locale_setting)
                 .asObservable().subscribe(forceLocaleValue -> LocaleTools.applyLocaleToContext(getApplicationContext(), forceLocaleValue)));
         addDisposable(mRxPrefs.getBoolean(R.string.settings_key_auto_space, R.bool.settings_default_auto_space)
-                .asObservable().subscribe(value -> mPrefsAutoSpace = value));
+                .asObservable().subscribe(value -> { mPrefsAutoSpace = value; mAutoSpace = mPrefsAutoSpace; }));
         addDisposable(mRxPrefs.getBoolean(R.string.settings_key_hide_soft_when_physical, R.bool.settings_default_hide_soft_when_physical)
                 .asObservable().subscribe(value -> mHideKeyboardWhenPhysicalKeyboardUsed = value));
         addDisposable(mRxPrefs.getBoolean(R.string.settings_key_landscape_fullscreen, R.bool.settings_default_landscape_fullscreen)

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -91,8 +91,6 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
         //we can call this as many times as we want, it has a short-circuit check.
         setCandidatesViewShown(true/*we need candidates-view to be shown, since we are going to show suggestions*/);
 
-        confirmLastGesture(mPrefsAutoSpace);
-
         mGestureTypingDetector.clearGesture();
         mGestureTypingDetector.addPoint(x, y, eventTime);
     }
@@ -106,23 +104,20 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     @Override
     public void onKey(int primaryCode, Keyboard.Key key, int multiTapIndex, int[] nearByKeyCodes, boolean fromUI) {
         if (getGestureTypingEnabled() && TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
-            if (primaryCode > 0 /*printable character*/) {
-                confirmLastGesture(primaryCode != KeyCodes.SPACE && mPrefsAutoSpace);
-            }
+            confirmLastGesture(primaryCode != KeyCodes.SPACE && mPrefsAutoSpace);
         }
 
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
     }
 
     private void confirmLastGesture(boolean withAutoSpace) {
-        if (TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
-            pickSuggestionManually(0, mWord.getTypedWord(), withAutoSpace);
-        }
+        pickSuggestionManually(0, mWord.getTypedWord(), withAutoSpace);
     }
 
     @Override
     public void onGestureTypingInputDone() {
         if (!getGestureTypingEnabled()) return;
+        confirmLastGesture(mPrefsAutoSpace);
 
         InputConnection ic = getCurrentInputConnection();
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -103,7 +103,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
 
     public boolean handleKeyAfterGesture(int primaryCode) {
         if (getGestureTypingEnabled() && TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
-            confirmLastGesture(primaryCode != KeyCodes.SPACE && mPrefsAutoSpace);
+            confirmLastGesture(primaryCode != KeyCodes.SPACE && mAutoSpace);
 
             if (primaryCode == KeyCodes.DELETE) {
                 TextEntryState.performedGesture();
@@ -125,7 +125,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     @Override
     public void onGestureTypingInputDone() {
         if (!getGestureTypingEnabled()) return;
-        confirmLastGesture(mPrefsAutoSpace);
+        confirmLastGesture(mAutoSpace);
 
         InputConnection ic = getCurrentInputConnection();
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -101,13 +101,21 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
         mGestureTypingDetector.addPoint(x, y, eventTime);
     }
 
-    @Override
-    public void onKey(int primaryCode, Keyboard.Key key, int multiTapIndex, int[] nearByKeyCodes, boolean fromUI) {
+    public boolean handleKeyAfterGesture(int primaryCode) {
         if (getGestureTypingEnabled() && TextEntryState.getState() == TextEntryState.State.PERFORMED_GESTURE) {
             confirmLastGesture(primaryCode != KeyCodes.SPACE && mPrefsAutoSpace);
+
+            if (primaryCode == KeyCodes.DELETE) {
+                TextEntryState.performedGesture();
+                // Delete the space added by picking the last suggestion
+                handleDeleteLastCharacter(false);
+                // Then, delete the last word
+                handleBackWord(getCurrentInputConnection());
+                return true;
+            }
         }
 
-        super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
+        return false;
     }
 
     private void confirmLastGesture(boolean withAutoSpace) {

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGestureTypingTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGestureTypingTest.java
@@ -19,6 +19,7 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
     @Override
     public void setUpForAnySoftKeyboardBase() throws Exception {
         SharedPrefsHelper.setPrefsValue(R.string.settings_key_gesture_typing, true);
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, true);
         super.setUpForAnySoftKeyboardBase();
         Robolectric.flushBackgroundThreadScheduler();
         Robolectric.flushForegroundThreadScheduler();
@@ -47,10 +48,67 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
     }
 
     @Test
-    public void testDoesNotConfirmLastGesturesWhenNonePrintableKeyIsPressed() {
+    public void testConfirmsLastGesturesWhenPrintableKeyIsPressedPickSuggestion() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "mysuggest");
+        Assert.assertEquals("mysuggest ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress('a');
+        Assert.assertEquals("mysuggest a", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGestureWhenShiftIsPressed() {
         simulateGestureProcess("hello");
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.isShifted());
+        simulateGestureProcess("world");
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+        Assert.assertEquals("hello World", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testShift() {
+        simulateGestureProcess("hello");
         Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.isShifted());
+        simulateGestureProcess("world");
+        Assert.assertEquals("hello World", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+    }
+
+    @Test
+    public void testShiftBeginning() {
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        simulateGestureProcess("hello");
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+        Assert.assertEquals("Hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+        Assert.assertEquals("Hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.isShifted());
+        simulateGestureProcess("world");
+        Assert.assertEquals("Hello World", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+    }
+
+    @Test
+    public void testShiftWithTyping() {
+        simulateGestureProcess("hello");
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.isShifted());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("world");
+        Assert.assertEquals("hello World", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.isShifted());
     }
 
     @Test
@@ -58,26 +116,66 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         simulateGestureProcess("hello");
         simulateGestureProcess("welcome");
         Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-
     }
 
     @Test
-    public void testDeleteGesturedWordOneCharacterAtTime() {
+    public void testConfirmsLastGesturesOnNextGestureStartsPickSuggestion() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "mysuggest");
+        Assert.assertEquals("mysuggest ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "mysuggest2");
+        Assert.assertEquals("mysuggest mysuggest2 ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDoesNotAddSpaceForTextIfSpacePressed() {
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testAddsSpaceForText() {
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testAddsSpaceForTextPickSuggestion() {
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "mysuggest");
+        Assert.assertEquals("mysuggest ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("mysuggest welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testAddsSpaceForTextNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hellowelcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testAddsSpaceForTextUnrecognized() {
+        mAnySoftKeyboardUnderTest.simulateTextTyping("notindictionary");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("notindictionary welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDeleteWholeGesturedWord() {
         simulateGestureProcess("hello");
         simulateGestureProcess("welcome");
         Assert.assertEquals("hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello welcom", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello welco", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello welc", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello wel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello we", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hello w", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
         Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
@@ -90,25 +188,56 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("he", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
     }
 
+    @Test
+    public void testDeleteWholeGesturedWordPickSuggestion() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "ms1");
+        simulateGestureProcess("welcome");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "ms2");
+        Assert.assertEquals("ms1 ms2 ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("ms1 ms2", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("ms1 ms", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("ms1 m", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
 
     @Test
     public void testRewriteGesturedWord() {
         simulateGestureProcess("hello");
         Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hell", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("hel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress('p');
-        Assert.assertEquals("help", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("p", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
-        Assert.assertEquals("help ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         simulateGestureProcess("welcome");
-        Assert.assertEquals("help welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("p welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-        Assert.assertEquals("help welcom", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateTextTyping("ing");
-        Assert.assertEquals("help welcoming", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        Assert.assertEquals("p ing", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testRewriteGesturedWordPickSuggestion() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "ms1");
+        Assert.assertEquals("ms1 ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("ms1", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress('p');
+        Assert.assertEquals("ms1p", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("ms1p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("ms1p welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("ms1p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("ing");
+        Assert.assertEquals("ms1p ing", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
     }
 
     @Test
@@ -121,6 +250,8 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("hello you", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateTextTyping("all");
         Assert.assertEquals("hello you all", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello you al", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
     }
 
     @Test
@@ -136,41 +267,140 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
     }
 
+    @Test
+    public void testDeleteGesturedWordOnWholeWordPickSuggestion() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(1, "ms");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("ms welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("ms ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("ms", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testOutputPrimarySuggestionOnGestureDoneNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGesturesWhenPrintableKeyIsPressedNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress('a');
+        Assert.assertEquals("helloa", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGestureWhenShiftIsPressedNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testConfirmsLastGesturesOnNextGestureStartsNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hellowelcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDeleteWholeGesturedWordNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hellowelcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hell", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hel", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("he", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("h", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+
+    @Test
+    public void testRewriteGesturedWordNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress('p');
+        Assert.assertEquals("p", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("p welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("p ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("ing");
+        Assert.assertEquals("p ing", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testSpaceAfterGestureJustConfirmsNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("you");
+        Assert.assertEquals("hello you", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateTextTyping("all");
+        Assert.assertEquals("hello youall", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hello youal", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testDeleteGesturedWordOnWholeWordNoAutoSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_space, false);
+        simulateGestureProcess("hello");
+        simulateGestureProcess("welcome");
+        Assert.assertEquals("hellowelcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+
     private void simulateGestureProcess(String pathKeys) {
         long time = ShadowSystemClock.currentTimeMillis();
         Keyboard.Key startKey = mAnySoftKeyboardUnderTest.findKeyWithPrimaryKeyCode(pathKeys.charAt(0));
         mAnySoftKeyboardUnderTest.onPress(startKey.getPrimaryCode());
-        mAnySoftKeyboardUnderTest.onGestureTypingInputStart(startKey.x + 2, startKey.y + 2, time);
+        int w = startKey.width/2;
+        int h = startKey.height/2;
+        mAnySoftKeyboardUnderTest.onGestureTypingInputStart(startKey.x + w, startKey.y + h, time);
+        mAnySoftKeyboardUnderTest.onUpdateSelection(0,0,0,0,0,0);
         for (int keyIndex = 1; keyIndex < pathKeys.length(); keyIndex++) {
             final Keyboard.Key followingKey = mAnySoftKeyboardUnderTest.findKeyWithPrimaryKeyCode(pathKeys.charAt(keyIndex));
             //simulating gesture from startKey to followingKey
-            final float xStep = startKey.width / 3;
-            final float yStep = startKey.height / 3;
-
-            final float xDistance = followingKey.x - startKey.x;
-            final float yDistance = followingKey.y - startKey.y;
-            int callsToMake = (int) Math.ceil(((xDistance + yDistance) / 2) / ((xStep + yStep) / 2));
-
             final long timeStep = 16;
-
-            float currentX = startKey.x;
-            float currentY = startKey.y;
 
             ShadowSystemClock.sleep(timeStep);
             time = ShadowSystemClock.currentTimeMillis();
-            mAnySoftKeyboardUnderTest.onGestureTypingInput(startKey.x + 2, startKey.y + 2, time);
-
-            while (callsToMake > 0) {
-                callsToMake--;
-                currentX += xStep;
-                currentY += yStep;
-                ShadowSystemClock.sleep(timeStep);
-                time = ShadowSystemClock.currentTimeMillis();
-                mAnySoftKeyboardUnderTest.onGestureTypingInput((int) currentX + 2, (int) currentY + 2, time);
-            }
+            mAnySoftKeyboardUnderTest.onGestureTypingInput(startKey.x + w, startKey.y + h, time);
 
             startKey = followingKey;
         }
+        mAnySoftKeyboardUnderTest.onGestureTypingInput(startKey.x + w, startKey.y + h, time);
         mAnySoftKeyboardUnderTest.onGestureTypingInputDone();
+        mAnySoftKeyboardUnderTest.onRelease(startKey.getPrimaryCode());
     }
 }

--- a/app/src/test/java/com/anysoftkeyboard/TestableAnySoftKeyboard.java
+++ b/app/src/test/java/com/anysoftkeyboard/TestableAnySoftKeyboard.java
@@ -111,7 +111,7 @@ public class TestableAnySoftKeyboard extends SoftKeyboard {
     @Override
     protected GestureTypingDetector createGestureTypingDetector() {
         return new GestureTypingDetectorTest.TestableGestureTypingDetector(Arrays.asList(
-                "hello", "welcome", "is", "you", "good", "bye", "one", "two", "three"
+                "hello", "welcome", "world", "is", "you", "good", "bye", "one", "two", "three"
         ));
     }
 
@@ -296,6 +296,10 @@ public class TestableAnySoftKeyboard extends SoftKeyboard {
 
     public String getCurrentInputConnectionText() {
         return mInputConnection.getCurrentTextInInputConnection();
+    }
+
+    public boolean isShifted() {
+        return mShiftKeyState.isActive();
     }
 
     @Override

--- a/app/src/test/java/com/anysoftkeyboard/dictionaries/TextEntryStateTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/dictionaries/TextEntryStateTest.java
@@ -135,14 +135,14 @@ public class TextEntryStateTest {
     public void testGestureHappyPath() throws Exception {
         Assert.assertFalse(TextEntryState.isPredicting());
         TextEntryState.performedGesture();
-        Assert.assertTrue(TextEntryState.isPredicting());
+        Assert.assertFalse(TextEntryState.isPredicting());
         Assert.assertEquals(TextEntryState.State.PERFORMED_GESTURE, TextEntryState.getState());
         TextEntryState.acceptedDefault("hello");
         Assert.assertFalse(TextEntryState.isPredicting());
         Assert.assertEquals(TextEntryState.State.ACCEPTED_DEFAULT, TextEntryState.getState());
 
         TextEntryState.performedGesture();
-        Assert.assertTrue(TextEntryState.isPredicting());
+        Assert.assertFalse(TextEntryState.isPredicting());
         TextEntryState.typedCharacter(' ', true);
         Assert.assertFalse(TextEntryState.isPredicting());
         Assert.assertEquals(TextEntryState.State.SPACE_AFTER_PICKED, TextEntryState.getState());
@@ -152,7 +152,7 @@ public class TextEntryStateTest {
     public void testGestureAndBackspace() throws Exception {
         TextEntryState.performedGesture();
         TextEntryState.backspace();
-        Assert.assertTrue(TextEntryState.isPredicting());
-        Assert.assertEquals(TextEntryState.State.IN_WORD, TextEntryState.getState());
+        Assert.assertFalse(TextEntryState.isPredicting());
+        Assert.assertEquals(TextEntryState.State.UNDO_COMMIT, TextEntryState.getState());
     }
 }


### PR DESCRIPTION
- Fix spacing and delete for various combinations of typing and gesturing
- Fix spacing and delete for input types (ex: chromium url bar) that don't do auto space
- Delete whole word when deleting a gesture
- Fix shift, caps lock and finishing a gesture by pressing shift

I undid your TextState changes. This implementation has the advantage of working correctly for the cases above (especially the chromium url bar), but it is definitely an abuse of the states. I am not sure how else to implement it though, so I am definitely open to ideas. The tests should handle any regressions if you want to play around with it.

Everything related to gesturing should be inside the withGestureTyping class, which should hopefully make it less awful than the last PR. Also, everything has a check, so this should not introduce any regressions if the feature flag is disabled.

Thanks for getting the mocks set up! They were so helpful. Let me know if you want this PR broken up.