### PR TITLE
Add: AOSP/Gboard bottom common kbd

### DIFF
--- a/api/src/main/res/values/keyboard_theme_api.xml
+++ b/api/src/main/res/values/keyboard_theme_api.xml
@@ -257,6 +257,8 @@
         <!-- should support normal, key_type_feedback -->
         <attr name="iconKeyClipboardFineSelect" format="reference"/>
         <!-- should support normal, key_type_feedback -->
+        <attr name="iconKeyQuickTextPopup" format="reference"/>
+        <!-- should support normal, key_type_feedback -->
         <attr name="iconKeyQuickText" format="reference"/>
         <!-- should support normal, key_type_feedback -->
         <attr name="iconKeyUndo" format="reference"/>

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
@@ -920,6 +920,9 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
             case R.attr.iconKeyClipboardFineSelect:
                 keyCode = KeyCodes.CLIPBOARD_SELECT;
                 break;
+            case R.attr.iconKeyQuickTextPopup:
+                keyCode = KeyCodes.QUICK_TEXT_POPUP;
+                break;
             case R.attr.iconKeyQuickText:
                 keyCode = KeyCodes.QUICK_TEXT;
                 break;

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -535,6 +535,7 @@
     <string name="extension_kbd_bottom_alt_with_mic">Alternate with mic</string>
     <string name="extension_kbd_bottom_old">Old School</string>
     <string name="extension_kbd_bottom_simple">Simple</string>
+    <string name="extension_kbd_bottom_row_aosp">AOSP styled</string>
 
     <string name="extension_kbd_bottom_ng">New Generation - Testing</string>
     <string name="extension_kbd_extension_numbers_symbols">Numbers and symbols</string>

--- a/ime/app/src/main/res/values/styles_base_keyboard_theme.xml
+++ b/ime/app/src/main/res/values/styles_base_keyboard_theme.xml
@@ -51,6 +51,7 @@
         <item name="iconKeyClipboardSelect">@drawable/ic_clipboard_select</item>
         <item name="iconKeyClipboardFineSelect">@drawable/ic_clipboard_fine_select</item>
         <item name="iconKeyQuickText">@drawable/ic_quick_text_dark_theme</item>
+        <item name="iconKeyQuickTextPopup">@drawable/ic_quick_text_dark_theme</item>
 
         <item name="iconKeyUndo">@drawable/ic_undo_dark_theme</item>
         <item name="iconKeyRedo">@drawable/ic_redo_dark_theme</item>

--- a/ime/app/src/main/res/values/styles_lean_light_keyboard_theme.xml
+++ b/ime/app/src/main/res/values/styles_lean_light_keyboard_theme.xml
@@ -71,6 +71,7 @@
         <item name="iconKeyClipboardSelect">@drawable/ic_clipboard_select_light</item>
         <item name="iconKeyClipboardFineSelect">@drawable/ic_clipboard_fine_select_light</item>
         <item name="iconKeyQuickText">@drawable/ic_quick_text_light_theme</item>
+        <item name="iconKeyQuickTextPopup">@drawable/ic_quick_text_light_theme</item>
         <item name="iconKeyImageInsert">@drawable/ic_media_insertion_light</item>
 
         <item name="iconKeyUndo">@drawable/ic_undo_light_theme</item>

--- a/ime/app/src/main/res/values/styles_yochees_keyboard_theme.xml
+++ b/ime/app/src/main/res/values/styles_yochees_keyboard_theme.xml
@@ -50,6 +50,7 @@
         <item name="iconKeyClipboardSelect">@drawable/yochees_dark_select_all</item>
         <item name="iconKeyClipboardFineSelect">@drawable/ic_clipboard_fine_select</item>
         <item name="iconKeyQuickText">@drawable/yochees_dark_smiley</item>
+        <item name="iconKeyQuickTextPopup">@drawable/yochees_dark_smiley</item>
 
         <item name="iconKeyArrowRight">@drawable/yochees_dark_arrow_right</item>
         <item name="iconKeyArrowLeft">@drawable/yochees_dark_arrow_left</item>

