### PR TITLE
AnyKeyboard: Combining characters aren't EOW characters

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -340,7 +340,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     @Override
     protected boolean isAlphabet(int code) {
         if (super.isAlphabet(code)) return true;
-        // inner letters have more options: ' in English. " in Hebrew, and more.
+        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing combining characters.
         if (TextEntryState.isPredicting()) {
             return getCurrentAlphabetKeyboard().isInnerWordLetter((char) code);
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -340,7 +340,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     @Override
     protected boolean isAlphabet(int code) {
         if (super.isAlphabet(code)) return true;
-        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing combining characters.
+        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing
+        // combining characters.
         if (TextEntryState.isPredicting()) {
             return getCurrentAlphabetKeyboard().isInnerWordLetter((char) code);
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -558,7 +558,8 @@ public abstract class AnyKeyboard extends Keyboard {
 
     public boolean isInnerWordLetter(char keyValue) {
         return Character.isLetter(keyValue)
-                || (keyValue == BTreeDictionary.QUOTE || keyValue == BTreeDictionary.CURLY_QUOTE);
+                || (keyValue == BTreeDictionary.QUOTE || keyValue == BTreeDictionary.CURLY_QUOTE)
+                || (Character.getType(keyValue) == 6 || Character.getType(keyValue) == 8);
     }
 
     public abstract char[] getSentenceSeparators();


### PR DESCRIPTION
Fixes #1919 , thanks for pointing me in the right direction, @ArenaL5 !

Uses [getType](https://developer.android.com/reference/java/lang/Character.html#getType(int)): a return value of 6 is a [combining non-spacing character](https://developer.android.com/reference/java/lang/Character.html#NON_SPACING_MARK), a value of 8 is a [combining spacing character](https://developer.android.com/reference/java/lang/Character.html#COMBINING_SPACING_MARK). 