### PR TITLE
Fix cursor lagging (#1875)

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -621,14 +621,13 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                     cursorPosition = -1;
                 }
 
-                /* mGlobalCursorPosition is updated when onUpdateSelection is called,
-                 * but that doesn't happen if several keys are pressed simultaneously */
-                mGlobalCursorPosition = cursorPosition;
-
                 ic.setComposingText(mWord.getTypedWord(), 1);
                 if (cursorPosition > 0) {
                     ic.setSelection(cursorPosition, cursorPosition);
                     ic.endBatchEdit();
+                    /* mGlobalCursorPosition is updated when onUpdateSelection is called,
+                     * but that doesn't happen if several keys are pressed simultaneously */
+                    mGlobalCursorPosition = cursorPosition;
                 }
             }
             // this should be done ONLY if the key is a letter, and not a inner

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -621,6 +621,10 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                     cursorPosition = -1;
                 }
 
+                /* mGlobalCursorPosition is updated when onUpdateSelection is called,
+                 * but that doesn't happen if several keys are pressed simultaneously */
+                mGlobalCursorPosition = cursorPosition;
+
                 ic.setComposingText(mWord.getTypedWord(), 1);
                 if (cursorPosition > 0) {
                     ic.setSelection(cursorPosition, cursorPosition);

--- a/scripts/adb.sh
+++ b/scripts/adb.sh
@@ -38,7 +38,7 @@ else
             exit 1
         fi
     done
-    tags=`grep -R 'TAG = ".*"' app/src/main/java/com/* jnidictionaryv1/src/main/java/com/* jnidictionaryv2/src/main/java/com/*`
+    tags=`grep -R 'TAG = ".*"' ime/app/src/main/java/com/* ime/jnidictionaryv1/src/main/java/com/* ime/jnidictionaryv2/src/main/java/com/*`
     # We can go back to our original folder now:
     cd "$oldpath"
     tags="$(echo $tags | sed -E 's![a-z/A-Z12]*\.java: (protected |private )?(static )?(final )?String [A-Z_]* = "([^\"]*)";!\4!g')"


### PR DESCRIPTION
The main commit in this pull request is b18bd87fa58467791ac07029fd6d9cb47d028bd7. It updates the global cursor position after every character is handled, which has normally no effect (as it's overwritten when `onUpdateSelection` is called), but takes into account the effects of every key when several keys are pressed, not just the last one.

This should fix bug #1875.

The last commit is the one I'm the most unsure about: that test is completely unrelated to my fix, but it keeps failing in my local master branch.