### PR TITLE
Fix swapped shift and backspace on colemak layout

### DIFF
--- a/app/src/main/res/xml/colemak.xml
+++ b/app/src/main/res/xml/colemak.xml
@@ -14,9 +14,9 @@
         <Key android:codes="117" android:keyLabel="u"/>
         <Key android:codes="121" android:keyLabel="y"/>
         <Key android:codes="59,58" android:keyLabel=";" android:keyEdgeFlags="right"/>
-      </Row>
+    </Row>
 
-      <Row>
+    <Row>
         <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left"/>
         <Key android:codes="114" android:keyLabel="r"/>
         <Key android:codes="115" android:keyLabel="s"/>
@@ -30,7 +30,7 @@
       </Row>
     
     <Row>
-        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
         <Key android:horizontalGap="5%p" android:codes="122" android:keyLabel="z"/>
         <Key android:codes="120" android:keyLabel="x"/>
         <Key android:codes="99" android:keyLabel="c"/>
@@ -38,7 +38,6 @@
         <Key android:codes="98" android:keyLabel="b"/>
         <Key android:codes="107" android:keyLabel="k"/>
         <Key android:codes="109" android:keyLabel="m"/>
-        <Key android:codes="-1" 
-                android:isModifier="true" android:isSticky="true" android:horizontalGap="5%p" android:keyEdgeFlags="right"/>
+        <Key android:codes="-5" android:isRepeatable="true" android:horizontalGap="5%p" android:keyEdgeFlags="right"/>
     </Row>
 </Keyboard>


### PR DESCRIPTION
ASK's Colemak layout swaps shift and backspace, as noted in issue #998 . This swapped layout does not match the backspace key positioning on the number and symbol input pages, leading to much annoyance.

This PR simply swaps them back to match the symbols page, and all other keyboards.

~The official colemak keyboard layout (colemak.com) does not move the backspace key at all, it is in the default position on the keyboard.~ Actually colemak recommends remapping capslock to backspace, but on an android keyboard this doesn't make much sense.