### PR TITLE
Add terminal common top row

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -583,6 +583,7 @@
     <string name="extension_kbd_top_numbers_alt">Alternate number keys</string>
     <string name="extension_kbd_top_nav">Navigation keys</string>
     <string name="extension_kbd_top_numbers_simple">Simple, numbers only</string>
+    <string name="extension_kbd_top_terminal">Terminal</string>
 
     <string name="extension_kbd_bottom_regular_with_voice">Regular</string>
     <string name="extension_kbd_bottom_regular">Classic (no mic)</string>

--- a/app/src/main/res/xml/ext_kbd_top_row_terminal.xml
+++ b/app/src/main/res/xml/ext_kbd_top_row_terminal.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:rowEdgeFlags="top" android:keyWidth="10%p" android:keyHeight="@integer/key_short_height">
+        <Key android:keyWidth="15%p" android:codes="@integer/key_code_ctrl" android:isModifier="true" android:keyEdgeFlags="left"/>
+
+        <Key android:codes="9"/>
+
+        <Key android:codes="124" android:keyLabel="|"/>
+        <Key android:codes="47" android:keyLabel="/" />
+
+        <Key android:codes="@integer/key_code_arrow_left"/>
+        <Key android:codes="@integer/key_code_arrow_up"/>
+        <Key android:codes="@integer/key_code_arrow_down"/>
+        <Key android:codes="@integer/key_code_arrow_right"/>
+
+        <Key android:keyWidth="15%p" android:codes="27" android:keyLabel="ESC" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/extension_keyboards.xml
+++ b/app/src/main/res/xml/extension_keyboards.xml
@@ -57,6 +57,14 @@
             description=""
             index="7"
             />
+    <ExtensionKeyboard
+        id="49c8c4b0-b3bc-11e8-933e-975e4dcf2c13"
+        nameResId="@string/extension_kbd_top_terminal"
+        extensionKeyboardResId="@xml/ext_kbd_top_row_terminal"
+        extensionKeyboardType="2"
+        description=""
+        index="8"
+        />
 
     <!-- bottom rows -->
     <ExtensionKeyboard

--- a/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
@@ -65,7 +65,7 @@ public class KeyboardExtensionFactoryTest {
     @Test
     public void testGetAllAvailableExtensions() throws Exception {
         assertBasicListDetails(AnyApplication.getBottomRowFactory(RuntimeEnvironment.application).getAllAddOns(), 9, KeyboardExtension.TYPE_BOTTOM);
-        assertBasicListDetails(AnyApplication.getTopRowFactory(RuntimeEnvironment.application).getAllAddOns(), 7, KeyboardExtension.TYPE_TOP);
+        assertBasicListDetails(AnyApplication.getTopRowFactory(RuntimeEnvironment.application).getAllAddOns(), 8, KeyboardExtension.TYPE_TOP);
         assertBasicListDetails(AnyApplication.getKeyboardExtensionFactory(RuntimeEnvironment.application).getAllAddOns(), 1, KeyboardExtension.TYPE_EXTENSION);
     }
 


### PR DESCRIPTION
Adds a terminal common top row, for terminal use with non-QWERTY layouts, or for people who prefer these keys on top.

See #1443.