### PR TITLE
Add a variant of the "Simple" bottom row with an Emoji key

### DIFF
--- a/ime/app/src/main/res/values-de/strings.xml
+++ b/ime/app/src/main/res/values-de/strings.xml
@@ -392,6 +392,7 @@
     <string name="extension_kbd_bottom_alt_with_mic">Alternativ mit Mikrofon</string>
     <string name="extension_kbd_bottom_old">Old School</string>
     <string name="extension_kbd_bottom_simple">Einfach</string>
+    <string name="extension_kbd_bottom_simple_with_emoji">Einfach mit Emojis</string>
     <string name="extension_kbd_bottom_ng">Neue Generation - wird getestet</string>
     <string name="extension_kbd_extension_numbers_symbols">Zahlen und Symbole</string>
     <!-- Tutorials -->

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -557,6 +557,7 @@
     <string name="extension_kbd_bottom_alt_with_mic">Alternate with mic</string>
     <string name="extension_kbd_bottom_old">Old School</string>
     <string name="extension_kbd_bottom_simple">Simple</string>
+    <string name="extension_kbd_bottom_simple_with_emoji">Simple with Emojis</string>
 
     <string name="extension_kbd_bottom_ng">New Generation - Testing</string>
     <string name="extension_kbd_extension_numbers_symbols">Numbers and symbols</string>

--- a/ime/app/src/main/res/xml/ext_kbd_bottom_row_simple_with_emoji.xml
+++ b/ime/app/src/main/res/xml/ext_kbd_bottom_row_simple_with_emoji.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:ask="http://schemas.android.com/apk/res-auto">
+
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_normal" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_keyboard_mode_change" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_mode_alphabet" ask:showInLayout="if_applicable"
+             ask:longPressCode="@integer/key_code_cancel"
+             ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup"/>
+        <Key ask:isFunctional="true" android:codes="44" android:popupCharacters=";:_-'\u0022" ask:hintLabel="; : -"/>
+        <Key android:keyWidth="35%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="." android:popupCharacters="\?!\u00bf\u00a1&#11822;&#8253;" ask:hintLabel="\? !"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_im" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_keyboard_mode_change" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_mode_alphabet" ask:showInLayout="if_applicable"
+             ask:longPressCode="@integer/key_code_cancel"
+             ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup"/>
+        <Key ask:isFunctional="true" android:codes="44" android:popupCharacters=";:_-'\u0022" ask:hintLabel="; : -"/>
+        <Key android:keyWidth="35%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="." android:popupCharacters="\?!\u00bf\u00a1&#11822;&#8253;" ask:hintLabel="\? !"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_url" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_keyboard_mode_change" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_mode_alphabet" ask:showInLayout="if_applicable"
+             ask:longPressCode="@integer/key_code_cancel"
+             ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes=":" android:popupCharacters="\u002C;-" ask:hintLabel=", ; -"/>
+        <Key ask:isFunctional="true" android:codes="/" android:popupCharacters="~_+\u003D$%\u0026\@"
+             ask:hintLabel="~ _ +"/>
+        <Key android:keyWidth="25%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_domain" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="." android:popupCharacters="\?!\u00bf\u00a1&#11822;&#8253;" ask:hintLabel="\? !"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_email" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_keyboard_mode_change" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_mode_alphabet" ask:showInLayout="if_applicable"
+             ask:longPressCode="@integer/key_code_cancel"
+             ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="44" android:popupCharacters=";:_-'\u0022" ask:hintLabel="; : -"/>
+        <Key ask:isFunctional="true" android:codes="\@" android:popupCharacters="~_+\u003D$%\u0026"
+             ask:hintLabel="~ _ +"/>
+        <Key android:keyWidth="25%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_domain" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="." android:popupCharacters="\?!\u00bf\u00a1&#11822;&#8253;" ask:hintLabel="\? !"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_password" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_keyboard_mode_change" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_mode_alphabet" ask:showInLayout="if_applicable"
+            ask:longPressCode="@integer/key_code_cancel"
+            ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup"/>
+        <Key ask:isFunctional="true" android:codes="44" android:popupCharacters=";:_-'\u0022" ask:hintLabel="; : -"/>
+        <Key android:keyWidth="35%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="." android:popupCharacters="\?!\u00bf\u00a1&#11822;&#8253;" ask:hintLabel="\? !"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+            ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/extension_keyboards.xml
+++ b/ime/app/src/main/res/xml/extension_keyboards.xml
@@ -139,6 +139,14 @@
         description=""
         index="9"
         />
+    <ExtensionKeyboard
+        id="6f04bd17-b89d-4ba1-8b38-584a9e1f0f10"
+        nameResId="@string/extension_kbd_bottom_simple_with_emoji"
+        extensionKeyboardResId="@xml/ext_kbd_bottom_row_simple_with_emoji"
+        extensionKeyboardType="@integer/extension_keyboard_type_bottom_row"
+        description=""
+        index="10"
+        />
 
     <!-- top extension keyboards -->
     <ExtensionKeyboard

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
@@ -74,7 +74,7 @@ public class KeyboardExtensionFactoryTest {
     public void testGetAllAvailableExtensions() throws Exception {
         assertBasicListDetails(
                 AnyApplication.getBottomRowFactory(getApplicationContext()).getAllAddOns(),
-                9,
+                10,
                 KeyboardExtension.TYPE_BOTTOM);
         assertBasicListDetails(
                 AnyApplication.getTopRowFactory(getApplicationContext()).getAllAddOns(),


### PR DESCRIPTION
All other bottom rows with emoji keys have a very short space bar.
This variant is an extension of the "simple" one, with just the emoji key added.

Screenshots:

|Normal|Messaging|URL|Password|
|---|---|---|---|
|![Screenshot_S _Notes_20200218-093631~2](https://user-images.githubusercontent.com/5486389/75130900-a6607580-5724-11ea-9657-a057382fcb10.png)|![Screenshot_Signal_20200218-093708~2](https://user-images.githubusercontent.com/5486389/75130905-ab252980-5724-11ea-92d5-ebaf4ee0f7d6.png)|![Screenshot_Firefox_Preview_20200218-093646~2](https://user-images.githubusercontent.com/5486389/75130907-b24c3780-5724-11ea-8541-23e3834508f2.png)|![Screenshot_N26_20200218-093822~2](https://user-images.githubusercontent.com/5486389/75130912-b7a98200-5724-11ea-9c01-af85ac02fcec.png)|



