### PR TITLE
lowered keypress vibration values

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,9 +22,9 @@
 
     <string-array name="vibrate_on_key_press_values">
         <item>0</item>
-        <item>17</item>
+        <item>1</item>
+        <item>15</item>
         <item>30</item>
-        <item>50</item>
     </string-array>
 
     <string-array name="power_save_mode_values">


### PR DESCRIPTION
Just a temporary solution to make the phone not vibrate out of my hands and into the stratosphere while writing with vibration on.
In future, could anyone who knows how to work with it change this option to a slider pls?