### PR TITLE
Spanish locale

### DIFF
--- a/ime/app/src/main/res/values-es/currency_data.xml
+++ b/ime/app/src/main/res/values-es/currency_data.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="default_currency_sign_unicode">8364</integer>
+    <string name="default_currency_sign">&#8364;</string>
+    <string name="popup_currency_signs">$₽¥¢&#8377;£&#162;₢€₿</string>
+</resources>

--- a/ime/app/src/main/res/xml-es/symbols.xml
+++ b/ime/app/src/main/res/xml-es/symbols.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
+    <Row>
+        <Key android:codes="49" android:keyLabel="1" android:popupCharacters="¹₁" android:keyEdgeFlags="left"/>
+        <Key android:codes="50" android:keyLabel="2" android:popupCharacters="½²₂"/>
+        <Key android:codes="51" android:keyLabel="3" android:popupCharacters="⅓⅔³₃π"/>
+        <Key android:codes="52" android:keyLabel="4" android:popupCharacters="¼¾⁴₄"/>
+        <Key android:codes="53" android:keyLabel="5" android:popupCharacters="⁵₅"/>
+        <Key android:codes="54" android:keyLabel="6" android:popupCharacters="⁶₆"/>
+        <Key android:codes="55" android:keyLabel="7" android:popupCharacters="⁷₇"/>
+        <Key android:codes="56" android:keyLabel="8" android:popupCharacters="⅛⅜⅞⁸₈"/>
+        <Key android:codes="57" android:keyLabel="9" android:popupCharacters="⁹₉"/>
+        <Key android:codes="48" android:keyLabel="0" android:popupCharacters="⁰₀°" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="\u00a1&#8253;" android:keyEdgeFlags="left"/>
+        <Key android:codes="64" android:keyLabel="\@"/>
+        <Key android:codes="35" android:keyLabel="\#"/>
+        <Key android:codes="@integer/default_currency_sign_unicode"
+            android:keyLabel="@string/default_currency_sign"
+            android:popupCharacters="@string/popup_currency_signs"/>
+        <Key android:codes="37" android:keyLabel="%" android:popupCharacters="‰"/>
+        <Key android:codes="94" android:keyLabel="^" android:popupCharacters="&#8592;&#8593;&#8594;&#8595;"/>
+        <Key android:codes="38" android:keyLabel="&amp;"/>
+        <Key android:codes="42" android:keyLabel="*" android:popupCharacters="†‡§¶"/>
+        <Key android:codes="40" android:keyLabel="("/>
+        <Key android:codes="41" android:keyLabel=")" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="@integer/key_code_mode_symbols" android:keyEdgeFlags="left"/>
+        <Key android:codes="34" android:keyLabel="&quot;" android:popupCharacters="\'\u201c\u201e\u201d\u2018\u2019‹›«»"/>
+        <Key android:codes="46" android:keyLabel="." android:popupCharacters=",…⋯ "/>
+        <Key android:codes="58" android:keyLabel=":" android:popupCharacters=";"/>
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\u00bf\u00a1&#11822;&#8253;"/>
+        <Key android:codes="47" android:keyLabel="/" android:popupCharacters="\\"/>
+        <Key android:codes="45" android:keyLabel="-" android:popupCharacters="–—&#1470;"/>
+        <Key android:codes="61" android:keyLabel="=" android:popupCharacters="&#8800;&#8776;&#8801;&#8802;&#8803;&#8793;&#8792;&#8791;"/>
+        <Key android:codes="43" android:keyLabel="+"/>
+        <Key android:codes="@integer/key_code_delete" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION

Fixes #2074 

Commit [7185d6](https://github.com/AnySoftKeyboard/AnySoftKeyboard/commit/7185d6e060cb9db519df0f506927a52f8e160abe) fixes the currency issue.
Commit [07558cd](https://github.com/AnySoftKeyboard/AnySoftKeyboard/commit/07558cd2499667e2d83360edffa63c3577632c76) could be improved. 

I think it should not be bound to the locale but to the language addon being used.

If I am italian, and my phone language is set to Italian, when I type in Spanish, I cannot benefit from the easily accessible `¿` and `¡`. These symbols are bound the the language you are writing into, and not to the one set as default language in Android.

I tried to move a modified version of [symbols.xml](https://github.com/AnySoftKeyboard/AnySoftKeyboard/blob/master/ime/app/src/main/res/xml/symbols.xml) to [xml](https://github.com/AnySoftKeyboard/AnySoftKeyboard/tree/master/addons/languages/spain/pack/src/main/res/xml), but it does not work.

If there's a way to do it, I'll be happy to give it a try.