### PR TITLE
AnyKeyboard: Combining characters aren't EOW characters

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -340,7 +340,7 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     @Override
     protected boolean isAlphabet(int code) {
         if (super.isAlphabet(code)) return true;
-        // inner letters have more options: ' in English. " in Hebrew, and more.
+        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing combining characters.
         if (TextEntryState.isPredicting()) {
             return getCurrentAlphabetKeyboard().isInnerWordLetter((char) code);
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -340,7 +340,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     @Override
     protected boolean isAlphabet(int code) {
         if (super.isAlphabet(code)) return true;
-        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing combining characters.
+        // inner letters have more options: ' in English. " in Hebrew, and spacing and non-spacing
+        // combining characters.
         if (TextEntryState.isPredicting()) {
             return getCurrentAlphabetKeyboard().isInnerWordLetter((char) code);
         } else {

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -558,8 +558,10 @@ public abstract class AnyKeyboard extends Keyboard {
 
     public boolean isInnerWordLetter(char keyValue) {
         return Character.isLetter(keyValue)
-                || (keyValue == BTreeDictionary.QUOTE || keyValue == BTreeDictionary.CURLY_QUOTE)
-                || (Character.getType(keyValue) == 6 || Character.getType(keyValue) == 8);
+                || keyValue == BTreeDictionary.QUOTE
+                || keyValue == BTreeDictionary.CURLY_QUOTE
+                || Character.getType(keyValue) == Character.NON_SPACING_MARK
+                || Character.getType(keyValue) == Character.COMBINING_SPACING_MARK;
     }
 
     public abstract char[] getSentenceSeparators();

--- a/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
+++ b/app/src/main/java/com/anysoftkeyboard/keyboards/AnyKeyboard.java
@@ -558,7 +558,8 @@ public abstract class AnyKeyboard extends Keyboard {
 
     public boolean isInnerWordLetter(char keyValue) {
         return Character.isLetter(keyValue)
-                || (keyValue == BTreeDictionary.QUOTE || keyValue == BTreeDictionary.CURLY_QUOTE);
+                || (keyValue == BTreeDictionary.QUOTE || keyValue == BTreeDictionary.CURLY_QUOTE)
+                || (Character.getType(keyValue) == 6 || Character.getType(keyValue) == 8);
     }
 
     public abstract char[] getSentenceSeparators();

--- a/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardTest.java
+++ b/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardTest.java
@@ -8,6 +8,7 @@ import com.anysoftkeyboard.AnySoftKeyboardRobolectricTestRunner;
 import com.anysoftkeyboard.addons.AddOn;
 import com.anysoftkeyboard.addons.DefaultAddOn;
 import com.anysoftkeyboard.api.KeyCodes;
+import com.anysoftkeyboard.dictionaries.Dictionary;
 import com.anysoftkeyboard.keyboards.views.KeyDrawableStateProvider;
 import com.menny.android.anysoftkeyboard.AnyApplication;
 import com.menny.android.anysoftkeyboard.R;
@@ -231,5 +232,53 @@ public class ExternalAnyKeyboardTest {
         Assert.assertEquals("ĥ", key99.popupCharacters.toString());
         Assert.assertEquals(R.xml.popup_one_row, key99.popupResId);
         Assert.assertFalse(key99.isFunctional());
+    }
+
+    @Test
+    public void testInnerCharacters() {
+        ExternalAnyKeyboard keyboard =
+                new ExternalAnyKeyboard(
+                        mDefaultAddOn,
+                        mContext,
+                        R.xml.keyboard_with_codes_as_letters,
+                        R.xml.keyboard_with_codes_as_letters,
+                        "test",
+                        R.drawable.sym_keyboard_notification_icon,
+                        0,
+                        "en",
+                        "*&",
+                        "",
+                        Keyboard.KEYBOARD_ROW_MODE_NORMAL);
+        keyboard.loadKeyboard(SIMPLE_KeyboardDimens);
+
+        // sanity: known characters
+        Assert.assertTrue(keyboard.isInnerWordLetter('a'));
+        Assert.assertTrue(keyboard.isInnerWordLetter('b'));
+        // known, generic, inner letters
+        Assert.assertTrue(keyboard.isInnerWordLetter('\''));
+        Assert.assertTrue(keyboard.isInnerWordLetter(Dictionary.CURLY_QUOTE));
+        // additional
+        Assert.assertTrue(keyboard.isInnerWordLetter('*'));
+        Assert.assertTrue(keyboard.isInnerWordLetter('&'));
+
+        // COMBINING_SPACING_MARK
+        Assert.assertTrue(keyboard.isInnerWordLetter('ಂ'));
+        // NON_SPACING_MARK
+        Assert.assertTrue(keyboard.isInnerWordLetter('\u032A'));
+
+        // whitespaces are not
+        Assert.assertFalse(keyboard.isInnerWordLetter(' '));
+        Assert.assertFalse(keyboard.isInnerWordLetter('\n'));
+        Assert.assertFalse(keyboard.isInnerWordLetter('\t'));
+        // digits are not
+        Assert.assertFalse(keyboard.isInnerWordLetter('0'));
+        Assert.assertFalse(keyboard.isInnerWordLetter('1'));
+        // punctuation are not
+        Assert.assertFalse(keyboard.isInnerWordLetter('?'));
+        Assert.assertFalse(keyboard.isInnerWordLetter('!'));
+        Assert.assertFalse(keyboard.isInnerWordLetter('.'));
+        Assert.assertFalse(keyboard.isInnerWordLetter(','));
+        Assert.assertFalse(keyboard.isInnerWordLetter(':'));
+        Assert.assertFalse(keyboard.isInnerWordLetter('-'));
     }
 }

--- a/scripts/ci/ci_check.sh
+++ b/scripts/ci/ci_check.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-./gradlew verifyGoogleJavaFormat
+./gradlew verifyGoogleJavaFormat || {
+    echo "code is not formatted."
+    echo "run './gradlew googleJavaFormat' to fix."
+    exit 1
+}
 ./gradlew --stacktrace lintDebug checkstyleMain pmdMain pmdTest
 ./gradlew --stacktrace verifyReleaseResources
 ./gradlew --stacktrace generateReleasePlayResources


### PR DESCRIPTION
Fixes #1919

Uses [getType](https://developer.android.com/reference/java/lang/Character.html#getType(int)): a return value of 6 is a [combining non-spacing character](https://developer.android.com/reference/java/lang/Character.html#NON_SPACING_MARK), a value of 8 is a [combining spacing character](https://developer.android.com/reference/java/lang/Character.html#COMBINING_SPACING_MARK). 

I've moved the pull request, but I'm afraid I don't know much about tests/java in general, would I be able to get any help on that?