### PR TITLE
Generate unsigned release APKs, fix #971 and #1636

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,15 +31,16 @@ android {
                 keyPassword System.getenv("ANYSOFTKEYBOARD_KEYSTORE_KEY_PASSWORD")
                 println "Using 'anysoftkeyboard.keystore' to release APK (with alias '${keyAlias}')."
             } else {
-                println "Could not find 'anysoftkeyboard.keystore' file. Can not sign release APK with release keystore! Using debug."
-                initWith signingConfigs.debug
+                println "Could not find 'anysoftkeyboard.keystore' file. Release APK will not be signed."
             }
         }
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (file("/tmp/anysoftkeyboard.keystore").exists()) {
+                signingConfig signingConfigs.release
+            }
             zipAlignEnabled true
             debuggable false
 

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -830,13 +830,15 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             return;
         }
 
-        if (TextEntryState.isPredicting() && mWord.cursorPosition() > 0 && mWord.length() > 0) {
+        if (TextEntryState.isPredicting()
+                && mWord.cursorPosition() > 0
+                && mWord.codePointCount() > 0) {
             // sp#ace -> ace
             // cursor == 2
             // length == 5
             // textAfterCursor = word.substring(2, 3) -> word.substring(cursor, length - cursor)
             final CharSequence textAfterCursor =
-                    mWord.getTypedWord().subSequence(mWord.cursorPosition(), mWord.charLength());
+                    mWord.getTypedWord().subSequence(mWord.cursorPosition(), mWord.charCount());
             mWord.reset();
             getSuggest().resetNextWordSentence();
             TextEntryState.newSession(isPredictionOn());
@@ -897,7 +899,9 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     private void handleDeleteLastCharacter(boolean forMultiTap) {
         InputConnection ic = getCurrentInputConnection();
         final boolean wordManipulation =
-                TextEntryState.isPredicting() && mWord.length() > 0 && mWord.cursorPosition() > 0;
+                TextEntryState.isPredicting()
+                        && mWord.codePointCount() > 0
+                        && mWord.cursorPosition() > 0;
         final TextEntryState.State newState = TextEntryState.backspace();
 
         if (newState == TextEntryState.State.UNDO_COMMIT) {
@@ -905,7 +909,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         } else if (wordManipulation) {
             final int charsToDelete = mWord.deleteLast();
             final int cursorPosition;
-            if (mWord.cursorPosition() != mWord.charLength()) {
+            if (mWord.cursorPosition() != mWord.charCount()) {
                 cursorPosition = getCursorPosition(ic);
             } else {
                 cursorPosition = -1;
@@ -916,7 +920,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             }
 
             ic.setComposingText(mWord.getTypedWord(), 1);
-            if (mWord.length() == 0) {
+            if (mWord.codePointCount() == 0) {
                 TextEntryState.newSession(isPredictionOn());
             } else if (cursorPosition >= 0) {
                 ic.setSelection(cursorPosition - charsToDelete, cursorPosition - charsToDelete);
@@ -960,13 +964,13 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     private void handleForwardDelete(InputConnection ic) {
         final boolean wordManipulation =
                 TextEntryState.isPredicting()
-                        && mWord.length() > 0
-                        && mWord.cursorPosition() < mWord.charLength();
+                        && mWord.codePointCount() > 0
+                        && mWord.cursorPosition() < mWord.charCount();
 
         if (wordManipulation) {
             mWord.deleteForward();
             final int cursorPosition;
-            if (mWord.cursorPosition() != mWord.charLength()) {
+            if (mWord.cursorPosition() != mWord.charCount()) {
                 cursorPosition = getCursorPosition(ic);
             } else {
                 cursorPosition = -1;
@@ -977,7 +981,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             }
 
             ic.setComposingText(mWord.getTypedWord(), 1);
-            if (mWord.length() == 0) {
+            if (mWord.codePointCount() == 0) {
                 TextEntryState.newSession(isPredictionOn());
             } else if (cursorPosition >= 0) {
                 ic.setSelection(cursorPosition, cursorPosition);
@@ -1304,7 +1308,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             return;
         }
 
-        final int currentLength = mWord.length();
+        final int currentLength = mWord.codePointCount();
         boolean shouldDeleteUsingCompletion;
         if (currentLength > 0) {
             shouldDeleteUsingCompletion = true;

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -606,7 +606,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             final Key key,
             final int multiTapIndex,
             final int[] nearByKeyCodes) {
-        if (BuildConfig.DEBUG) Logger.d(TAG, "onFunctionKey %d", primaryCode);
+        if (BuildConfig.DEBUG) Logger.d(TAG, "onNonFunctionKey %d", primaryCode);
 
         final InputConnection ic = getCurrentInputConnection();
 

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -896,7 +896,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
 
     private void handleDeleteLastCharacter(boolean forMultiTap) {
         InputConnection ic = getCurrentInputConnection();
-        final boolean wordManipulation = TextEntryState.isPredicting() && mWord.length() > 0 && mWord.cursorPosition() > 0;
+        final boolean wordManipulation =
+                TextEntryState.isPredicting() && mWord.length() > 0 && mWord.cursorPosition() > 0;
         final TextEntryState.State newState = TextEntryState.backspace();
 
         if (newState == TextEntryState.State.UNDO_COMMIT) {
@@ -941,7 +942,11 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
                     // hence the "if (!forMultiTap)" above
                     final CharSequence beforeText = ic.getTextBeforeCursor(8, 0);
                     final int textLengthBeforeDelete =
-                            TextUtils.isEmpty(beforeText) ? 0 : Character.charCount(Character.codePointBefore(beforeText, beforeText.length()));
+                            TextUtils.isEmpty(beforeText)
+                                    ? 0
+                                    : Character.charCount(
+                                            Character.codePointBefore(
+                                                    beforeText, beforeText.length()));
                     if (textLengthBeforeDelete > 0) {
                         ic.deleteSurroundingText(textLengthBeforeDelete, 0);
                     } else {
@@ -953,7 +958,10 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     }
 
     private void handleForwardDelete(InputConnection ic) {
-        final boolean wordManipulation = TextEntryState.isPredicting() && mWord.length() > 0 && mWord.cursorPosition() < mWord.length();
+        final boolean wordManipulation =
+                TextEntryState.isPredicting()
+                        && mWord.length() > 0
+                        && mWord.cursorPosition() < mWord.length();
 
         if (wordManipulation) {
             mWord.deleteForward();
@@ -986,7 +994,9 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             } else {
                 final CharSequence afterText = ic.getTextAfterCursor(8, 0);
                 final int textLengthAfterDelete =
-                        TextUtils.isEmpty(afterText) ? 0 : Character.charCount(Character.codePointAt(afterText, 0));
+                        TextUtils.isEmpty(afterText)
+                                ? 0
+                                : Character.charCount(Character.codePointAt(afterText, 0));
                 ic.deleteSurroundingText(0, textLengthAfterDelete);
             }
         }

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -672,7 +672,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
                         if (controlCode == 9) {
                             sendTab();
                         } else {
-                            ic.commitText(Character.toString((char) controlCode), 1);
+                            ic.commitText(new String(new int[] {controlCode}, 0, 1), 1);
                         }
                     } else {
                         handleCharacter(primaryCode, key, multiTapIndex, nearByKeyCodes);

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -836,7 +836,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             // length == 5
             // textAfterCursor = word.substring(2, 3) -> word.substring(cursor, length - cursor)
             final CharSequence textAfterCursor =
-                    mWord.getTypedWord().subSequence(mWord.cursorPosition(), mWord.length());
+                    mWord.getTypedWord().subSequence(mWord.cursorPosition(), mWord.charLength());
             mWord.reset();
             getSuggest().resetNextWordSentence();
             TextEntryState.newSession(isPredictionOn());
@@ -905,7 +905,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         } else if (wordManipulation) {
             final int charsToDelete = mWord.deleteLast();
             final int cursorPosition;
-            if (mWord.cursorPosition() != mWord.length()) {
+            if (mWord.cursorPosition() != mWord.charLength()) {
                 cursorPosition = getCursorPosition(ic);
             } else {
                 cursorPosition = -1;
@@ -961,12 +961,12 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         final boolean wordManipulation =
                 TextEntryState.isPredicting()
                         && mWord.length() > 0
-                        && mWord.cursorPosition() < mWord.length();
+                        && mWord.cursorPosition() < mWord.charLength();
 
         if (wordManipulation) {
             mWord.deleteForward();
             final int cursorPosition;
-            if (mWord.cursorPosition() != mWord.length()) {
+            if (mWord.cursorPosition() != mWord.charLength()) {
                 cursorPosition = getCursorPosition(ic);
             } else {
                 cursorPosition = -1;

--- a/app/src/main/java/com/anysoftkeyboard/addons/AddOnImpl.java
+++ b/app/src/main/java/com/anysoftkeyboard/addons/AddOnImpl.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 
 public abstract class AddOnImpl implements AddOn {
 
-    private static final String TAG = "ASK_AddOnImpl";
+    private static final String TAG = "ASKAddOnImpl";
     private final String mId;
     private final String mName;
     private final CharSequence mDescription;

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/DictionaryContentObserver.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/DictionaryContentObserver.java
@@ -24,7 +24,7 @@ import java.lang.ref.WeakReference;
 
 public class DictionaryContentObserver extends ContentObserver {
 
-    private static final String TAG = "DictionaryContentObserver";
+    private static final String TAG = "DictContentObserver";
     private final WeakReference<BTreeDictionary> mDictionary;
 
     public DictionaryContentObserver(BTreeDictionary dictionary) {

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/Suggest.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/Suggest.java
@@ -289,7 +289,7 @@ public class Suggest {
         // Search the dictionary only if there are at least mMinimumWordLengthToStartCorrecting
         // (configurable)
         // characters
-        if (wordComposer.length() >= mMinimumWordLengthToStartCorrecting) {
+        if (wordComposer.codePointCount() >= mMinimumWordLengthToStartCorrecting) {
             mSuggestionsProvider.getSuggestions(wordComposer, mTypingDictionaryWordCallback);
             mSuggestionsProvider.getAbbreviations(wordComposer, mAbbreviationWordCallback);
 

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/TextEntryState.java
@@ -70,9 +70,9 @@ public class TextEntryState {
         displayState();
     }
 
-    public static void typedCharacter(char c, boolean isSeparator) {
-        final boolean isSpace = c == ' ';
-        final boolean isEnter = c == '\n';
+    public static void typedCharacter(int c, boolean isSeparator) {
+        final boolean isSpace = c == (int) ' ';
+        final boolean isEnter = c == (int) '\n';
 
         // CHECKSTYLE:OFF: missingswitchdefault
         switch (sState) {

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/UserDictionary.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/UserDictionary.java
@@ -28,7 +28,7 @@ import com.menny.android.anysoftkeyboard.R;
 
 public class UserDictionary extends EditableDictionary {
 
-    private static final String TAG = "ASK_SUD";
+    private static final String TAG = "ASKUserDict";
     private final NextWordDictionary mNextWordDictionary;
     private final Context mContext;
     private final String mLocale;

--- a/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/SQLiteUserDictionaryBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/dictionaries/sqlite/SQLiteUserDictionaryBase.java
@@ -24,7 +24,7 @@ import com.anysoftkeyboard.base.utils.Logger;
 import com.anysoftkeyboard.dictionaries.BTreeDictionary;
 
 public abstract class SQLiteUserDictionaryBase extends BTreeDictionary {
-    private static final String TAG = "SQLiteUserDictionaryBase";
+    private static final String TAG = "SQLiteUserDictBase";
 
     private volatile WordsSQLiteConnection mStorage;
     private final String mLocale;

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
@@ -123,9 +123,10 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
                         ic.setSelection(globalSelectionStartPosition, globalCursorPosition);
                     } else {
                         ic.setSelection(
-                                globalSelectionStartPosition -
-                                    Character.charCount(toLeft.codePointBefore(toLeft.length())),
-                                    globalCursorPosition);
+                                globalSelectionStartPosition
+                                        - Character.charCount(
+                                                toLeft.codePointBefore(toLeft.length())),
+                                globalCursorPosition);
                     }
                     return true;
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
@@ -135,8 +136,7 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
                     } else {
                         ic.setSelection(
                                 globalSelectionStartPosition,
-                                globalCursorPosition +
-                                    Character.charCount(toRight.codePointAt(0)));
+                                globalCursorPosition + Character.charCount(toRight.codePointAt(0)));
                     }
                     return true;
                 default:

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
@@ -116,11 +116,28 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
         if (mArrowSelectionState && ic != null) {
             switch (keyEventKeyCode) {
                 case KeyEvent.KEYCODE_DPAD_LEFT:
-                    ic.setSelection(
-                            Math.max(0, globalSelectionStartPosition - 1), globalCursorPosition);
+                    // A Unicode codepoint can be made up of two Java chars.
+                    // We check if that's what happening before the cursor:
+                    final String toLeft = ic.getTextBeforeCursor(8, 0).toString();
+                    if (toLeft.length() == 0) {
+                        ic.setSelection(globalSelectionStartPosition, globalCursorPosition);
+                    } else {
+                        ic.setSelection(
+                                globalSelectionStartPosition -
+                                    Character.charCount(toLeft.codePointBefore(toLeft.length())),
+                                    globalCursorPosition);
+                    }
                     return true;
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
-                    ic.setSelection(globalSelectionStartPosition, globalCursorPosition + 1);
+                    final String toRight = ic.getTextAfterCursor(8, 0).toString();
+                    if (toRight.length() == 0) {
+                        ic.setSelection(globalSelectionStartPosition, globalCursorPosition);
+                    } else {
+                        ic.setSelection(
+                                globalSelectionStartPosition,
+                                globalCursorPosition +
+                                    Character.charCount(toRight.codePointAt(0)));
+                    }
                     return true;
                 default:
                     mArrowSelectionState = false;

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
@@ -17,6 +17,7 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
 
     private boolean mArrowSelectionState;
     private Clipboard mClipboard;
+    protected static final int MAX_CHARS_PER_CODEPOINT = 2;
 
     @Override
     public void onCreate() {
@@ -118,7 +119,8 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
                 case KeyEvent.KEYCODE_DPAD_LEFT:
                     // A Unicode codepoint can be made up of two Java chars.
                     // We check if that's what happening before the cursor:
-                    final String toLeft = ic.getTextBeforeCursor(8, 0).toString();
+                    final String toLeft =
+                            ic.getTextBeforeCursor(MAX_CHARS_PER_CODEPOINT, 0).toString();
                     if (toLeft.length() == 0) {
                         ic.setSelection(globalSelectionStartPosition, globalCursorPosition);
                     } else {
@@ -130,7 +132,8 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
                     }
                     return true;
                 case KeyEvent.KEYCODE_DPAD_RIGHT:
-                    final String toRight = ic.getTextAfterCursor(8, 0).toString();
+                    final String toRight =
+                            ic.getTextAfterCursor(MAX_CHARS_PER_CODEPOINT, 0).toString();
                     if (toRight.length() == 0) {
                         ic.setSelection(globalSelectionStartPosition, globalCursorPosition);
                     } else {

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardPopText.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardPopText.java
@@ -111,7 +111,7 @@ public abstract class AnySoftKeyboardPopText extends AnySoftKeyboardPowerSaving 
         super.onKey(primaryCode, key, multiTapIndex, nearByKeyCodes, fromUI);
         mLastKey = key;
         if (mPopTextOnKeyPress && isAlphabet(primaryCode)) {
-            popText(Character.toString((char) primaryCode));
+            popText(new String(new int[] {primaryCode}, 0, 1));
         }
     }
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -636,11 +636,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                 mCandidateView.replaceTypedWord(mWord.getTypedWord());
             }
         } else {
-            if (Character.charCount(primaryCode) == 1) {
-                sendKeyChar((char) primaryCode);
-            } else {
-                sendKeyChar(Character.highSurrogate(primaryCode));
-                sendKeyChar(Character.lowSurrogate(primaryCode));
+            for (char c : Character.toChars(primaryCode)) {
+                sendKeyChar(c);
             }
         }
         mJustAutoAddedWord = false;
@@ -723,11 +720,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         }
 
         if (!handledOutputToInputConnection) {
-            if (Character.charCount(primaryCode) == 1) {
-                sendKeyChar((char) primaryCode);
-            } else {
-                sendKeyChar(Character.highSurrogate(primaryCode));
-                sendKeyChar(Character.lowSurrogate(primaryCode));
+            for (char c : Character.toChars(primaryCode)) {
+                sendKeyChar(c);
             }
         }
         TextEntryState.typedCharacter(primaryCode, true);

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -611,7 +611,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             if (ic != null) {
                 final int cursorPosition;
-                if (mWord.cursorPosition() != mWord.length()) {
+                if (mWord.cursorPosition() != mWord.charLength()) {
                     // Cursor is not at the end of the word. I'll need to reposition
                     cursorPosition =
                             mGlobalCursorPosition
@@ -677,7 +677,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         // this is a special case, when the user presses a separator WHILE
         // inside the predicted word.
         // in this case, I will want to just dump the separator.
-        final boolean separatorInsideWord = (mWord.cursorPosition() < mWord.length());
+        final boolean separatorInsideWord = (mWord.cursorPosition() < mWord.charLength());
         if (TextEntryState.isPredicting() && !separatorInsideWord) {
             // ACTION does not invoke default picking. See
             // https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/198

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -611,7 +611,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             if (ic != null) {
                 final int cursorPosition;
-                if (mWord.cursorPosition() != mWord.charLength()) {
+                if (mWord.cursorPosition() != mWord.charCount()) {
                     // Cursor is not at the end of the word. I'll need to reposition
                     cursorPosition =
                             mGlobalCursorPosition
@@ -674,7 +674,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         // this is a special case, when the user presses a separator WHILE
         // inside the predicted word.
         // in this case, I will want to just dump the separator.
-        final boolean separatorInsideWord = (mWord.cursorPosition() < mWord.charLength());
+        final boolean separatorInsideWord = (mWord.cursorPosition() < mWord.charCount());
         if (TextEntryState.isPredicting() && !separatorInsideWord) {
             // ACTION does not invoke default picking. See
             // https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/198
@@ -1349,7 +1349,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
     private void checkAddToDictionaryWithAutoDictionary(
             WordComposer suggestion, Suggest.AdditionType type) {
         mJustAutoAddedWord = false;
-        if (suggestion == null || suggestion.length() < 1 || !mShowSuggestions) {
+        if (suggestion == null || suggestion.codePointCount() < 1 || !mShowSuggestions) {
             return;
         }
 

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -613,7 +613,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                 final int cursorPosition;
                 if (mWord.cursorPosition() != mWord.length()) {
                     // Cursor is not at the end of the word. I'll need to reposition
-                    cursorPosition = mGlobalCursorPosition + 1 /*adding the new character*/;
+                    cursorPosition = mGlobalCursorPosition + Character.charCount(primaryCode); /*adding the new character*/
                     ic.beginBatchEdit();
                 } else {
                     cursorPosition = -1;
@@ -816,8 +816,9 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             final int[] tempNearByKeys = new int[1];
 
-            for (int index = 0; index < word.length(); index++) {
-                final char c = word.charAt(index);
+            final int[] wordCodePoints = word.codePoints().toArray();
+            for (int index = 0; index < wordCodePoints.length; index++) {
+                final int c = wordCodePoints[index];
                 if (index == 0) mWord.setFirstCharCapitalized(Character.isUpperCase(c));
 
                 tempNearByKeys[0] = c;

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -613,7 +613,9 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                 final int cursorPosition;
                 if (mWord.cursorPosition() != mWord.length()) {
                     // Cursor is not at the end of the word. I'll need to reposition
-                    cursorPosition = mGlobalCursorPosition + Character.charCount(primaryCode); /*adding the new character*/
+                    cursorPosition =
+                            mGlobalCursorPosition
+                                    + Character.charCount(primaryCode); /*adding the new character*/
                     ic.beginBatchEdit();
                 } else {
                     cursorPosition = -1;

--- a/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -812,15 +812,16 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             final int[] tempNearByKeys = new int[1];
 
-            final int[] wordCodePoints = word.codePoints().toArray();
-            for (int index = 0; index < wordCodePoints.length; index++) {
-                final int c = wordCodePoints[index];
+            int index = 0;
+            while (index < word.length()) {
+                final int c = Character.offsetByCodePoints(word, 0, index);
                 if (index == 0) mWord.setFirstCharCapitalized(Character.isUpperCase(c));
 
                 tempNearByKeys[0] = c;
                 mWord.add(c, tempNearByKeys);
 
                 TextEntryState.typedCharacter(c, false);
+                index += Character.charCount(c);
             }
             ic.setComposingRegion(
                     mGlobalCursorPosition - toLeft.length(),

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -224,11 +224,11 @@ public abstract class AnyKeyboard extends Keyboard {
                         if (isAlphabetKey(key) && (key.icon == null)) {
                             final boolean labelIsOriginallyEmpty = TextUtils.isEmpty(key.label);
                             if (labelIsOriginallyEmpty) {
-                                final char code = (char) key.mCodes[0];
+                                final int code = key.mCodes[0];
                                 // check the ASCII table, everything below 32,
                                 // is not printable
                                 if (code > 31 && !Character.isWhitespace(code)) {
-                                    key.label = Character.toString(code);
+                                    key.label = new String(new int[] {code}, 0, 1);
                                 }
                             }
                         }

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -272,11 +272,12 @@ public abstract class AnyKeyboard extends Keyboard {
                 for (int keyIndex = rowStartIndex; keyIndex < rowEndIndex; keyIndex++) {
                     final Key keyToModify = keyList.get(keyIndex);
                     keyToModify.width = (int) (keyToModify.width + additionalSpacePerKey);
-                    if (keyIndex == foundLanguageKeyIndex) {
-                        xOffset -= (widthToRemove + keyboardDimens.getKeyHorizontalGap());
-                    }
                     keyToModify.x = (int) (keyToModify.x + xOffset);
-                    xOffset += additionalSpacePerKey;
+                    if (keyIndex == foundLanguageKeyIndex) {
+                        xOffset -= widthToRemove;
+                    } else {
+                        xOffset += additionalSpacePerKey;
+                    }
                 }
                 keyList.remove(foundLanguageKeyIndex);
             }

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
@@ -62,8 +62,9 @@ public class AnyPopupKeyboard extends AnyKeyboard {
         loadKeyboard(keyboardDimens);
 
         final int rowsCount = getPopupRowsCount(popupCharacters);
+        final int popupCharactersLength = Character.codePointCount(popupCharacters, 0, popupCharacters.length());
         final int keysPerRow =
-                (int) Math.ceil((float) popupCharacters.length() / (float) rowsCount);
+                (int) Math.ceil((float) popupCharactersLength / (float) rowsCount);
 
         List<Key> keys = getKeys();
         for (int rowIndex = rowsCount - 1; rowIndex >= 0; rowIndex--) {
@@ -91,25 +92,26 @@ public class AnyPopupKeyboard extends AnyKeyboard {
         // now adding the popups
         final float y = baseKey.y;
         final float keyHorizontalGap = row.defaultHorizontalGap;
-        char popupCharacter = popupCharacters.charAt(characterOffset);
-        baseKey.mCodes = new int[] {(int) popupCharacter};
-        baseKey.label = Character.toString(popupCharacter);
-        char upperCasePopupCharacter = Character.toUpperCase(popupCharacter);
-        baseKey.mShiftedCodes = new int[] {(int) upperCasePopupCharacter};
+        int popupCharacter = Character.codePointAt(popupCharacters, Character.offsetByCodePoints(popupCharacters, 0, characterOffset));
+        baseKey.mCodes = new int[] {popupCharacter};
+        baseKey.label = new String(new int[] {popupCharacter}, 0, 1);
+        int upperCasePopupCharacter = Character.toUpperCase(popupCharacter);
+        baseKey.mShiftedCodes = new int[] {upperCasePopupCharacter};
         float x = baseKey.width;
         AnyKey aKey = null;
+        final int popupCharactersLength = Character.codePointCount(popupCharacters, 0, popupCharacters.length());
         for (int popupCharIndex = characterOffset + 1;
                 popupCharIndex < characterOffset + keysPerRow
-                        && popupCharIndex < popupCharacters.length();
+                        && popupCharIndex < popupCharactersLength;
                 popupCharIndex++) {
             x += (keyHorizontalGap / 2);
 
             aKey = new AnyKey(row, keyboardDimens);
-            popupCharacter = popupCharacters.charAt(popupCharIndex);
-            aKey.mCodes = new int[] {(int) popupCharacter};
-            aKey.label = Character.toString(popupCharacter);
+            popupCharacter = Character.codePointAt(popupCharacters, Character.offsetByCodePoints(popupCharacters, 0, popupCharIndex));
+            aKey.mCodes = new int[] {popupCharacter};
+            aKey.label = new String(new int[] {popupCharacter}, 0, 1);
             upperCasePopupCharacter = Character.toUpperCase(popupCharacter);
-            aKey.mShiftedCodes = new int[] {(int) upperCasePopupCharacter};
+            aKey.mShiftedCodes = new int[] {upperCasePopupCharacter};
             aKey.x = (int) x;
             aKey.width = (int) (aKey.width - keyHorizontalGap); // the gap is on both sides
             aKey.centerX = aKey.x + aKey.width / 2;
@@ -147,7 +149,7 @@ public class AnyPopupKeyboard extends AnyKeyboard {
     }
 
     private static int getPopupRowsCount(CharSequence popupCharacters) {
-        final int count = popupCharacters.length();
+        final int count = Character.codePointCount(popupCharacters, 0, popupCharacters.length());
         if (count <= 8) return 1;
         if (count <= 16) {
             return 2;

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
@@ -62,9 +62,9 @@ public class AnyPopupKeyboard extends AnyKeyboard {
         loadKeyboard(keyboardDimens);
 
         final int rowsCount = getPopupRowsCount(popupCharacters);
-        final int popupCharactersLength = Character.codePointCount(popupCharacters, 0, popupCharacters.length());
-        final int keysPerRow =
-                (int) Math.ceil((float) popupCharactersLength / (float) rowsCount);
+        final int popupCharactersLength =
+                Character.codePointCount(popupCharacters, 0, popupCharacters.length());
+        final int keysPerRow = (int) Math.ceil((float) popupCharactersLength / (float) rowsCount);
 
         List<Key> keys = getKeys();
         for (int rowIndex = rowsCount - 1; rowIndex >= 0; rowIndex--) {
@@ -92,22 +92,22 @@ public class AnyPopupKeyboard extends AnyKeyboard {
         // now adding the popups
         final float y = baseKey.y;
         final float keyHorizontalGap = row.defaultHorizontalGap;
-        int popupCharacter = Character.codePointAt(popupCharacters, Character.offsetByCodePoints(popupCharacters, 0, characterOffset));
+        int[] popupKeycodes = popupCharacters.codePoints().toArray();
+        int popupCharacter = popupKeycodes[characterOffset];
         baseKey.mCodes = new int[] {popupCharacter};
         baseKey.label = new String(new int[] {popupCharacter}, 0, 1);
         int upperCasePopupCharacter = Character.toUpperCase(popupCharacter);
         baseKey.mShiftedCodes = new int[] {upperCasePopupCharacter};
         float x = baseKey.width;
         AnyKey aKey = null;
-        final int popupCharactersLength = Character.codePointCount(popupCharacters, 0, popupCharacters.length());
         for (int popupCharIndex = characterOffset + 1;
                 popupCharIndex < characterOffset + keysPerRow
-                        && popupCharIndex < popupCharactersLength;
+                        && popupCharIndex < popupKeycodes.length;
                 popupCharIndex++) {
             x += (keyHorizontalGap / 2);
 
             aKey = new AnyKey(row, keyboardDimens);
-            popupCharacter = Character.codePointAt(popupCharacters, Character.offsetByCodePoints(popupCharacters, 0, popupCharIndex));
+            popupCharacter = popupKeycodes[popupCharIndex];
             aKey.mCodes = new int[] {popupCharacter};
             aKey.label = new String(new int[] {popupCharacter}, 0, 1);
             upperCasePopupCharacter = Character.toUpperCase(popupCharacter);

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyPopupKeyboard.java
@@ -92,22 +92,29 @@ public class AnyPopupKeyboard extends AnyKeyboard {
         // now adding the popups
         final float y = baseKey.y;
         final float keyHorizontalGap = row.defaultHorizontalGap;
-        int[] popupKeycodes = popupCharacters.codePoints().toArray();
-        int popupCharacter = popupKeycodes[characterOffset];
+        int popupCharacter =
+                Character.codePointAt(
+                        popupCharacters,
+                        Character.offsetByCodePoints(popupCharacters, 0, characterOffset));
         baseKey.mCodes = new int[] {popupCharacter};
         baseKey.label = new String(new int[] {popupCharacter}, 0, 1);
         int upperCasePopupCharacter = Character.toUpperCase(popupCharacter);
         baseKey.mShiftedCodes = new int[] {upperCasePopupCharacter};
         float x = baseKey.width;
         AnyKey aKey = null;
+        final int popupCharactersLength =
+                Character.codePointCount(popupCharacters, 0, popupCharacters.length());
         for (int popupCharIndex = characterOffset + 1;
                 popupCharIndex < characterOffset + keysPerRow
-                        && popupCharIndex < popupKeycodes.length;
+                        && popupCharIndex < popupCharactersLength;
                 popupCharIndex++) {
             x += (keyHorizontalGap / 2);
 
             aKey = new AnyKey(row, keyboardDimens);
-            popupCharacter = popupKeycodes[popupCharIndex];
+            popupCharacter =
+                    Character.codePointAt(
+                            popupCharacters,
+                            Character.offsetByCodePoints(popupCharacters, 0, popupCharIndex));
             aKey.mCodes = new int[] {popupCharacter};
             aKey.label = new String(new int[] {popupCharacter}, 0, 1);
             upperCasePopupCharacter = Character.toUpperCase(popupCharacter);

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -44,7 +44,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTranslator {
 
-    private static final String TAG = "ASKExtendedAnyKeyboard";
+    private static final String TAG = "ASKExtendedAnyKbd";
 
     private static final String XML_TRANSLATION_TAG = "PhysicalTranslation";
     private static final String XML_QWERTY_ATTRIBUTE = "QwertyTranslation";

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
@@ -42,7 +42,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public abstract class Keyboard {
 
-    private static final String TAG = "Keyboard";
+    private static final String TAG = "ASKKbd";
 
     public static final String PREF_KEY_ROW_MODE_ENABLED_PREFIX =
             "settings_key_support_keyboard_type_state_row_type_";

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardFactory.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardFactory.java
@@ -27,7 +27,7 @@ import com.menny.android.anysoftkeyboard.BuildConfig;
 import com.menny.android.anysoftkeyboard.R;
 
 public class KeyboardFactory extends AddOnsFactory.MultipleAddOnsFactory<KeyboardAddOnAndBuilder> {
-    private static final String TAG = "ASK_KF";
+    private static final String TAG = "ASKKeyboardFactory";
 
     private static final String XML_LAYOUT_RES_ID_ATTRIBUTE = "layoutResId";
     private static final String XML_LANDSCAPE_LAYOUT_RES_ID_ATTRIBUTE = "landscapeResId";

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
@@ -13,7 +13,7 @@ import io.reactivex.Observable;
 import java.util.StringTokenizer;
 
 public class KeyboardSupport {
-    private static final String TAG = "KeyboardSupport";
+    private static final String TAG = "ASKKbdSupport";
 
     private static int[] parseCSV(String value) {
         int count = 0;

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSwitcher.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSwitcher.java
@@ -90,7 +90,7 @@ public class KeyboardSwitcher {
     private static final int SYMBOLS_KEYBOARD_PHONE_INDEX = 4;
     private static final int SYMBOLS_KEYBOARD_DATETIME_INDEX = 5;
     private static final int SYMBOLS_KEYBOARDS_COUNT = 6;
-    private static String TAG = "ASK_KeySwitcher";
+    private static String TAG = "ASKKbdSwitcher";
     @NonNull private final KeyboardSwitchedListener mKeyboardSwitchedListener;
     @NonNull private final Context mContext;
     // this will hold the last used keyboard ID per app's package ID

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardView.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardView.java
@@ -56,7 +56,7 @@ public class AnyKeyboardView extends AnyKeyboardViewWithExtraDraw
         implements InputViewBinder, ActionsStripSupportedChild {
 
     private static final int DELAY_BEFORE_POPPING_UP_EXTENSION_KBD = 35; // milliseconds
-    private static final String TAG = "AnyKeyboardView";
+    private static final String TAG = "ASKKbdView";
     private AnimationsLevel mAnimationLevel;
 
     private boolean mExtensionVisible = false;

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
@@ -1445,11 +1445,14 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
                     }
                 } else if (key.popupCharacters != null) {
                     final String hintString = key.popupCharacters.toString();
-                    final int hintLength = Character.codePointCount(hintString, 0, hintString.length());
+                    final int hintLength =
+                            Character.codePointCount(hintString, 0, hintString.length());
                     if (hintLength <= 3) {
                         hintText = hintString;
                     } else {
-                        hintText = hintString.substring(0, Character.offsetByCodePoints(hintString, 0, 3));
+                        hintText =
+                                hintString.substring(
+                                        0, Character.offsetByCodePoints(hintString, 0, 3));
                     }
                 }
 

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
@@ -1441,15 +1441,15 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
                     // not put too many characters in the hint label...
                 } else if (key.longPressCode != 0) {
                     if (Character.isLetterOrDigit(key.longPressCode)) {
-                        hintText = Character.toString((char) key.longPressCode);
+                        hintText = new String(new int[] {key.longPressCode}, 0, 1);
                     }
                 } else if (key.popupCharacters != null) {
                     final String hintString = key.popupCharacters.toString();
-                    final int hintLength = hintString.length();
+                    final int hintLength = Character.codePointCount(hintString, 0, hintString.length());
                     if (hintLength <= 3) {
                         hintText = hintString;
                     } else {
-                        hintText = hintString.substring(0, 3);
+                        hintText = hintString.substring(0, Character.offsetByCodePoints(hintString, 0, 3));
                     }
                 }
 

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/AskGestureEventsListener.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/AskGestureEventsListener.java
@@ -23,7 +23,7 @@ import com.menny.android.anysoftkeyboard.BuildConfig;
 
 final class AskGestureEventsListener implements AskOnGestureListener {
 
-    private static final String TAG = "AskGestureEventsListener";
+    private static final String TAG = "ASKGestureEventsListener";
 
     private final AnyKeyboardViewBase mKeyboardView;
 

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/PointerTracker.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/PointerTracker.java
@@ -530,7 +530,9 @@ class PointerTracker {
         } else {
             int multiTapCode = getMultiTapCode(key);
             // The following line became necessary when we stopped casting multiTapCode to char
-            if (multiTapCode < 32) {multiTapCode = 32;}
+            if (multiTapCode < 32) {
+                multiTapCode = 32;
+            }
             // because, if multiTapCode happened to be negative, this would fail:
             return new String(new int[] {multiTapCode}, 0, 1);
         }

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/PointerTracker.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/PointerTracker.java
@@ -528,15 +528,19 @@ class PointerTracker {
                     ? anyKey.label.toString().toUpperCase(Locale.getDefault())
                     : anyKey.label;
         } else {
-            return Character.toString(getMultiTapCode(key));
+            int multiTapCode = getMultiTapCode(key);
+            // The following line became necessary when we stopped casting multiTapCode to char
+            if (multiTapCode < 32) {multiTapCode = 32;}
+            // because, if multiTapCode happened to be negative, this would fail:
+            return new String(new int[] {multiTapCode}, 0, 1);
         }
     }
 
-    private char getMultiTapCode(final Key key) {
+    private int getMultiTapCode(final Key key) {
         final int codesCount = key.getCodesCount();
         if (codesCount == 0) return KeyCodes.SPACE; // space is good for nothing
         int safeMultiTapIndex = mTapCount < 0 ? 0 : mTapCount % codesCount;
-        return (char) key.getCodeAtIndex(safeMultiTapIndex, mKeyDetector.isKeyShifted(key));
+        return key.getCodeAtIndex(safeMultiTapIndex, mKeyDetector.isKeyShifted(key));
     }
 
     private void resetMultiTap() {

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/views/preview/KeyPreviewsManager.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/views/preview/KeyPreviewsManager.java
@@ -24,7 +24,7 @@ import java.util.Queue;
 
 public class KeyPreviewsManager implements KeyPreviewsController {
 
-    private static final String TAG = "ASK_PPM";
+    private static final String TAG = "ASKKeyPreviewsManager";
     private static final KeyPreview NULL_KEY_PREVIEW =
             new KeyPreview() {
                 @Override

--- a/app/src/main/java/com/anysoftkeyboard/ui/SendBugReportUiActivity.java
+++ b/app/src/main/java/com/anysoftkeyboard/ui/SendBugReportUiActivity.java
@@ -74,7 +74,7 @@ public class SendBugReportUiActivity extends FragmentActivity {
         // End of Parcel part
     }
 
-    private static final String TAG = "ASK_BUG_SENDER";
+    private static final String TAG = "ASKBugSender";
 
     public static final String EXTRA_KEY_BugReportDetails = "EXTRA_KEY_BugReportDetails";
 

--- a/app/src/main/java/com/anysoftkeyboard/utils/LocaleTools.java
+++ b/app/src/main/java/com/anysoftkeyboard/utils/LocaleTools.java
@@ -10,7 +10,7 @@ import com.anysoftkeyboard.base.utils.Logger;
 import java.util.Locale;
 
 public class LocaleTools {
-    private static final String TAG = "ASK_LocaleTools";
+    private static final String TAG = "ASKLocaleTools";
 
     public static void applyLocaleToContext(
             @NonNull Context context, @Nullable String localeString) {

--- a/app/src/main/java/com/menny/android/anysoftkeyboard/AnyApplication.java
+++ b/app/src/main/java/com/menny/android/anysoftkeyboard/AnyApplication.java
@@ -65,7 +65,7 @@ import java.util.List;
 
 public class AnyApplication extends Application {
 
-    private static final String TAG = "ASK_APP";
+    private static final String TAG = "ASKApp";
 
     static final String PREF_KEYS_FIRST_INSTALLED_APP_VERSION =
             "settings_key_first_app_version_installed";

--- a/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardRowsTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardRowsTest.java
@@ -468,7 +468,7 @@ public class ExternalAnyKeyboardRowsTest {
         // positions (note - keys are not evenly spread)
         // we have additional pixels now, since the language key was removed
         int[] keyIndices = new int[] {32, 33, 34, 35, 36};
-        int[] xPositions = new int[] {1, 21, 72, 86, 101};
+        int[] xPositions = new int[] {1, 21, 71, 86, 100};
         int[] widths = new int[] {18, 48, 12, 12, 18};
         int[] gaps = new int[] {0, 0, 0, 0, 0};
         for (int keyIndexIndex = 0; keyIndexIndex < keyIndices.length; keyIndexIndex++) {

--- a/base/src/main/java/com/anysoftkeyboard/base/utils/Logger.java
+++ b/base/src/main/java/com/anysoftkeyboard/base/utils/Logger.java
@@ -187,7 +187,7 @@ public class Logger {
     public static synchronized void e(final String tag, Throwable e, String text, Object... args) {
         if (msLogger.supportsE()) {
             String msg = getFormattedString(text, args);
-            msLogger.e(tag, appendErrorText(text, e));
+            msLogger.e(tag, appendErrorText(msg, e));
             addLog(LVL_E, tag, msg);
         }
     }

--- a/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
+++ b/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
@@ -72,6 +72,15 @@ public class WordComposer implements KeyCodesProvider {
         return mCodes.size();
     }
 
+    /**
+     * Number of chars in the composing word.
+     *
+     * @return the number of chars
+     */
+    public int charLength() {
+        return mTypedWord.length();
+    }
+
     /** Cursor position */
     public int cursorPosition() {
         return mCursorPosition;

--- a/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
+++ b/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
@@ -82,6 +82,7 @@ public class WordComposer implements KeyCodesProvider {
 
     @Override
     public int length() {
+        // DEPRECATED. Please use codePointCount() or charCount().
         return codePointCount();
     }
 

--- a/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
+++ b/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
@@ -142,10 +142,13 @@ public class WordComposer implements KeyCodesProvider {
         mTypedWord.setLength(0);
         mTypedWord.insert(mCursorPosition, typedWord);
 
-        typedWord.codePoints().forEachOrdered(codePoint -> {
-            mCodes.add(mCursorPosition, EMPTY_CODES_ARRAY);
-            if (Character.isUpperCase(codePoint)) mCapsCount++;
-        });
+        typedWord
+                .codePoints()
+                .forEachOrdered(
+                        codePoint -> {
+                            mCodes.add(mCursorPosition, EMPTY_CODES_ARRAY);
+                            if (Character.isUpperCase(codePoint)) mCapsCount++;
+                        });
         mCursorPosition += typedWord.length();
     }
 
@@ -199,9 +202,11 @@ public class WordComposer implements KeyCodesProvider {
         }
     }
 
-    /** Delete the last keystroke (codepoint) as a result of hitting backspace.
+    /**
+     * Delete the last keystroke (codepoint) as a result of hitting backspace.
      *
-     * @return the number of chars (not codepoints) deleted. */
+     * @return the number of chars (not codepoints) deleted.
+     */
     public int deleteLast() {
         if (mCursorPosition > 0) {
             // removing from the codes list, and taking it back to the reusable list
@@ -216,9 +221,11 @@ public class WordComposer implements KeyCodesProvider {
         }
     }
 
-    /** Delete the character after the cursor
+    /**
+     * Delete the character after the cursor
      *
-     * @return the number of chars (not codepoints) deleted. */
+     * @return the number of chars (not codepoints) deleted.
+     */
     public int deleteForward() {
         if (mCursorPosition < mTypedWord.length()) {
             mArraysToReuse.add(mCodes.remove(mTypedWord.codePointCount(0, mCursorPosition)));

--- a/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
+++ b/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
@@ -67,8 +67,7 @@ public class WordComposer implements KeyCodesProvider {
      *
      * @return the number of keystrokes
      */
-    @Override
-    public int length() {
+    public int codePointCount() {
         return mCodes.size();
     }
 
@@ -77,8 +76,13 @@ public class WordComposer implements KeyCodesProvider {
      *
      * @return the number of chars
      */
-    public int charLength() {
+    public int charCount() {
         return mTypedWord.length();
+    }
+
+    @Override
+    public int length() {
+        return codePointCount();
     }
 
     /** Cursor position */
@@ -87,8 +91,8 @@ public class WordComposer implements KeyCodesProvider {
     }
 
     public boolean setCursorPosition(int position /*, int candidatesStartPosition*/) {
-        if (position < 0 || position > charLength()) {
-            // note: the cursor can be AFTER the word, so it can be equal to charLength()
+        if (position < 0 || position > charCount()) {
+            // note: the cursor can be AFTER the word, so it can be equal to charCount()
             return false;
         }
         final boolean changed = mCursorPosition != position;
@@ -146,7 +150,7 @@ public class WordComposer implements KeyCodesProvider {
     }
 
     public void simulateTypedWord(CharSequence typedWord) {
-        mCursorPosition -= charLength();
+        mCursorPosition -= charCount();
 
         mTypedWord.setLength(0);
         mTypedWord.insert(mCursorPosition, typedWord);
@@ -236,7 +240,7 @@ public class WordComposer implements KeyCodesProvider {
      * @return the number of chars (not codepoints) deleted.
      */
     public int deleteForward() {
-        if (mCursorPosition < mTypedWord.length()) {
+        if (mCursorPosition < charCount()) {
             mArraysToReuse.add(mCodes.remove(mTypedWord.codePointCount(0, mCursorPosition)));
             int last = Character.codePointAt(mTypedWord, mCursorPosition);
             mTypedWord.delete(mCursorPosition, mCursorPosition + Character.charCount(last));
@@ -258,7 +262,7 @@ public class WordComposer implements KeyCodesProvider {
     }
 
     public boolean isAtTagsSearchState() {
-        return mTypedWord.length() > 0 && mTypedWord.charAt(0) == ':';
+        return charCount() > 0 && mTypedWord.charAt(0) == ':';
     }
 
     public void setFirstCharCapitalized(boolean capitalized) {

--- a/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
+++ b/dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java
@@ -87,8 +87,8 @@ public class WordComposer implements KeyCodesProvider {
     }
 
     public boolean setCursorPosition(int position /*, int candidatesStartPosition*/) {
-        if (position < 0 || position > mTypedWord.length()) {
-            // note: the cursor can be AFTER the word, so it can be equal to size()
+        if (position < 0 || position > charLength()) {
+            // note: the cursor can be AFTER the word, so it can be equal to charLength()
             return false;
         }
         final boolean changed = mCursorPosition != position;
@@ -119,7 +119,7 @@ public class WordComposer implements KeyCodesProvider {
     /**
      * Returns the codes at a particular position in the word.
      *
-     * @param index the position in the word
+     * @param index the position in the word (measured in Unicode codepoints, not chars)
      * @return the unicode for the pressed and surrounding keys
      */
     @Override
@@ -146,18 +146,18 @@ public class WordComposer implements KeyCodesProvider {
     }
 
     public void simulateTypedWord(CharSequence typedWord) {
-        mCursorPosition -= mTypedWord.length();
+        mCursorPosition -= charLength();
 
         mTypedWord.setLength(0);
         mTypedWord.insert(mCursorPosition, typedWord);
 
-        typedWord
-                .codePoints()
-                .forEachOrdered(
-                        codePoint -> {
-                            mCodes.add(mCursorPosition, EMPTY_CODES_ARRAY);
-                            if (Character.isUpperCase(codePoint)) mCapsCount++;
-                        });
+        int index = 0;
+        while (index < typedWord.length()) {
+            final int codePoint = Character.codePointAt(typedWord, index);
+            mCodes.add(mCursorPosition, EMPTY_CODES_ARRAY);
+            if (Character.isUpperCase(codePoint)) mCapsCount++;
+            index += Character.charCount(codePoint);
+        }
         mCursorPosition += typedWord.length();
     }
 

--- a/gradle/fdroid_yaml_output.gradle
+++ b/gradle/fdroid_yaml_output.gradle
@@ -22,7 +22,7 @@ def generateFdroidYamls = project.tasks.register('generateFdroidYamls') { task -
     commit: ${gitCommitProcess.text.trim()}
     gradle:
       - yes
-    output: ${rootProject.projectDir.relativePath(taskProject.buildDir)}/outputs/apk/release/app-release.apk
+    output: ${rootProject.projectDir.relativePath(taskProject.buildDir)}/outputs/apk/release/app-release-unsigned.apk
     gradleprops:
       - forceVersionBuildCount=${System.getenv('BUILD_COUNT_FOR_VERSION')}
 


### PR DESCRIPTION
These commits achieve four goals:

1. **Generate unsigned release APKs instead of debug APKs, with `./gradlew assembleRelease`.** Like you asked for at #303, the Gradle scripts for this projecy will now default to unsigned release APKs if no suitable keystore can be found. Debug APKs can still be created with `assembleDebug` and `build`. (I think `build` isn't working right now because of some problem with canary and test releases; I haven't looked into that.)

2. **Fix #1636 and all related bugs.** Basically, most string manipulation functions in Java depend in `char` values, which can each hold a single multi-byte character... until U+FFFF. Some characters have now assigned code-points over U+FFFF, and those can only fit in two `char`s.

Some select functions work with `int` values, which can fit values over 0xFFFF, and thus correspond to actual characters like we understand them. What I did here is to change every line which assumed "1 int = 1 char" and rigged the cursor keys to never split a character. **[This also allows keyboards to use codepoints over U+FFFF in `popupCharacters`.](https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/1636#issuecomment-466153250)**

I also fixed some very situational glitches (like deleting at prediction boundaries, and checking for the length of a word). This ~*should* fix bug #620 and~ *may* fix some occurrences of #1290, but not the ones that come from a race condition. (See below)

I needed to extend your WordComposer API to account for that. `length()` now returns the number of actual characters (codePoints), a new function `charLength` returns the number of char values, and `deleteLast` and `deleteForward` now return the number of `char` values deleted.

3. Fix some glitches when reporting to the logcat. **I may have overstepped my bounds here and changed some `TAGs` on commit 709ed5bb5854cd825eaf048be0ac784dedf7dff3**. Let me know if you'd like to undo these name changes or to use something else.

4. **Fix #971**, a cosmetic issue. The positioning of every key after a hidden key (with `ask:showInLayout="if_applicable"` was some pixels off.

What this PR won't fix
-----

- As described above, it's going to be difficult to fix #1290 if it's caused by race conditions.
- I misremembered bug #620, it's a distinct bug and still not fixed. (Multitap confuses the cursor position.) If this goes well, I'll try to fix it in the near future.
- Selection still acts a bit wonky: both left and right keys extend the selection range, none of them shrink it, and pressing up or down will abort it. Would you like a system like Shift+←↑→↓ on a PC, maybe with a button to swap regular cursor and selection cursor?