### PR TITLE
FIX *Remove PhoneKeyboard from listed keyboards #1610*

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSwitcher.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSwitcher.java
@@ -81,7 +81,7 @@ public class KeyboardSwitcher {
     private static final int SYMBOLS_KEYBOARD_REGULAR_INDEX = 0;
     private static final int SYMBOLS_KEYBOARD_ALT_INDEX = 1;
     private static final int SYMBOLS_KEYBOARD_ALT_NUMBERS_INDEX = 2;
-    private static final int SYMBOLS_KEYBOARD_LAST_CYCLE_INDEX = SYMBOLS_KEYBOARD_ALT_NUMBERS_INDEX;
+    private static final int SYMBOLS_KEYBOARD_LAST_CYCLE_INDEX =  1;
     private static final int SYMBOLS_KEYBOARD_NUMBERS_INDEX = 3;
     private static final int SYMBOLS_KEYBOARD_PHONE_INDEX = 4;
     private static final int SYMBOLS_KEYBOARD_DATETIME_INDEX = 5;


### PR DESCRIPTION
Now typing is a little bit more easy :)

DESCRIPTION "Keyboard just turned out symbols to be more intuitive and
now symbols will not include the irrelevant Numpad keyboard. It will pop
up only when keyboard for num pad is set up in a web app mobile view.
So if you need to type up numbers, you will have it. For everything else you have full support for symbols from now on."