### PR TITLE
Fix dictionary auto-learning

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
@@ -41,7 +41,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     protected static final int MAX_WORD_LENGTH = 32;
-    protected static final String TAG = "ASK UDict";
+    protected static final String TAG = "ASKUDict";
     private static final int INITIAL_ROOT_CAPACITY =
             26 /*number of letters in the English Alphabet. Why bother with auto-increment, when we can start at roughly the right final size..*/;
     protected final Context mContext;

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/DictionaryAddOnAndBuilder.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/DictionaryAddOnAndBuilder.java
@@ -32,7 +32,7 @@ public class DictionaryAddOnAndBuilder extends AddOnImpl {
 
     private static final int INVALID_RES_ID = 0;
 
-    private static final String TAG = "ASK DAOB";
+    private static final String TAG = "ASKDictAddOnBuilder";
 
     private final String mLanguage;
     private final String mAssetsFilename;

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/ExternalDictionaryFactory.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/ExternalDictionaryFactory.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public class ExternalDictionaryFactory extends AddOnsFactory<DictionaryAddOnAndBuilder> {
 
     private static final String PREFS_KEY_POSTFIX_OVERRIDE_DICTIONARY = "_override_dictionary";
-    private static final String TAG = "ASK ExtDictFctry";
+    private static final String TAG = "ASKExtDictFactory";
     private static final String XML_LANGUAGE_ATTRIBUTE = "locale";
     private static final String XML_ASSETS_ATTRIBUTE = "dictionaryAssertName";
     private static final String XML_RESOURCE_ATTRIBUTE = "dictionaryResourceId";

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/Suggest.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/Suggest.java
@@ -36,7 +36,7 @@ import java.util.Locale;
  * characters. This includes corrections and completions.
  */
 public class Suggest {
-    private static final String TAG = "ASK Suggest";
+    private static final String TAG = "ASKSuggest";
     @NonNull private final SuggestionsProvider mSuggestionsProvider;
     private final List<CharSequence> mSuggestions = new ArrayList<>();
     private final List<CharSequence> mNextSuggestions = new ArrayList<>();

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -71,8 +71,8 @@ public class TextEntryState {
     }
 
     public static void typedCharacter(char c, boolean isSeparator) {
-        boolean isSpace = c == ' ';
-        boolean isEnter = c == '\n';
+        final boolean isSpace = c == ' ';
+        final boolean isEnter = c == '\n';
 
         // CHECKSTYLE:OFF: missingswitchdefault
         switch (sState) {

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -71,8 +71,8 @@ public class TextEntryState {
     }
 
     public static void typedCharacter(char c, boolean isSeparator) {
-        final boolean isSpace = c == ' ';
-        final boolean isEnter = c == '\n';
+        boolean isSpace = c == ' ';
+        boolean isEnter = c == '\n';
 
         // CHECKSTYLE:OFF: missingswitchdefault
         switch (sState) {

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/content/ContactsDictionary.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/content/ContactsDictionary.java
@@ -45,7 +45,7 @@ import net.evendanan.chauffeur.lib.permissions.PermissionsFragmentChauffeurActiv
 @TargetApi(7)
 public class ContactsDictionary extends BTreeDictionary implements NextWordSuggestions {
 
-    protected static final String TAG = "ASK CDict";
+    protected static final String TAG = "ASKContactsDict";
     /** A contact is a valid word in a language, and it usually very frequent. */
     private static final int MINIMUM_CONTACT_WORD_FREQUENCY = 64;
 

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/AutoDictionary.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/AutoDictionary.java
@@ -69,7 +69,7 @@ public class AutoDictionary extends SQLiteUserDictionaryBase {
             int freq = getWordFrequency(word);
 
             freq = freq < 0 ? frequencyDelta : freq + frequencyDelta;
-            if (freq >= mLearnWordThreshold) {
+            if (mLearnWordThreshold != -1 && freq >= mLearnWordThreshold) {
                 Logger.i(
                         TAG, "Promoting the word '%s' to the user dictionary. It earned it.", word);
                 // no need for this word in this dictionary any longer

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/AutoDictionary.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/AutoDictionary.java
@@ -29,7 +29,7 @@ import io.reactivex.disposables.Disposable;
  */
 public class AutoDictionary extends SQLiteUserDictionaryBase {
 
-    protected static final String TAG = "ASK ADict";
+    protected static final String TAG = "ASKAutoDict";
     private final Disposable mPrefDisposable;
     private int mLearnWordThreshold;
 

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/WordsSQLiteConnection.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/WordsSQLiteConnection.java
@@ -26,7 +26,7 @@ import com.anysoftkeyboard.base.utils.Logger;
 import com.anysoftkeyboard.dictionaries.BTreeDictionary;
 
 public class WordsSQLiteConnection extends SQLiteOpenHelper {
-    private static final String TAG = "ASK SqliteCnnt";
+    private static final String TAG = "ASKSQliteConnect";
     private static final String TABLE_NAME = "WORDS"; // was FALL_BACK_USER_DICTIONARY;
     private static final String WORDS_ORDER_BY = Words._ID + " DESC";
     private final String mCurrentLocale;

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -1095,7 +1095,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
         if (!TextUtils.isEmpty(actualWordToOutput)) {
             TextEntryState.acceptedDefault(typedWord);
-            boolean fixed = !TextUtils.equals(typedWord, actualWordToOutput);
+            final boolean fixed = !TextUtils.equals(typedWord, actualWordToOutput);
             commitWordToInput(actualWordToOutput, fixed);
             if (!fixed) { // if the word typed was auto-replaced, we should not learn it.
                 // Add the word to the auto dictionary if it's not a known word

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -1095,7 +1095,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
         if (!TextUtils.isEmpty(actualWordToOutput)) {
             TextEntryState.acceptedDefault(typedWord);
-            final boolean fixed = !TextUtils.equals(typedWord, actualWordToOutput);
+            boolean fixed = !TextUtils.equals(typedWord, actualWordToOutput);
             commitWordToInput(actualWordToOutput, fixed);
             if (!fixed) { // if the word typed was auto-replaced, we should not learn it.
                 // Add the word to the auto dictionary if it's not a known word

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -50,7 +50,7 @@ import java.util.Locale;
 import org.xmlpull.v1.XmlPullParserException;
 
 public abstract class AnyKeyboard extends Keyboard {
-    private static final String TAG = "ASK - AK";
+    private static final String TAG = "ASKAnyKeyboard";
     private static final String TAG_ROW = "Row";
     private static final String TAG_KEY = "Key";
     private static final int STICKY_KEY_OFF = 0;

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -44,7 +44,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTranslator {
 
-    private static final String TAG = "ASK - EAK";
+    private static final String TAG = "ASKExtendedAnyKeyboard";
 
     private static final String XML_TRANSLATION_TAG = "PhysicalTranslation";
     private static final String XML_QWERTY_ATTRIBUTE = "QwertyTranslation";
@@ -153,7 +153,7 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
             Context context, int qwertyTranslationId) {
         HardKeyboardSequenceHandler translator = new HardKeyboardSequenceHandler();
         XmlPullParser parser = context.getResources().getXml(qwertyTranslationId);
-        final String TAG = "ASK Hard Translation Parser";
+        final String TAG = "ASKHardTranslationParser";
         try {
             int event;
             boolean inTranslations = false;

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -434,7 +434,7 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'e':
-                    key.popupCharacters = "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u03b5\u0113"; // "èéêëęε€";
+                    key.popupCharacters = "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u0117\u03b5\u0113"; // "èéêëęėε€";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'f':
@@ -450,7 +450,7 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'i':
-                    key.popupCharacters = "ìíîïłīι"; // "ìíîïł";
+                    key.popupCharacters = "ìíîïłīįι";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'j':
@@ -494,7 +494,7 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'u':
-                    key.popupCharacters = "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B\u03b8"; // "ùúûüŭűθ";
+                    key.popupCharacters = "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B\u0173\u03b8"; // "ùúûüŭűųθ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'v':

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -434,7 +434,8 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'e':
-                    key.popupCharacters = "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u0117\u03b5\u0113"; // "èéêëęėε€";
+                    key.popupCharacters =
+                            "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u0117\u03b5\u0113"; // "èéêëęėε€";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'f':
@@ -494,7 +495,8 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'u':
-                    key.popupCharacters = "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B\u0173\u03b8"; // "ùúûüŭűųθ";
+                    key.popupCharacters =
+                            "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B\u0173\u03b8"; // "ùúûüŭűųθ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'v':

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -408,15 +408,25 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
     @CallSuper
     protected boolean setupKeyAfterCreation(AnyKey key) {
         if (super.setupKeyAfterCreation(key)) return true;
-
+        // ABCDEFGHIJKLMNOPQRSTUVWXYZ QWERTY KEYBOARD
+        // αβξδεφγθιϊκλμνοπψρστυϋωχηζ VIM digraphs
+        // ΑΒΞΔΕΦΓΘΙΪΚΛΜΝΟΠΨΡΣΤΥΫΩΧΗΖ VIM DIGRAPHS
+        // αβψδεφγηιξκλμνοπ;ρστθωςχυζ Greek layout
+        // ΑΒΨΔΕΦΓΗΙΞΚΛΜΝΟΠ;ΡΣΤΘΩΣΧΥΖ GREEK LAYOUT
+        // αβχδεφγηι κλμνοπθρστυ ωχψζ Magicplot
+        // ΑΒΧΔΕΦΓΗΙ ΚΛΜΝΟΠΘΡΣΤΥ ΩΧΨΖ MAGICPLOT
         if (key.mCodes.length > 0) {
             switch (key.getPrimaryCode()) {
                 case 'a':
                     key.popupCharacters = "àáâãāäåæąăα";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
+                case 'b':
+                    key.popupCharacters = "β";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
                 case 'c':
-                    key.popupCharacters = "çćĉčγ";
+                    key.popupCharacters = "çćĉčψ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'd':
@@ -424,15 +434,19 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'e':
-                    key.popupCharacters = "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u0113"; // "èéêëę€";
+                    key.popupCharacters = "\u00e8\u00e9\u00ea\u00eb\u0119\u20ac\u03b5\u0113"; // "èéêëęε€";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'f':
+                    key.popupCharacters = "φ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'g':
-                    key.popupCharacters = "\u011d"; // "ĝ";
+                    key.popupCharacters = "\u011d\u011f\u03b3"; // "ĝğγ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'h':
-                    key.popupCharacters = "ĥθ";
+                    key.popupCharacters = "ĥη";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'i':
@@ -440,31 +454,63 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'j':
-                    key.popupCharacters = "\u0135"; // "ĵ";
+                    key.popupCharacters = "\u0135\u03be"; // "ĵξ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'k':
+                    key.popupCharacters = "κ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'l':
-                    key.popupCharacters = "ľĺłλ"; // "ł";
+                    key.popupCharacters = "ľĺłλ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
-                case 'o':
-                    key.popupCharacters = "òóôǒōõöőøœo";
-                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
-                    break;
-                case 's':
-                    key.popupCharacters = "§ßśŝšșσ";
-                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
-                    break;
-                case 'u':
-                    key.popupCharacters = "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B"; // "ùúûüŭű";
+                case 'm':
+                    key.popupCharacters = "μ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'n':
                     key.popupCharacters = "ñńν";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
+                case 'o':
+                    key.popupCharacters = "òóôǒōõöőøœo";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'p':
+                    key.popupCharacters = "π";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'r':
+                    key.popupCharacters = "ρ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 's':
+                    key.popupCharacters = "§ßśŝšșσ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 't':
+                    key.popupCharacters = "τ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'u':
+                    key.popupCharacters = "\u00f9\u00fa\u00fb\u00fc\u016d\u0171\u016B\u03b8"; // "ùúûüŭűθ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'v':
+                    key.popupCharacters = "ω";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'w':
+                    key.popupCharacters = "ς";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
+                case 'x':
+                    key.popupCharacters = "χ";
+                    key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
+                    break;
                 case 'y':
-                    key.popupCharacters = "ýÿψ";
+                    key.popupCharacters = "ýÿυ";
                     key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
                     break;
                 case 'z':

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
@@ -54,7 +54,7 @@ import java.util.List;
 
 public class CandidateView extends View implements ThemeableChild {
 
-    private static final String TAG = "ASK CandidateView";
+    private static final String TAG = "ASKCandidateView";
 
     private static final int OUT_OF_BOUNDS_X_CORD = -1;
     private int mTouchX = OUT_OF_BOUNDS_X_CORD;

--- a/app/src/main/java/com/anysoftkeyboard/receivers/PackagesChangedReceiver.java
+++ b/app/src/main/java/com/anysoftkeyboard/receivers/PackagesChangedReceiver.java
@@ -27,7 +27,7 @@ import com.menny.android.anysoftkeyboard.BuildConfig;
 
 public class PackagesChangedReceiver extends BroadcastReceiver {
 
-    private static final String TAG = "ASK PkgChanged";
+    private static final String TAG = "ASKPkgChanged";
 
     private final AnySoftKeyboard mIme;
     private final StringBuilder mStringBuffer = new StringBuilder();

--- a/app/src/main/java/com/anysoftkeyboard/ui/tutorials/TutorialsProvider.java
+++ b/app/src/main/java/com/anysoftkeyboard/ui/tutorials/TutorialsProvider.java
@@ -32,7 +32,7 @@ import com.menny.android.anysoftkeyboard.BuildConfig;
 import com.menny.android.anysoftkeyboard.R;
 
 public class TutorialsProvider {
-    private static final String TAG = "ASK Tutorial";
+    private static final String TAG = "ASKTutorial";
 
     public static void showDragonsIfNeeded(Context context) {
         if (BuildConfig.TESTING_BUILD && firstTestersTimeVersionLoaded(context)) {

--- a/app/src/main/java/com/anysoftkeyboard/utils/IMEUtil.java
+++ b/app/src/main/java/com/anysoftkeyboard/utils/IMEUtil.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class IMEUtil {
     public static final int IME_ACTION_CUSTOM_LABEL = EditorInfo.IME_MASK_ACTION + 1;
 
-    private static final String TAG = "ASK IMEUtils";
+    private static final String TAG = "ASKIMEUtils";
 
     /* Damerau-Levenshtein distance */
     public static int editDistance(@NonNull CharSequence s, @NonNull CharSequence t) {

--- a/app/src/main/java/com/menny/android/anysoftkeyboard/ChewbaccaUncaughtExceptionHandler.java
+++ b/app/src/main/java/com/menny/android/anysoftkeyboard/ChewbaccaUncaughtExceptionHandler.java
@@ -42,7 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class ChewbaccaUncaughtExceptionHandler implements UncaughtExceptionHandler, Consumer<Throwable> {
-    private static final String TAG = "ASK CHEWBACCA";
+    private static final String TAG = "ASKChewbacca";
 
     private final UncaughtExceptionHandler mOsDefaultHandler;
     private final Context mApp;

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -60,6 +60,7 @@
     <string name="ime_settings">Configuración del teclado</string>
     <string name="switch_incognito">Modo incógnito</string>
     <string name="vibrate_on_key_press_title">Vibrar al pulsar una tecla</string>
+    <string name="vibrate_on_key_press_value_template">%d milisegundos</string>
     <string name="night_mode_screen">Configuración del modo nocturno</string>
     <string name="night_mode_description">El modo nocturno cambiará estas características:</string>
     <string name="night_mode_state_summary">Activación del modo nocturno. Actualmente: \u0020%s</string>
@@ -108,6 +109,9 @@
     <string name="switch_keyboard_on_space">El espacio cambia de teclados</string>
     <string name="switch_keyboard_on_space_on_summary">Cambiar de símbolos/números a alfabeto al pulsar espacio.</string>
     <string name="switch_keyboard_on_space_off_summary">No cambiar de símbolos/números a alfabeto al pulsar espacio.</string>
+    <string name="colorize_nav_bar_title">Dibujar detrás de la barra de navegación.</string>
+    <string name="colorize_nav_bar_summary_on">Dibujará el fondo del teclado detrás de la barra de navegación. Esto no es compatible con todos los dispositivos.</string>
+    <string name="colorize_nav_bar_summary_off">No dibujar detrás de la barra de navegación.</string>
     <string name="persistent_layout_per_package_id_title">Recordar la distribución del alfabeto por aplicación</string>
     <string name="persistent_layout_per_package_id_off_summary">Usar la misma distribución para todas las aplicaciones.</string>
     <string name="persistent_layout_per_package_id_on_summary">Cambiar automáticamente a la distribución anterior utilizada en la aplicación.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,6 +62,7 @@
     <string name="ime_settings">Paramètres du clavier</string>
     <string name="switch_incognito">Mode incognito</string>
     <string name="vibrate_on_key_press_title">Vibrer lors de la saisie</string>
+    <string name="vibrate_on_key_press_value_template">%d millisecondes</string>
     <string name="night_mode_screen">Paramètres du mode nuit</string>
     <string name="night_mode_description">Le mode nuit va modifier ces fonctionnalités :</string>
     <string name="night_mode_state_summary">Actuellement, déclencheur du mode nuit : \u0020%s</string>
@@ -110,6 +111,9 @@
     <string name="switch_keyboard_on_space">Appui sur Espace pour changer de clavier</string>
     <string name="switch_keyboard_on_space_on_summary">Passer de symboles/nombres à l\'alphabet lors d\'un appui sur Espace</string>
     <string name="switch_keyboard_on_space_off_summary">Ne pas passer des symboles/nombres à l\'alphabet lors d\'un appui sur Espace</string>
+    <string name="colorize_nav_bar_title">Dessiner derrière la barre de navigation</string>
+    <string name="colorize_nav_bar_summary_on">L\'arrière-plan du clavier sera dessiné derrière la barre de navigation. Ceci n\'est pas pris en charge par tous les appareils.</string>
+    <string name="colorize_nav_bar_summary_off">Ne pas dessiner derrière la barre de navigation.</string>
     <string name="persistent_layout_per_package_id_title">Mémoriser la disposition alphabétique par application</string>
     <string name="persistent_layout_per_package_id_off_summary">Utiliser la même disposition pour toutes les applications</string>
     <string name="persistent_layout_per_package_id_on_summary">Passer automatiquement à la disposition précédente utilisée par l\'application</string>

--- a/app/src/main/res/xml/symbols.xml
+++ b/app/src/main/res/xml/symbols.xml
@@ -34,8 +34,8 @@
 
     <Row>
         <Key android:codes="@integer/key_code_mode_symbols" android:keyEdgeFlags="left"/>
-        <Key android:codes="34" android:keyLabel="&quot;" android:popupCharacters="\'\u201c\u201e\u201d\u2018\u2019"/>
-        <Key android:codes="46" android:keyLabel="." android:popupCharacters=","/>
+        <Key android:codes="34" android:keyLabel="&quot;" android:popupCharacters="\'\u201c\u201e\u201d\u2018\u2019‹›«»"/>
+        <Key android:codes="46" android:keyLabel="." android:popupCharacters=",…⋯ "/>
         <Key android:codes="58" android:keyLabel=":" android:popupCharacters=";"/>
         <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="&#11822;&#8253;\u00bf\u00a1"/>
         <Key android:codes="47" android:keyLabel="/" android:popupCharacters="\\"/>

--- a/app/src/main/res/xml/symbols.xml
+++ b/app/src/main/res/xml/symbols.xml
@@ -27,7 +27,7 @@
         <Key android:codes="37" android:keyLabel="%" android:popupCharacters="‰"/>
         <Key android:codes="94" android:keyLabel="^" android:popupCharacters="&#8592;&#8593;&#8594;&#8595;"/>
         <Key android:codes="38" android:keyLabel="&amp;"/>
-        <Key android:codes="42" android:keyLabel="*"/>
+        <Key android:codes="42" android:keyLabel="*" android:popupCharacters="†‡§¶"/>
         <Key android:codes="40" android:keyLabel="("/>
         <Key android:codes="41" android:keyLabel=")" android:keyEdgeFlags="right"/>
     </Row>

--- a/app/src/main/res/xml/symbols_alt.xml
+++ b/app/src/main/res/xml/symbols_alt.xml
@@ -16,7 +16,7 @@
         <Key android:codes="93" android:keyLabel="]"/>
         <Key android:codes="123" android:keyLabel="{"/>
         <Key android:codes="125" android:keyLabel="}"/>
-        <Key android:codes="124" android:keyLabel="|" android:keyEdgeFlags="right"/>
+        <Key android:codes="124" android:keyLabel="|" android:popupCharacters="¦‖" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>

--- a/app/src/main/res/xml/symbols_alt.xml
+++ b/app/src/main/res/xml/symbols_alt.xml
@@ -35,7 +35,7 @@
     <Row>
         <Key android:codes="@integer/key_code_mode_symbols" android:keyEdgeFlags="left"/>
         <Key android:codes="96" android:keyLabel="`" android:popupCharacters="´"/>
-        <Key android:codes="176" android:keyLabel="°"/>
+        <Key android:codes="176" android:keyLabel="°" android:popupCharacters="′″‴⁗"/>
         <Key android:codes="8226" android:keyLabel="•"/>
         <Key android:codes="92" android:keyLabel="\\"/>
         <Key android:codes="95" android:keyLabel="_"/>

--- a/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboardTest.java
@@ -629,7 +629,7 @@ public class AnyKeyboardViewWithMiniKeyboardTest extends AnyKeyboardViewBaseTest
     public void testLongPressKeyWithoutAny() throws Exception {
         Assert.assertNull(mViewUnderTest.getMiniKeyboard());
         Assert.assertFalse(mViewUnderTest.mMiniKeyboardPopup.isShowing());
-        final Keyboard.Key keyWithoutPopups = findKey('v');
+        final Keyboard.Key keyWithoutPopups = findKey('q');
         // sanity checks
         Assert.assertTrue(TextUtils.isEmpty(keyWithoutPopups.popupCharacters));
         Assert.assertEquals(0, keyWithoutPopups.popupResId);

--- a/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboardTest.java
@@ -629,7 +629,7 @@ public class AnyKeyboardViewWithMiniKeyboardTest extends AnyKeyboardViewBaseTest
     public void testLongPressKeyWithoutAny() throws Exception {
         Assert.assertNull(mViewUnderTest.getMiniKeyboard());
         Assert.assertFalse(mViewUnderTest.mMiniKeyboardPopup.isShowing());
-        final Keyboard.Key keyWithoutPopups = findKey('q');
+        final Keyboard.Key keyWithoutPopups = findKey(' ');
         // sanity checks
         Assert.assertTrue(TextUtils.isEmpty(keyWithoutPopups.popupCharacters));
         Assert.assertEquals(0, keyWithoutPopups.popupResId);

--- a/base/src/main/java/com/anysoftkeyboard/base/utils/CompatUtils.java
+++ b/base/src/main/java/com/anysoftkeyboard/base/utils/CompatUtils.java
@@ -26,7 +26,7 @@ import android.widget.PopupWindow;
 import com.getkeepsafe.relinker.ReLinker;
 
 public class CompatUtils {
-    private static final String TAG = "ASK CompatUtils";
+    private static final String TAG = "ASKCompatUtils";
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     public static void setPopupUnattachedToDecor(PopupWindow popupWindow) {


### PR DESCRIPTION
This PR is mainly meant to fix auto dictionary. Until now, the option for "Do not learn new words" failed because AnySoftKeyboard naïvely set `mLearnWordThreshold` to -1, forcing it to always learn automatically new words instead. It also reported always the same two states, causing other bugs.

Later, I added little fixes like:
- Adding Greek letters to the default layouts. There is no universal way to map Greek characters to the standard QWERTY keyboard and the characters that were already there didn't seem to match any layout I knew of. I set them up using the Greek layout on Ubuntu as a base, but I noticed that AZERTY users will find Greek letters in different places... so please check into this and swap whatever's needed.
- Adding Lithuanian characters.
- Updating `strings.xml` for Spanish and French with the files in Crowdin, seeing as they are 100% completed and reviewed (please add a link to Crowdin on `README.md`).
- Removed the spaces in the tags for `logcat` as the usual syntax of `adb logcat ASK\ ADict:D` or `adb logcat -s "ASK ADict"` didn't work, forcing me to use a crude `grep` to filter messages.

You might want to review everything yourself, some of the changes may be too reckless (especially with the Greek letters).