--- a/ime/app/src/main/res/xml/ext_kbd_bottom_row_aosp.xml
+++ b/ime/app/src/main/res/xml/ext_kbd_bottom_row_aosp.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:ask="http://schemas.android.com/apk/res-auto">
+    <!-- Generic bottom row -->
+    <Row android:keyboardMode="@integer/keyboard_mode_normal" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_keyboard_mode_change" 
+		     ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"
+		     android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="44" ask:shiftedCodes="46"
+		     android:popupCharacters="._`*\u005C\u003C\u003E\u00b7\u2026\u2014"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text_popup" 
+             ask:longPressCode="@integer/key_code_quick_text"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="40%p"/>
+
+		<Key ask:isFunctional="true" android:codes="46" ask:shiftedCodes="44"
+             android:popupCharacters="\u003F\!,#)(/;@':-\u0022\+%\u0026"/>
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_enter"
+             android:keyEdgeFlags="right" ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_im" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_keyboard_mode_change" 
+		     ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"
+		     android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="44" ask:shiftedCodes="46"
+		     android:popupCharacters="._`*\u005C\u003C\u003E\u00b7\u2026\u2014"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text_popup"
+             ask:longPressCode="@integer/key_code_quick_text"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="40%p"/>
+
+		<Key ask:isFunctional="true" android:codes="46" ask:shiftedCodes="44"
+             android:popupCharacters="\u003F\!,#)(/;@':-\u0022\+%\u0026"/>
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_enter"
+             android:keyEdgeFlags="right" ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_url" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_keyboard_mode_change" 
+		     ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"
+		     android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="47" ask:shiftedCodes=":"
+		     android:popupCharacters=":,-_"/>
+
+		<Key ask:isFunctional="true" android:codes="@integer/key_code_domain"/> 
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="40%p"/>
+
+        <Key ask:isFunctional="true" android:codes="." android:keyLabel="."
+             ask:longPressCode="@integer/key_code_quick_text_popup"/>
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_enter"
+             android:keyEdgeFlags="right" ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_email" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_keyboard_mode_change" 
+		     ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"
+		     android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="64" android:keyLabel="\@" ask:shiftedCodes="44"
+		     android:popupCharacters=".-_+"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_domain"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="40%p"/>
+
+		<Key ask:isFunctional="true" android:codes="46" ask:shiftedCodes="64"
+             android:popupCharacters=",-_+"/>
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_enter"
+             android:keyEdgeFlags="right" ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_password" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_keyboard_mode_change" 
+		     ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"
+		     android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="44" ask:shiftedCodes="46"
+		     android:popupCharacters="._`*\u005C\u003C\u003E\u00b7\u2026\u2014"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text_popup" android:keyLabel=":)"
+             ask:longPressCode="@integer/key_code_quick_text"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="40%p"/>
+
+		<Key ask:isFunctional="true" android:codes="46" ask:shiftedCodes="44"
+             android:popupCharacters="\u003F\!,#)(/;@':-\u0022\+%\u0026"/>
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_enter"
+             android:keyEdgeFlags="right" ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/extension_keyboards.xml
+++ b/ime/app/src/main/res/xml/extension_keyboards.xml
@@ -65,6 +65,14 @@
         description=""
         index="8"
         />
+    <ExtensionKeyboard
+        id="16bbcd88-5532-4fd6-92ff-db57977dd815"
+        nameResId="@string/extension_kbd_top_text_editing"
+        extensionKeyboardResId="@xml/ext_kbd_top_row_text_editing"
+        extensionKeyboardType="@integer/extension_keyboard_type_top_row"
+        description=""
+        index="9"
+        />
 
     <!-- bottom rows -->
     <ExtensionKeyboard
@@ -140,12 +148,12 @@
         index="9"
         />
     <ExtensionKeyboard
-        id="16bbcd88-5532-4fd6-92ff-db57977dd815"
-        nameResId="@string/extension_kbd_top_text_editing"
-        extensionKeyboardResId="@xml/ext_kbd_top_row_text_editing"
-        extensionKeyboardType="@integer/extension_keyboard_type_top_row"
+        id="4bd88cea-f31e-4500-b20d-f51757350d8d"
+        nameResId="@string/extension_kbd_bottom_row_aosp"
+        extensionKeyboardResId="@xml/ext_kbd_bottom_row_aosp"
+        extensionKeyboardType="@integer/extension_keyboard_type_bottom_row"
         description=""
-        index="9"
+        index="10"
         />
 
     <!-- top extension keyboards -->

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
@@ -74,7 +74,7 @@ public class KeyboardExtensionFactoryTest {
     public void testGetAllAvailableExtensions() throws Exception {
         assertBasicListDetails(
                 AnyApplication.getBottomRowFactory(getApplicationContext()).getAllAddOns(),
-                9,
+                10,
                 KeyboardExtension.TYPE_BOTTOM);
         assertBasicListDetails(
                 AnyApplication.getTopRowFactory(getApplicationContext()).getAllAddOns(),


### PR DESCRIPTION
Adding the bottom row for AOSP/Gboard.

The emoticon icon works same as Gboard (single tap shows the emoticons list), for this reason I had to add an icon for `key_code_quick_text_popup`

I have tested Normal/URL/IM/Email modes and it works almost exactly like Gboard.

I will also post an issue to see if you can help with a couple of things that could be improved.

This related to https://github.com/AnySoftKeyboard/LanguagePack/issues/260 (now archived)