### PR TITLE
Add German QWERTY keyboards

### DIFF
--- a/addons/languages/german/pack/src/main/res/values-de/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values-de/german_pack_strings_dont_translate.xml
@@ -8,4 +8,8 @@
     <string name="de_keyboard">Deutsch</string>
     <string name="de_keyboard_broad">Deutsch breit</string>
     <string name="de_keyboard_extra">Deutsch breit+</string>
+    <string name="de_keyboard_qwerty">Deutsch QWERTY</string>
+    <string name="de_keyboard_qwerty_broad">Deutsch QWERTY breit</string>
+    <string name="de_keyboard_qwerty_extra">Deutsch QWERTY breit+</string>
+    <string name="de_keyboard_qwerty_slim">Deutsch QWERTY slim</string>
 </resources>

--- a/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -11,6 +11,14 @@
     <string name="de_keyboard_broad_description">Slightly broader layout with umlauts as popups (saving keys)</string>
     <string name="de_keyboard_extra">German broad+</string>
     <string name="de_keyboard_extra_description">Slightly broader layout with umlauts as popups (saving keys), also additional characters</string>
+    <string name="de_keyboard_qwerty">German QWERTY</string>
+    <string name="de_keyboard_qwerty_description">Created by Thomas Eizinger</string>
+    <string name="de_keyboard_qwerty_broad">German QWERTY broad</string>
+    <string name="de_keyboard_qwerty_broad_description">Slightly broader QWERTY layout with umlauts as popups (saving keys)</string>
+    <string name="de_keyboard_qwerty_extra">German QWERTY broad+</string>
+    <string name="de_keyboard_qwerty_extra_description">Slightly broader QWERTY layout with umlauts as popups (saving keys), also additional characters</string>
+    <string name="de_keyboard_qwerty_slim">German QWERTY slim</string>
+    <string name="de_keyboard_qwerty_slim_description">Slim QWERTY layout with umlauts as popups (saving keys)</string>
     <string name="de_keyboard_neo2">German neo2</string>
     <string name="de_keyboard_neo2_simple">German neo2 simple</string>
 </resources>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="9.09%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w"  android:popupCharacters=""/>
+        <Key android:codes="101" android:keyLabel="e"  android:popupCharacters="€"/>
+        <Key android:codes="114" android:keyLabel="r"  android:popupCharacters=""/>
+        <Key android:codes="116" android:keyLabel="t"  android:popupCharacters=""/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters=""/>
+        <Key android:codes="117" android:keyLabel="u"  android:popupCharacters=""/>
+        <Key android:codes="105" android:keyLabel="i"  android:popupCharacters=""/>
+        <Key android:codes="111" android:keyLabel="o"  android:popupCharacters=""/>
+        <Key android:codes="112" android:keyLabel="p"  android:popupCharacters=""/>
+        <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="9.09%p">
+        <Key android:codes="97" android:keyLabel="a"  android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters=""/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters=""/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters=""/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters=""/>
+        <Key android:codes="246" android:keyLabel="ö" android:popupCharacters=""/>
+        <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row>
+        <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="122" android:keyLabel="z"  android:popupCharacters=""/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters=""/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
+        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters=""/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters=""/>
+        <Key android:codes="223" android:keyLabel="ß" android:popupCharacters="" ask:shiftedCodes="7838" ask:shiftedKeyLabel="ẞ"/>
+        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_broad.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_broad.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="10%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\@" android:keyEdgeFlags="left" />
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters=""/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="€"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters=""/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters=""/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters=""/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters=""/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö"/>
+        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="11.111%p">
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="ä" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters=""/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters=""/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="10.625%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters=""/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters=""/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
+        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters=""/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters=""/>
+        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_extra.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_extra.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="10%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\@1" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="2"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="€3èéêëęē"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="5"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="6żžź"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü7ùúûũūŭű"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö9òóôõōøœő"/>
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" android:popupCharacters="0"/>
+    </Row>
+    
+    <Row android:keyWidth="11.111%p">
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞśŝš"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥ"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="ĵ"/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="10.625%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="ýÿ"/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters="çćĉč"/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
+        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñ"/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
+        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="10%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\@1" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="2"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="€3èéêëęē"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="5"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="6żžź"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü7ùúûũūŭű"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö9òóôõōøœő"/>
+        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right" android:popupCharacters="0"/>
+    </Row>
+    
+    <Row>
+        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞśŝš"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥ"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="ĵ"/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row>
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="ýÿ"/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters="çćĉč"/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
+        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñ"/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
+        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -15,14 +15,34 @@
               defaultDictionaryLocale="de" description="@string/de_keyboard_extra_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard nameResId="@string/de_keyboard_qwerty" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_qwerty" id="797fbddf-346b-4216-b67c-80834638d7ce"
+              defaultDictionaryLocale="de" description="@string/de_keyboard_qwerty_description"
+              index="4" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard nameResId="@string/de_keyboard_qwerty_broad" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_qwerty_broad" id="9f5e0409-849b-423c-8d5f-46acbfe4e934"
+              defaultDictionaryLocale="de" description="@string/de_keyboard_qwerty_broad_description"
+              index="5" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard nameResId="@string/de_keyboard_qwerty_extra" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_qwerty_extra" id="6755ccc0-1015-4364-bd87-2b755bf9ab4b"
+              defaultDictionaryLocale="de" description="@string/de_keyboard_qwerty_extra_description"
+              index="6" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard nameResId="@string/de_keyboard_qwerty_slim" iconResId="@drawable/ic_status_german"
+              layoutResId="@xml/de_qwerty_slim" id="33421de8-0d71-456c-90f1-3935fcb4e30f"
+              defaultDictionaryLocale="de" description="@string/de_keyboard_qwerty_slim_description"
+              index="7" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/german_physical" />
     <Keyboard nameResId="@string/de_keyboard_neo2" iconResId="@drawable/ic_status_german"
               layoutResId="@xml/de_neo2" id="ad1b5ffa-15cc-4ba4-abb7-68df2c0874e7"
               defaultDictionaryLocale="de"
-              index="4" defaultEnabled="false"
+              index="8" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/german_neo2_physical" />
     <Keyboard nameResId="@string/de_keyboard_neo2_simple" iconResId="@drawable/ic_status_german"
               layoutResId="@xml/de_neo2_simple" id="37606729-66c1-4e04-9968-b32314c7094a"
               defaultDictionaryLocale="de"
-              index="5" defaultEnabled="false"
+              index="9" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/german_neo2_physical" />
 </Keyboards>


### PR DESCRIPTION
This patch adds 3 keyboards to the German language addon, each of them offering a QWERTY variant of the existing layouts.

I am not an android developer, so I haven't been able to test this locally. I tried to install the output of the `build` task on my phone but it failed without a helpful error message.

Any pointers on where I can get a build from that I can install on my phone?
Is the CI going to produce artifacts that I can install?