### PR TITLE
Add toggle for physical hardware shift+space layout switch shortcut

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -123,13 +123,6 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 return true;
             case KeyEvent.KEYCODE_SHIFT_LEFT:
             case KeyEvent.KEYCODE_SHIFT_RIGHT:
-                if (event.isAltPressed() && mSwitchLanguageOnAltSpace) {
-                    switchToNextPhysicalKeyboard(ic);
-                    return true;
-                }
-                // NOTE: letting it fall-through to the other meta-keys
-                // The line below will disable the checkstyle error.
-                // fallthru
             case KeyEvent.KEYCODE_ALT_LEFT:
             case KeyEvent.KEYCODE_ALT_RIGHT:
             case KeyEvent.KEYCODE_SYM:

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -22,6 +22,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
 
     private boolean mUseVolumeKeyForLeftRight;
     private boolean mUseKeyRepeat;
+    private boolean mSwitchLanguageOnShiftSpace;
     protected boolean mUseBackWord;
 
     @Override
@@ -31,6 +32,8 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 .asObservable().subscribe(aBoolean -> mUseVolumeKeyForLeftRight = aBoolean, GenericOnError.onError("settings_key_use_volume_key_for_left_right")));
         addDisposable(prefs().getBoolean(R.string.settings_key_use_key_repeat, R.bool.settings_default_use_key_repeat)
                 .asObservable().subscribe(aBoolean -> mUseKeyRepeat = aBoolean, GenericOnError.onError("settings_key_use_key_repeat")));
+        addDisposable(prefs().getBoolean(R.string.settings_key_enable_shift_space_language_shortcut, R.bool.settings_default_enable_shift_space_language_shortcut)
+                .asObservable().subscribe(aBoolean -> mSwitchLanguageOnShiftSpace = aBoolean, GenericOnError.onError("settings_key_enable_shift_space_language_shortcut")));
         addDisposable(prefs().getBoolean(R.string.settings_key_use_backword, R.bool.settings_default_use_backword)
                 .asObservable().subscribe(aBoolean -> mUseBackWord = aBoolean, GenericOnError.onError("settings_key_use_backword")));
     }
@@ -132,9 +135,8 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 mMetaState = MyMetaKeyKeyListener.handleKeyDown(mMetaState, keyEventKeyCode, event);
                 break;
             case KeyEvent.KEYCODE_SPACE:
