### PR TITLE
doc typo: Include :addons: in gradlew path.

### DIFF
--- a/addons/CONTRIBUTING.md
+++ b/addons/CONTRIBUTING.md
@@ -20,7 +20,7 @@ include ":addons:languages:klingon:pack", ":addons:languages:klingon:apk"
     * Try to locate AOSP dictionary files (could be found at [AOSP](https://android.googlesource.com/platform/packages/inputmethods/LatinIME/+/master/dictionaries/), or [LineageOS](https://github.com/LineageOS/android_packages_inputmethods_LatinIME/tree/lineage-16.0/dictionaries)) (you should use the `XX_wordlist.combined.gz` file).
     * If you have anything that was pre-built into a word-list XML, put those under `klingon/pack/dictionary/prebuilt`.
     * Add text files that will be parsed - word-counted -  to generate word-list XMLs
-1. Generate the dictionary: `./gradlew :languages:klingon:pack:makeDictionary`. This will create the following files (which _should not_ checked into the repo):
+1. Generate the dictionary: `./gradlew :addons:languages:klingon:pack:makeDictionary`. This will create the following files (which _should not_ checked into the repo):
     * raw resources under `klingon/pack/src/main/res/raw/klingon_words_?.dict`
     * IDs resource array under `klingon/pack/src/main/res/values/klingon_words_dict_array.xml`
 1. Edit `klingon_dictionaries.xml`:
@@ -31,7 +31,7 @@ include ":addons:languages:klingon:pack", ":addons:languages:klingon:apk"
 1. Set the status-bar icon text at `klingon/pack/build.gradle`: `ext.status_icon_text = "kl"`
 1. Replace the flag at `klingon/apk/flag` with a, high-quality, png or svg, image of the flag. It should be named `flag.png` or `flag.svg`. _Note_ that sometimes svg files are not converted correctly, but they will produce highest quality if successful.
 1. To generate the icons, you'll need ImageMagick installed on your path. Check out the installation [page](https://imagemagick.org/script/download.php) for details.
-1. Generate the icons: `./gradlew :languages:klingon:pack:generateLanguagePackIcons :languages:klingon:apk:generateStoreLogoIcon`. This will generate the following files (which _should_ be checked into the repo):
+1. Generate the icons: `./gradlew :addons:languages:klingon:pack:generateLanguagePackIcons :addons:languages:klingon:apk:generateStoreLogoIcon`. This will generate the following files (which _should_ be checked into the repo):
     * `klingon/pack/src/main/res/drawable-*/ic_status_klingon.png`
     * `klingon/apk/src/main/res/mipmap-*/ic_launcher.png`
     * `klingon/apk/src/main/play/listings/en-US/graphics/feature-graphic/pack_store_feature_graphics.png`

--- a/addons/CONTRIBUTING.md
+++ b/addons/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Let's say you want to create a language-pack for Klingon. We'll call the pack `k
 ```
 include ":addons:languages:klingon:pack", ":addons:languages:klingon:apk"
 ```
-1. At this point, you'll need to sync you Android Studio project.
+1. At this point, you'll need to sync your Android Studio project.
 1. Rename the package names (`com.anysoftkeyboard.english.*` -> `com.anysoftkeyboard.klingon.*`:
     * Change `package` value in `AndroidManifest.xml` files (one in `pack` and the second in `apk`).
     * Move the `PackBroadcastReceiver` package to the right place.


### PR DESCRIPTION
These example commands weren't updated when the language
repository was merged back into the main keyboard repo.