### PR TITLE
added popupcaracters to de_querty and de_quertz

### DIFF
--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ask="http://schemas.android.com/apk/res-auto"
     android:keyWidth="10%p">
     
-    <Row android:keyWidth="9.09%p">
-        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="" android:keyEdgeFlags="left"/>
-        <Key android:codes="119" android:keyLabel="w"  android:popupCharacters=""/>
-        <Key android:codes="101" android:keyLabel="e"  android:popupCharacters="€"/>
-        <Key android:codes="114" android:keyLabel="r"  android:popupCharacters=""/>
-        <Key android:codes="116" android:keyLabel="t"  android:popupCharacters=""/>
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters=""/>
-        <Key android:codes="117" android:keyLabel="u"  android:popupCharacters=""/>
-        <Key android:codes="105" android:keyLabel="i"  android:popupCharacters=""/>
-        <Key android:codes="111" android:keyLabel="o"  android:popupCharacters=""/>
-        <Key android:codes="112" android:keyLabel="p"  android:popupCharacters=""/>
+    <Row android:keyWidth="10%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\@1" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="2"/>
+        <Key android:codes="e"   android:keyLabel="e" android:popupKeyboard="@xml/popup_e" ask:hintLabel="€3"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="5"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="ýÿ"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü7ùúûũūŭű"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö9òóôõōøœő"/>
+        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="0"/>
         <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">
-        <Key android:codes="97" android:keyLabel="a"  android:popupCharacters="" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters=""/>
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞśŝš"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters=""/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥ"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="ĵ"/>
         <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l"/>
         <Key android:codes="246" android:keyLabel="ö" android:popupCharacters=""/>
         <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="" android:keyEdgeFlags="right"/>
     </Row>
     
-    <Row>
-        <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z"  android:popupCharacters=""/>
+    <Row android:keyWidth="9.444%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" 
+             android:keyEdgeFlags="left"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="6żžź"/>
         <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
-        <Key android:codes="99" android:keyLabel="c" android:popupCharacters=""/>
+        <Key android:codes="99"  android:keyLabel="c" android:popupCharacters="çćĉč"/>
         <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
-        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters=""/>
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters=""/>
+        <Key android:codes="98"  android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñ"/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
         <Key android:codes="223" android:keyLabel="ß" android:popupCharacters="" ask:shiftedCodes="7838" ask:shiftedKeyLabel="ẞ"/>
-        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+        <Key android:codes="-5"  android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>
 </Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwertz.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwertz.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ask="http://schemas.android.com/apk/res-auto"
     android:keyWidth="10%p">
     
-    <Row android:keyWidth="9.09%p">
-        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="" android:keyEdgeFlags="left"/>
-        <Key android:codes="119" android:keyLabel="w"  android:popupCharacters=""/>
-        <Key android:codes="101" android:keyLabel="e"  android:popupCharacters="€"/>
-        <Key android:codes="114" android:keyLabel="r"  android:popupCharacters=""/>
-        <Key android:codes="116" android:keyLabel="t"  android:popupCharacters=""/>
-        <Key android:codes="122" android:keyLabel="z"  android:popupCharacters=""/>
-        <Key android:codes="117" android:keyLabel="u"  android:popupCharacters=""/>
-        <Key android:codes="105" android:keyLabel="i"  android:popupCharacters=""/>
-        <Key android:codes="111" android:keyLabel="o"  android:popupCharacters=""/>
-        <Key android:codes="112" android:keyLabel="p"  android:popupCharacters=""/>
+    <Row android:keyWidth="10%p">
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters="\@1" android:keyEdgeFlags="left"/>
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="2"/>
+        <Key android:codes="e"   android:keyLabel="e" android:popupKeyboard="@xml/popup_e" ask:hintLabel="€3"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="4"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="5"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="6żžź"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ü7ùúûũūŭű"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="8ìíîïłī"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="ö9òóôõōøœő"/>
+        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="0"/>
         <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">
-        <Key android:codes="97" android:keyLabel="a"  android:popupCharacters="" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters=""/>
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
+        <Key android:codes="97"  android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞśŝš"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters=""/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters=""/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥ"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="ĵ"/>
         <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters=""/>
+        <Key android:codes="108" android:keyLabel="l"/>
         <Key android:codes="246" android:keyLabel="ö" android:popupCharacters=""/>
         <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="" android:keyEdgeFlags="right"/>
     </Row>
     
-    <Row>
-        <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters=""/>
+    <Row android:keyWidth="9.444%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true"           
+             android:keyEdgeFlags="left"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="ýÿ"/>
         <Key android:codes="120" android:keyLabel="x" android:popupCharacters=""/>
-        <Key android:codes="99" android:keyLabel="c" android:popupCharacters=""/>
+        <Key android:codes="99"  android:keyLabel="c" android:popupCharacters="çćĉč"/>
         <Key android:codes="118" android:keyLabel="v" android:popupCharacters=""/>
-        <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters=""/>
-        <Key android:codes="109" android:keyLabel="m" android:popupCharacters=""/>
+        <Key android:codes="98"  android:keyLabel="b" android:popupCharacters=""/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñ"/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
         <Key android:codes="223" android:keyLabel="ß" android:popupCharacters="" ask:shiftedCodes="7838" ask:shiftedKeyLabel="ẞ"/>
-        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+        <Key android:codes="-5"  android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>
 </Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/popup_e.xml
+++ b/addons/languages/german/pack/src/main/res/xml/popup_e.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:rowEdgeFlags="top">
+        <Key android:codes="51" android:keyEdgeFlags="left"/>
+        <Key android:codes="é"/>
+        <Key android:codes="ë"/>
+        <Key android:codes="ē" android:keyEdgeFlags="right"/>
+    </Row>    
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:codes="€" android:keyEdgeFlags="left"/>
+        <Key android:codes="è"/>
+        <Key android:codes="ê"/>
+        <Key android:codes="ę" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
Fixes #2010 
As the default qwertz and qwerty layouts didn't have any popups characters at all, I tried addressing this issue by just modifying those layouts instead of creating new ones.

If you think I should create new ones, leaving those original intact, I can do that. 