-                if ((event.isAltPressed() && !Workarounds
-                        .isAltSpaceLangSwitchNotPossible())
-                        || event.isShiftPressed()) {
+                if ((event.isAltPressed() && !Workarounds.isAltSpaceLangSwitchNotPossible())
+                        || (event.isShiftPressed() && mSwitchLanguageOnShiftSpace)) {
                     switchToNextPhysicalKeyboard(ic);
                     return true;
                 }

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardHardware.java
@@ -11,7 +11,6 @@ import com.anysoftkeyboard.keyboards.KeyboardSwitcher;
 import com.anysoftkeyboard.keyboards.physical.HardKeyboardActionImpl;
 import com.anysoftkeyboard.keyboards.physical.MyMetaKeyKeyListener;
 import com.anysoftkeyboard.rx.GenericOnError;
-import com.anysoftkeyboard.utils.Workarounds;
 import com.menny.android.anysoftkeyboard.R;
 
 public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffects {
@@ -22,6 +21,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
 
     private boolean mUseVolumeKeyForLeftRight;
     private boolean mUseKeyRepeat;
+    private boolean mSwitchLanguageOnAltSpace;
     private boolean mSwitchLanguageOnShiftSpace;
     protected boolean mUseBackWord;
 
@@ -32,6 +32,8 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 .asObservable().subscribe(aBoolean -> mUseVolumeKeyForLeftRight = aBoolean, GenericOnError.onError("settings_key_use_volume_key_for_left_right")));
         addDisposable(prefs().getBoolean(R.string.settings_key_use_key_repeat, R.bool.settings_default_use_key_repeat)
                 .asObservable().subscribe(aBoolean -> mUseKeyRepeat = aBoolean, GenericOnError.onError("settings_key_use_key_repeat")));
+        addDisposable(prefs().getBoolean(R.string.settings_key_enable_alt_space_language_shortcut, R.bool.settings_default_enable_alt_space_language_shortcut)
+                .asObservable().subscribe(aBoolean -> mSwitchLanguageOnAltSpace = aBoolean, GenericOnError.onError("settings_key_enable_alt_space_language_shortcut")));
         addDisposable(prefs().getBoolean(R.string.settings_key_enable_shift_space_language_shortcut, R.bool.settings_default_enable_shift_space_language_shortcut)
                 .asObservable().subscribe(aBoolean -> mSwitchLanguageOnShiftSpace = aBoolean, GenericOnError.onError("settings_key_enable_shift_space_language_shortcut")));
         addDisposable(prefs().getBoolean(R.string.settings_key_use_backword, R.bool.settings_default_use_backword)
@@ -121,8 +123,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 return true;
             case KeyEvent.KEYCODE_SHIFT_LEFT:
             case KeyEvent.KEYCODE_SHIFT_RIGHT:
-                if (event.isAltPressed()
-                        && Workarounds.isAltSpaceLangSwitchNotPossible()) {
+                if (event.isAltPressed() && mSwitchLanguageOnAltSpace) {
                     switchToNextPhysicalKeyboard(ic);
                     return true;
                 }
@@ -135,7 +136,7 @@ public abstract class AnySoftKeyboardHardware extends AnySoftKeyboardPressEffect
                 mMetaState = MyMetaKeyKeyListener.handleKeyDown(mMetaState, keyEventKeyCode, event);
                 break;
             case KeyEvent.KEYCODE_SPACE:
-                if ((event.isAltPressed() && !Workarounds.isAltSpaceLangSwitchNotPossible())
+                if ((event.isAltPressed() && mSwitchLanguageOnAltSpace)
                         || (event.isShiftPressed() && mSwitchLanguageOnShiftSpace)) {
                     switchToNextPhysicalKeyboard(ic);
                     return true;

--- a/app/src/main/java/com/anysoftkeyboard/utils/Workarounds.java
+++ b/app/src/main/java/com/anysoftkeyboard/utils/Workarounds.java
@@ -33,12 +33,4 @@ public class Workarounds {
                 return false;
         }
     }
-
-    public static boolean isAltSpaceLangSwitchNotPossible() {
-        String model = android.os.Build.MODEL.toLowerCase(Locale.US);
-        if (model.equals("milestone") || model.equals("droid")) {
-            return true;
-        }
-        return false;
-    }
 }

--- a/app/src/main/java/com/anysoftkeyboard/utils/Workarounds.java
+++ b/app/src/main/java/com/anysoftkeyboard/utils/Workarounds.java
@@ -16,8 +16,6 @@
 
 package com.anysoftkeyboard.utils;
 
-import java.util.Locale;
-
 public class Workarounds {
 
     public static boolean isRightToLeftCharacter(final char key) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -174,12 +174,6 @@
     <string name="hide_soft_when_physical_off_summary">Show soft keyboard when physical keyboard is
         used
     </string>
-    <string name="enable_alt_space_language_shortcut">Alt + Space switches languages</string>
-    <string name="enable_alt_space_language_shortcut_on_summary">Alt + space switches to the next available layout.</string>
-    <string name="enable_alt_space_language_shortcut_off_summary">Alt + space enters a space.</string>
-    <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
-    <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
-    <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>
     <string name="fullscreen_input_connection_supported">Use full-screen editor in landscape
     </string>
     <string name="fullscreen_input_connection_supported_on_summary">Take over the screen when

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -174,6 +174,9 @@
     <string name="hide_soft_when_physical_off_summary">Show soft keyboard when physical keyboard is
         used
     </string>
+    <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
+    <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
+    <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>
     <string name="fullscreen_input_connection_supported">Use full-screen editor in landscape
     </string>
     <string name="fullscreen_input_connection_supported_on_summary">Take over the screen when

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -174,6 +174,9 @@
     <string name="hide_soft_when_physical_off_summary">Show soft keyboard when physical keyboard is
         used
     </string>
+    <string name="enable_alt_space_language_shortcut">Alt + Space switches languages</string>
+    <string name="enable_alt_space_language_shortcut_on_summary">Alt + space switches to the next available layout.</string>
+    <string name="enable_alt_space_language_shortcut_off_summary">Alt + space enters a space.</string>
     <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
     <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
     <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>

--- a/app/src/main/res/values/settings_defaults_dont_translate.xml
+++ b/app/src/main/res/values/settings_defaults_dont_translate.xml
@@ -26,6 +26,7 @@
     <string name="settings_default_auto_dictionary_add_threshold">9</string>
     <bool name="settings_default_user_dictionary">true</bool>
     <bool name="settings_default_hide_soft_when_physical">true</bool>
+    <bool name="settings_default_enable_alt_space_language_shortcut">true</bool>
     <bool name="settings_default_enable_shift_space_language_shortcut">true</bool>
     <bool name="settings_default_key_press_shows_preview_popup">true</bool>
 

--- a/app/src/main/res/values/settings_defaults_dont_translate.xml
+++ b/app/src/main/res/values/settings_defaults_dont_translate.xml
@@ -26,6 +26,7 @@
     <string name="settings_default_auto_dictionary_add_threshold">9</string>
     <bool name="settings_default_user_dictionary">true</bool>
     <bool name="settings_default_hide_soft_when_physical">true</bool>
+    <bool name="settings_default_enable_shift_space_language_shortcut">true</bool>
     <bool name="settings_default_key_press_shows_preview_popup">true</bool>
 
     <bool name="settings_default_show_keyboard_name_text_value">true</bool>

--- a/app/src/main/res/values/settings_keys_dont_translate.xml
+++ b/app/src/main/res/values/settings_keys_dont_translate.xml
@@ -103,6 +103,7 @@
     <string name="settings_key_use_contacts_dictionary">settings_key_use_contacts_dictionary</string>
 
     <string name="settings_key_hide_soft_when_physical">settings_key_hide_soft_when_physical</string>
+    <string name="settings_key_enable_shift_space_language_shortcut">settings_key_enable_shift_space_language_shortcut</string>
 
     <string name="settings_key_always_use_fallback_user_dictionary">settings_key_always_use_fallback_user_dictionary</string>
 

--- a/app/src/main/res/values/settings_keys_dont_translate.xml
+++ b/app/src/main/res/values/settings_keys_dont_translate.xml
@@ -103,6 +103,7 @@
     <string name="settings_key_use_contacts_dictionary">settings_key_use_contacts_dictionary</string>
 
     <string name="settings_key_hide_soft_when_physical">settings_key_hide_soft_when_physical</string>
+    <string name="settings_key_enable_alt_space_language_shortcut">settings_key_enable_alt_space_language_shortcut</string>
     <string name="settings_key_enable_shift_space_language_shortcut">settings_key_enable_shift_space_language_shortcut</string>
 
     <string name="settings_key_always_use_fallback_user_dictionary">settings_key_always_use_fallback_user_dictionary</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,9 @@
     <string name="hide_soft_when_physical_off_summary">Show soft keyboard when physical keyboard is
         used
     </string>
+    <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
+    <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
+    <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>
     <string name="fullscreen_input_connection_supported">Use full-screen editor in landscape
     </string>
     <string name="fullscreen_input_connection_supported_on_summary">Take over the screen when

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,11 +175,11 @@
         used
     </string>
     <string name="enable_alt_space_language_shortcut">Alt + Space switches languages</string>
-    <string name="enable_alt_space_language_shortcut_on_summary">Alt + space switches to the next available layout.</string>
-    <string name="enable_alt_space_language_shortcut_off_summary">Alt + space enters a space.</string>
+    <string name="enable_alt_space_language_shortcut_on_summary">Hardware Alt + Space switches to the next available layout.</string>
+    <string name="enable_alt_space_language_shortcut_off_summary">Hardware Alt + Space enters a space.</string>
     <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
-    <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
-    <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>
+    <string name="enable_shift_space_language_shortcut_on_summary">Hardware Shift + Space switches to the next available layout.</string>
+    <string name="enable_shift_space_language_shortcut_off_summary">Hardware Shift + Space enters a space.</string>
     <string name="fullscreen_input_connection_supported">Use full-screen editor in landscape
     </string>
     <string name="fullscreen_input_connection_supported_on_summary">Take over the screen when

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,9 @@
     <string name="hide_soft_when_physical_off_summary">Show soft keyboard when physical keyboard is
         used
     </string>
+    <string name="enable_alt_space_language_shortcut">Alt + Space switches languages</string>
+    <string name="enable_alt_space_language_shortcut_on_summary">Alt + space switches to the next available layout.</string>
+    <string name="enable_alt_space_language_shortcut_off_summary">Alt + space enters a space.</string>
     <string name="enable_shift_space_language_shortcut">Shift + Space switches languages</string>
     <string name="enable_shift_space_language_shortcut_on_summary">Shift + space switches to the next available layout.</string>
     <string name="enable_shift_space_language_shortcut_off_summary">Shift + space enters a space.</string>

--- a/app/src/main/res/xml/prefs_language_tweaks.xml
+++ b/app/src/main/res/xml/prefs_language_tweaks.xml
@@ -45,6 +45,14 @@
             android:summaryOff="@string/hide_soft_when_physical_off_summary"
             android:summaryOn="@string/hide_soft_when_physical_on_summary"
             android:title="@string/hide_soft_when_physical"/>
+
+        <android.support.v7.preference.CheckBoxPreference
+            android:defaultValue="@bool/settings_default_enable_shift_space_language_shortcut"
+            android:key="@string/settings_key_enable_shift_space_language_shortcut"
+            android:persistent="true"
+            android:summaryOff="@string/enable_shift_space_language_shortcut_off_summary"
+            android:summaryOn="@string/enable_shift_space_language_shortcut_on_summary"
+            android:title="@string/enable_shift_space_language_shortcut"/>
     </android.support.v7.preference.PreferenceCategory>
 
     <android.support.v7.preference.PreferenceCategory

--- a/app/src/main/res/xml/prefs_language_tweaks.xml
+++ b/app/src/main/res/xml/prefs_language_tweaks.xml
@@ -47,6 +47,14 @@
             android:title="@string/hide_soft_when_physical"/>
 
         <android.support.v7.preference.CheckBoxPreference
+            android:defaultValue="@bool/settings_default_enable_alt_space_language_shortcut"
+            android:key="@string/settings_key_enable_alt_space_language_shortcut"
+            android:persistent="true"
+            android:summaryOff="@string/enable_alt_space_language_shortcut_off_summary"
+            android:summaryOn="@string/enable_alt_space_language_shortcut_on_summary"
+            android:title="@string/enable_alt_space_language_shortcut"/>
+
+        <android.support.v7.preference.CheckBoxPreference
             android:defaultValue="@bool/settings_default_enable_shift_space_language_shortcut"
             android:key="@string/settings_key_enable_shift_space_language_shortcut"
             android:persistent="true"

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
@@ -352,8 +352,6 @@ public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest
 
     @Test
     public void testKeyboardSwitchesLayoutOnAltSpace() {
-        ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "other");
-
         SupportTest.ensureKeyboardAtIndexEnabled(0, true);
         SupportTest.ensureKeyboardAtIndexEnabled(1, true);
         SupportTest.ensureKeyboardAtIndexEnabled(2, true);
@@ -376,8 +374,7 @@ public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest
 
     @Test
     public void testKeyboardNoLayoutSwitchOnAltSpace() {
-        ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "droid");
-
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_enable_alt_space_language_shortcut, false);
         SupportTest.ensureKeyboardAtIndexEnabled(0, true);
         SupportTest.ensureKeyboardAtIndexEnabled(1, true);
         SupportTest.ensureKeyboardAtIndexEnabled(2, true);

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
@@ -6,6 +6,7 @@ import android.os.Parcelable;
 import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 
+import com.anysoftkeyboard.addons.SupportTest;
 import com.anysoftkeyboard.test.SharedPrefsHelper;
 import com.menny.android.anysoftkeyboard.R;
 
@@ -14,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
 public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest {
@@ -154,8 +156,9 @@ public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
 
         long time = 0;
-        mAnySoftKeyboardUnderTest.onKeyDown('c', new TestKeyEvent(time, KeyEvent.ACTION_DOWN, 'c', -1));
-        mAnySoftKeyboardUnderTest.onKeyUp('c', new TestKeyEvent(time, KeyEvent.ACTION_UP, 'c', -1));
+        int virtualKeyboardDeviceId = -1;
+        mAnySoftKeyboardUnderTest.onKeyDown('c', new TestKeyEvent(time, KeyEvent.ACTION_DOWN, 'c', 0, virtualKeyboardDeviceId));
+        mAnySoftKeyboardUnderTest.onKeyUp('c', new TestKeyEvent(time, KeyEvent.ACTION_UP, 'c', 0, virtualKeyboardDeviceId));
 
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
     }
@@ -347,6 +350,101 @@ public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest
         Assert.assertTrue(mAnySoftKeyboardUnderTest.isKeyboardViewHidden());
     }
 
+    @Test
+    public void testKeyboardSwitchesLayoutOnAltSpace() {
+        ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "other");
+
+        SupportTest.ensureKeyboardAtIndexEnabled(0, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(1, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(2, true);
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        long time = 0;
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE, KeyEvent.META_ALT_ON));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE, KeyEvent.META_ALT_ON));
+
+        Assert.assertEquals("12335055-4aa6-49dc-8456-c7d38a1a5123", mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+    }
+
+    @Test
+    public void testKeyboardNoLayoutSwitchOnAltSpace() {
+        ReflectionHelpers.setStaticField(android.os.Build.class, "MODEL", "droid");
+
+        SupportTest.ensureKeyboardAtIndexEnabled(0, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(1, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(2, true);
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        long time = 0;
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE, KeyEvent.META_ALT_ON));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE, KeyEvent.META_ALT_ON));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+    }
+
+    @Test
+    public void testKeyboardSwitchesLayoutOnShiftSpace() {
+        SupportTest.ensureKeyboardAtIndexEnabled(0, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(1, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(2, true);
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        long time = 0;
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE, KeyEvent.META_SHIFT_ON));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE, KeyEvent.META_SHIFT_ON));
+
+        Assert.assertEquals("12335055-4aa6-49dc-8456-c7d38a1a5123", mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+    }
+
+    @Test
+    public void testKeyboardNoLayoutSwitchOnShiftSpace() {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_enable_shift_space_language_shortcut, false);
+        SupportTest.ensureKeyboardAtIndexEnabled(0, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(1, true);
+        SupportTest.ensureKeyboardAtIndexEnabled(2, true);
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        long time = 0;
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+
+        mAnySoftKeyboardUnderTest.onKeyDown(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SPACE, KeyEvent.META_SHIFT_ON));
+        mAnySoftKeyboardUnderTest.onKeyUp(KeyEvent.KEYCODE_SPACE, new TestKeyEvent(time, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SPACE, KeyEvent.META_SHIFT_ON));
+
+        Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a",
+                mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().getKeyboardId());
+    }
+
     public static class TestKeyEvent extends KeyEvent {
 
         public static final Parcelable.Creator<TestKeyEvent> CREATOR = new Parcelable.Creator<TestKeyEvent>() {
@@ -362,11 +460,15 @@ public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest
         };
 
         public TestKeyEvent(long downTime, int action, int code) {
-            this(downTime, action, code, 99);
+            this(downTime, action, code, 0, 99);
         }
 
-        public TestKeyEvent(long downTime, int action, int code, int deviceId) {
-            super(downTime, action == KeyEvent.ACTION_DOWN ? downTime : downTime + 1, action, code, 0, 0, deviceId, code);
+        public TestKeyEvent(long downTime, int action, int code, int metaState) {
+            this(downTime, action, code, metaState, 99);
+        }
+
+        public TestKeyEvent(long downTime, int action, int code, int metaState, int deviceId) {
+            super(downTime, action == KeyEvent.ACTION_DOWN ? downTime : downTime + 1, action, code, 0, metaState, deviceId, code);
         }
 
         @Override

--- a/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardPhysicalKeyboardTest.java
@@ -15,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.util.ReflectionHelpers;
 
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
 public class AnySoftKeyboardPhysicalKeyboardTest extends AnySoftKeyboardBaseTest {


### PR DESCRIPTION
Issue #111 mentioned that the current shift+space shortcut for switching layouts on physical keyboards was unintuitive, and it is inconvenient when typing capital letters, parentheses, underscores, etc.

This PR adds a toggle in the hardware keyboard settings to disable that shortcut.