### PR TITLE
Add middle dot and hyphen-minus as letter exceptions in Catalan

### DIFF
--- a/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
+++ b/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
@@ -3,4 +3,5 @@
     <string name="catalan_dictionary_description">Diccionari de català</string>
     <string name="catalan_keyboard">Català</string>
     <string name="catalan_keyboard_description">Teclat QWERTY</string>
+    <string name="catalan_additional_is_letter_exceptions">&middot;&#45;</string>
 </resources>

--- a/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
+++ b/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
@@ -3,5 +3,5 @@
     <string name="catalan_dictionary_description">Diccionari de català</string>
     <string name="catalan_keyboard">Català</string>
     <string name="catalan_keyboard_description">Teclat QWERTY</string>
-    <string name="catalan_additional_is_letter_exceptions">&middot;&#45;</string>
+    <string name="catalan_additional_is_letter_exceptions">&#183;&#45;</string>
 </resources>

--- a/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
+++ b/addons/languages/catalan/pack/src/main/res/values/catalan_pack_strings.xml
@@ -3,5 +3,4 @@
     <string name="catalan_dictionary_description">Diccionari de català</string>
     <string name="catalan_keyboard">Català</string>
     <string name="catalan_keyboard_description">Teclat QWERTY</string>
-    <string name="catalan_additional_is_letter_exceptions">&#183;&#45;</string>
 </resources>

--- a/addons/languages/catalan/pack/src/main/res/xml/catalan_keyboards.xml
+++ b/addons/languages/catalan/pack/src/main/res/xml/catalan_keyboards.xml
@@ -10,6 +10,6 @@
         layoutResId="@xml/qwerty"
         nameResId="@string/catalan_keyboard"
         physicalKeyboardMappingResId="@xml/english_physical"
-        additionalIsLetterExceptions="@string/catalan_additional_is_letter_exceptions" />
+        additionalIsLetterExceptions="·-" />
 
 </Keyboards>

--- a/addons/languages/catalan/pack/src/main/res/xml/catalan_keyboards.xml
+++ b/addons/languages/catalan/pack/src/main/res/xml/catalan_keyboards.xml
@@ -9,6 +9,7 @@
         index="1"
         layoutResId="@xml/qwerty"
         nameResId="@string/catalan_keyboard"
-        physicalKeyboardMappingResId="@xml/english_physical" />
+        physicalKeyboardMappingResId="@xml/english_physical"
+        additionalIsLetterExceptions="@string/catalan_additional_is_letter_exceptions" />
 
 </Keyboards>

--- a/addons/languages/catalan/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/catalan/pack/src/main/res/xml/qwerty.xml
@@ -29,7 +29,7 @@
         <Key android:codes="105" android:popupCharacters="íï8"/>
         <Key android:codes="111" android:popupCharacters="òó9ö"/>
         <Key android:codes="112" android:popupCharacters="0"/>
-        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="·" android:keyEdgeFlags="right"/>
+        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="'" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>

--- a/addons/languages/catalan/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/catalan/pack/src/main/res/xml/qwerty.xml
@@ -29,7 +29,7 @@
         <Key android:codes="105" android:popupCharacters="íï8"/>
         <Key android:codes="111" android:popupCharacters="òó9ö"/>
         <Key android:codes="112" android:popupCharacters="0"/>
-        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="" android:keyEdgeFlags="right"/>
+        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="·" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>


### PR DESCRIPTION
Catalan has many words using the middle dot (interpunct) between two L in order to represent the [ɫː] phoneme but when typing a middle dot in ASK it will stop suggesting those words as it does not consider it an inner word character. The same goes with the hyphen, used especially when inflecting verbs.

This PR adds both the middle dot and the hyphen to the IsLetter exceptions and the middle dot as a popup character of the hyphen.
