### PR TITLE
Allow displaying hints with the AOSP based themes

### DIFF
--- a/app/src/main/res/values/styles_aosp_keyboard_theme.xml
+++ b/app/src/main/res/values/styles_aosp_keyboard_theme.xml
@@ -16,7 +16,6 @@
 
     <style name="AospBaseTheme" parent="@style/AnyKeyboardBaseTheme">
         <item name="keyVerticalGap">5dp</item>
-        <item name="hintTextSize">0px</item>
 
         <item name="keyTextStyle">normal</item>
         <item name="shadowRadius">0px</item>


### PR DESCRIPTION
Fixes #1884 by allowing the user to chose if they want to display hints or not with AOSP themes