### PR TITLE
put current layout language first in the dictionary overriding list

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1164,14 +1164,24 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         final List<DictionaryAddOnAndBuilder> buildersForKeyboard =
                 AnyApplication.getExternalDictionaryFactory(this)
                         .getBuildersForKeyboard(getCurrentAlphabetKeyboard());
-        final List<DictionaryAddOnAndBuilder> allBuilders =
+        final List<DictionaryAddOnAndBuilder> allBuildersUnsorted =
                 AnyApplication.getExternalDictionaryFactory(this).getAllAddOns();
-
-        final CharSequence[] items = new CharSequence[allBuilders.size()];
+        final CharSequence[] items = new CharSequence[allBuildersUnsorted.size()];
         final boolean[] checked = new boolean[items.length];
-
-        for (int dictionaryIndex = 0; dictionaryIndex < allBuilders.size(); dictionaryIndex++) {
-            DictionaryAddOnAndBuilder dictionaryBuilder = allBuilders.get(dictionaryIndex);
+        final List<DictionaryAddOnAndBuilder> sortedAllBuilders =
+                new ArrayList<>(allBuildersUnsorted.size());
+        // put first in the list the current AlphabetKeyboard builders
+        sortedAllBuilders.addAll(buildersForKeyboard);
+        // and then add the remaining builders
+        for (int builderIndex = 0; builderIndex < allBuildersUnsorted.size(); builderIndex++) {
+            if (!sortedAllBuilders.contains(allBuildersUnsorted.get(builderIndex))) {
+                sortedAllBuilders.add(allBuildersUnsorted.get(builderIndex));
+            }
+        }
+        for (int dictionaryIndex = 0;
+                dictionaryIndex < sortedAllBuilders.size();
+                dictionaryIndex++) {
+            DictionaryAddOnAndBuilder dictionaryBuilder = sortedAllBuilders.get(dictionaryIndex);
             String description = dictionaryBuilder.getName();
             if (!TextUtils.isEmpty(dictionaryBuilder.getDescription())) {
                 description += " (" + dictionaryBuilder.getDescription() + ")";
@@ -1211,13 +1221,14 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
                                     List<DictionaryAddOnAndBuilder> newBuildersForKeyboard =
                                             new ArrayList<>(buildersForKeyboard.size());
                                     for (int itemIndex = 0;
-                                            itemIndex < allBuilders.size();
+                                            itemIndex < sortedAllBuilders.size();
                                             itemIndex++) {
                                         if (checked[itemIndex]) {
-                                            newBuildersForKeyboard.add(allBuilders.get(itemIndex));
+
+                                            newBuildersForKeyboard.add(
+                                                    sortedAllBuilders.get(itemIndex));
                                         }
                                     }
-
                                     AnyApplication.getExternalDictionaryFactory(
                                                     AnySoftKeyboard.this)
                                             .setBuildersForKeyboard(

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SuggestionsProvider.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SuggestionsProvider.java
@@ -280,37 +280,32 @@ public class SuggestionsProvider {
         final CompositeDisposable disposablesHolder = mDictionaryDisposables;
 
         for (int i = 0; i < dictionaryBuilders.size(); i++) {
+            DictionaryAddOnAndBuilder dictionaryBuilder = dictionaryBuilders.get(i);
             try {
                 Logger.d(
                         TAG,
                         " Creating dictionary %s (%s)...",
-                        dictionaryBuilders.get(i).getId(),
-                        dictionaryBuilders.get(i).getLanguage());
-                final Dictionary dictionary = dictionaryBuilders.get(i).createDictionary();
+                        dictionaryBuilder.getId(),
+                        dictionaryBuilder.getLanguage());
+                final Dictionary dictionary = dictionaryBuilder.createDictionary();
                 mMainDictionary.add(dictionary);
                 Logger.d(
                         TAG,
                         " Loading dictionary %s (%s)...",
-                        dictionaryBuilders.get(i).getId(),
-                        dictionaryBuilders.get(i).getLanguage());
+                        dictionaryBuilder.getId(),
+                        dictionaryBuilder.getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(cb, dictionary));
             } catch (Exception e) {
-                Logger.e(
-                        TAG,
-                        e,
-                        "Failed to create dictionary %s",
-                        dictionaryBuilders.get(i).getId());
+                Logger.e(TAG, e, "Failed to create dictionary %s", dictionaryBuilder.getId());
             }
 
             if (mUserDictionaryEnabled) {
                 final UserDictionary userDictionary =
-                        createUserDictionaryForLocale(dictionaryBuilders.get(i).getLanguage());
+                        createUserDictionaryForLocale(dictionaryBuilder.getLanguage());
                 mUserDictionary.add(userDictionary);
                 Logger.d(
-                        TAG,
-                        " Loading user dictionary for %s...",
-                        dictionaryBuilders.get(i).getLanguage());
+                        TAG, " Loading user dictionary for %s...", dictionaryBuilder.getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(userDictionary));
                 mUserNextWordDictionary.add(userDictionary.getUserNextWordGetter());
@@ -319,34 +314,27 @@ public class SuggestionsProvider {
             }
             // if mQuickFixesEnabled and mQuickFixesSecondDisabled are true
             // it  activates autotext only to the current keyboard layout language
-            if ((mQuickFixesEnabled && mQuickFixesSecondDisabled && i == 0)
-                    || (!mQuickFixesSecondDisabled && mQuickFixesEnabled)) {
-                final AutoText autoText = dictionaryBuilders.get(i).createAutoText();
+            if (mQuickFixesEnabled && (i == 0 || !mQuickFixesSecondDisabled)) {
+                final AutoText autoText = dictionaryBuilder.createAutoText();
                 if (autoText != null) {
                     mQuickFixesAutoText.add(autoText);
                 }
                 final AbbreviationsDictionary abbreviationsDictionary =
-                        new AbbreviationsDictionary(
-                                mContext, dictionaryBuilders.get(i).getLanguage());
+                        new AbbreviationsDictionary(mContext, dictionaryBuilder.getLanguage());
                 mAbbreviationDictionary.add(abbreviationsDictionary);
                 Logger.d(
-                        TAG,
-                        " Loading abbr dictionary for %s...",
-                        dictionaryBuilders.get(i).getLanguage());
+                        TAG, " Loading abbr dictionary for %s...", dictionaryBuilder.getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(
                                 abbreviationsDictionary));
             }
 
-            mInitialSuggestionsList.addAll(dictionaryBuilders.get(i).createInitialSuggestions());
+            mInitialSuggestionsList.addAll(dictionaryBuilder.createInitialSuggestions());
 
             // only one auto-dictionary. There is no way to know to which language the typed word
             // belongs.
-            mAutoDictionary = new AutoDictionary(mContext, dictionaryBuilders.get(i).getLanguage());
-            Logger.d(
-                    TAG,
-                    " Loading auto dictionary for %s...",
-                    dictionaryBuilders.get(i).getLanguage());
+            mAutoDictionary = new AutoDictionary(mContext, dictionaryBuilder.getLanguage());
+            Logger.d(TAG, " Loading auto dictionary for %s...", dictionaryBuilder.getLanguage());
             disposablesHolder.add(
                     DictionaryBackgroundLoader.loadDictionaryInBackground(mAutoDictionary));
         }

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SuggestionsProvider.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SuggestionsProvider.java
@@ -264,60 +264,61 @@ public class SuggestionsProvider {
         mCurrentSetupHashCode = newSetupHashCode;
         final CompositeDisposable disposablesHolder = mDictionaryDisposables;
 
-        for (DictionaryAddOnAndBuilder dictionaryBuilder : dictionaryBuilders) {
+        for (int i=0; i< dictionaryBuilders.size(); i++) {
             try {
                 Logger.d(
                         TAG,
                         " Creating dictionary %s (%s)...",
-                        dictionaryBuilder.getId(),
-                        dictionaryBuilder.getLanguage());
-                final Dictionary dictionary = dictionaryBuilder.createDictionary();
+                        dictionaryBuilders.get(i).getId(),
+                        dictionaryBuilders.get(i).getLanguage());
+                final Dictionary dictionary = dictionaryBuilders.get(i).createDictionary();
                 mMainDictionary.add(dictionary);
                 Logger.d(
                         TAG,
                         " Loading dictionary %s (%s)...",
-                        dictionaryBuilder.getId(),
-                        dictionaryBuilder.getLanguage());
+                        dictionaryBuilders.get(i).getId(),
+                        dictionaryBuilders.get(i).getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(cb, dictionary));
             } catch (Exception e) {
-                Logger.e(TAG, e, "Failed to create dictionary %s", dictionaryBuilder.getId());
+                Logger.e(TAG, e, "Failed to create dictionary %s", dictionaryBuilders.get(i).getId());
             }
 
             if (mUserDictionaryEnabled) {
                 final UserDictionary userDictionary =
-                        createUserDictionaryForLocale(dictionaryBuilder.getLanguage());
+                        createUserDictionaryForLocale(dictionaryBuilders.get(i).getLanguage());
                 mUserDictionary.add(userDictionary);
                 Logger.d(
-                        TAG, " Loading user dictionary for %s...", dictionaryBuilder.getLanguage());
+                        TAG, " Loading user dictionary for %s...", dictionaryBuilders.get(i).getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(userDictionary));
                 mUserNextWordDictionary.add(userDictionary.getUserNextWordGetter());
             } else {
                 Logger.d(TAG, " User does not want user dictionary, skipping...");
             }
-
-            if (mQuickFixesEnabled) {
-                final AutoText autoText = dictionaryBuilder.createAutoText();
+            // it  activates autotext only to the current keyboard layout language
+            // and if mQuickFixesEnabled is enabled in the settings
+            if (mQuickFixesEnabled && i==0) {
+                final AutoText autoText = dictionaryBuilders.get(i).createAutoText();
                 if (autoText != null) {
                     mQuickFixesAutoText.add(autoText);
                 }
                 final AbbreviationsDictionary abbreviationsDictionary =
-                        new AbbreviationsDictionary(mContext, dictionaryBuilder.getLanguage());
+                        new AbbreviationsDictionary(mContext, dictionaryBuilders.get(i).getLanguage());
                 mAbbreviationDictionary.add(abbreviationsDictionary);
                 Logger.d(
-                        TAG, " Loading abbr dictionary for %s...", dictionaryBuilder.getLanguage());
+                        TAG, " Loading abbr dictionary for %s...", dictionaryBuilders.get(i).getLanguage());
                 disposablesHolder.add(
                         DictionaryBackgroundLoader.loadDictionaryInBackground(
                                 abbreviationsDictionary));
             }
 
-            mInitialSuggestionsList.addAll(dictionaryBuilder.createInitialSuggestions());
+            mInitialSuggestionsList.addAll(dictionaryBuilders.get(i).createInitialSuggestions());
 
             // only one auto-dictionary. There is no way to know to which language the typed word
             // belongs.
-            mAutoDictionary = new AutoDictionary(mContext, dictionaryBuilder.getLanguage());
-            Logger.d(TAG, " Loading auto dictionary for %s...", dictionaryBuilder.getLanguage());
+            mAutoDictionary = new AutoDictionary(mContext, dictionaryBuilders.get(i).getLanguage());
+            Logger.d(TAG, " Loading auto dictionary for %s...", dictionaryBuilders.get(i).getLanguage());
             disposablesHolder.add(
                     DictionaryBackgroundLoader.loadDictionaryInBackground(mAutoDictionary));
         }

--- a/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
@@ -24,6 +24,7 @@
     <bool name="settings_default_use_volume_key_for_left_right">false</bool>
     <bool name="settings_default_do_not_flip_quick_keys_functionality">true</bool>
     <bool name="settings_default_quick_fix">true</bool>
+    <bool name="settings_default_key_quick_fix_second_disabled">false</bool>
     <bool name="settings_default_contacts_dictionary">true</bool>
     <bool name="settings_default_always_hide_language_key">false</bool>
     <string name="settings_default_auto_dictionary_add_threshold">9</string>

--- a/ime/app/src/main/res/values/settings_keys_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_keys_dont_translate.xml
@@ -354,7 +354,7 @@
     <string name="settings_key_persistent_layout_per_package_id_mapping">settings_key_persistent_layout_per_package_id_mapping</string>
 
     <string name="settings_key_quick_fix">quick_fix</string>
-    <string name="settings_key_quick_fix_second_disabled">quick_fix_second_disabled</string>
+    <string name="settings_key_quick_fix_second_disabled">settings_key_quick_fix_second_disabled</string>
 
     <string name="settings_key_layout_for_internet_fields">settings_key_layout_for_internet_fields</string>
 

--- a/ime/app/src/main/res/values/settings_keys_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_keys_dont_translate.xml
@@ -354,6 +354,7 @@
     <string name="settings_key_persistent_layout_per_package_id_mapping">settings_key_persistent_layout_per_package_id_mapping</string>
 
     <string name="settings_key_quick_fix">quick_fix</string>
+    <string name="settings_key_quick_fix_second_disabled">quick_fix_second_disabled</string>
 
     <string name="settings_key_layout_for_internet_fields">settings_key_layout_for_internet_fields</string>
 

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -445,8 +445,12 @@
     </string>
     <string name="candidates_off_summary">No suggestions will be shown</string>
     <string name="quick_fix">Quick fixes and abbreviations</string>
-    <string name="quick_fix_summary">Corrects commonly typed mistakes, and expands abbreviations
-    </string>
+    <string name="quick_fix_summary">Corrects commonly typed mistakes, and expands abbreviations</string>
+    <string name="quick_fix_secon_disabled">&#8230;on first language only</string>
+    <string name="quick_fix_secon_disabled_summ_on">Quick fixes and abbreviations will work only on current layout language</string> 
+    <string name="quick_fix_secon_disabled_summ_off">Quick fixes and abbreviations will work on every language 
+                  checked in override default dictionary</string>
+
     <string name="allow_suggestions_restart">Suggestions restart</string>
     <string name="allow_suggestions_restart_summary">Restart word suggestion upon cursor movement
     </string>

--- a/ime/app/src/main/res/xml/prefs_dictionaries.xml
+++ b/ime/app/src/main/res/xml/prefs_dictionaries.xml
@@ -51,6 +51,14 @@
             android:summaryOff=""
             android:summaryOn="@string/quick_fix_summary"
             android:title="@string/quick_fix"/>
+        <android.support.v7.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:dependency="@string/settings_key_quick_fix"
+            android:key="@string/settings_key_quick_fix_second_disabled"
+            android:persistent="true"
+            android:summaryOff="@string/quick_fix_secon_disabled_summ_off"
+            android:summaryOn="@string/quick_fix_secon_disabled_summ_on"
+            android:title="@string/quick_fix_secon_disabled"/>
 
         <android.support.v7.preference.ListPreference
             android:key="@string/settings_key_auto_pick_suggestion_aggressiveness"

--- a/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/SuggestionsProviderTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/SuggestionsProviderTest.java
@@ -298,6 +298,50 @@ public class SuggestionsProviderTest {
     }
 
     @Test
+    public void testDoesNotCreateAutoTextForSecondaries() throws Exception {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_quick_fix, true);
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_quick_fix_second_disabled, true);
+
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("hell", "hello", "say", "said", "drink")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("salt", "helll")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("ciao", "come")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("hola", "como")));
+
+        mSuggestionsProvider.setupSuggestionsForKeyboard(mFakeBuilders, mMockListener);
+
+        for (int i = 0; i < mFakeBuilders.size(); i++) {
+            DictionaryAddOnAndBuilder fakeB = mFakeBuilders.get(i);
+            if (i != 0) {
+                Mockito.verify(fakeB).createDictionary();
+                Mockito.verify(fakeB, Mockito.never()).createAutoText();
+                Mockito.verify(fakeB).createInitialSuggestions();
+                Mockito.verify(fakeB, Mockito.atLeastOnce()).getLanguage();
+            }
+        }
+    }
+
+    @Test
+    public void testDoesCreateAutoTextForSecondaries() throws Exception {
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_quick_fix, true);
+        SharedPrefsHelper.setPrefsValue(R.string.settings_key_quick_fix_second_disabled, false);
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("hell", "hello", "say", "said", "drink")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("salt", "helll")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("ciao", "come")));
+        mFakeBuilders.add(Mockito.spy(new FakeBuilder("hola", "como")));
+        mSuggestionsProvider.setupSuggestionsForKeyboard(mFakeBuilders, mMockListener);
+
+        for (int i = 0; i < mFakeBuilders.size(); i++) {
+            DictionaryAddOnAndBuilder fakeB = mFakeBuilders.get(i);
+            if (i == 0) {
+                Mockito.verify(fakeB).createDictionary();
+                Mockito.verify(fakeB).createAutoText();
+                Mockito.verify(fakeB).createInitialSuggestions();
+                Mockito.verify(fakeB, Mockito.atLeastOnce()).getLanguage();
+            }
+        }
+    }
+
+    @Test
     public void testIsValid() throws Exception {
         Assert.assertFalse(mSuggestionsProvider.isValidWord("hello"));
 


### PR DESCRIPTION
Fixes #1879
Fixes #2173

<table>
<tr>
    <th>Enabled</th>
    <th>Disabled</th>
</tr>
<tr>
    <td><img src="https://user-images.githubusercontent.com/16888339/77706340-68c06800-6fc2-11ea-8238-08d43a37dc1d.jpg" width="200" height="204"></td>
    <td><img src="https://user-images.githubusercontent.com/16888339/77706334-652ce100-6fc2-11ea-9c5a-4dba1e7ef7cd.jpg" width="200" height="204"></td>
</tr>
</table>

This branch does two things:
1. Allows the user to add custom words to the language the current layout belongs to. The current layout  language always appears first  in the list now.
2. Adds a new checkbox in language settings, right after `Quick fixes and abbreviations`. It's unchecked by default. When checked, it disables autotext to every language checked in `Override default dictionary` except the primary one (current keyboard layout).
In this way, if you write in a Language that has lower-case `i` (ltalian and a few slavonic languages eg. czech) or other conflicting words/letters, you can disable autotext for secondary languages by  keeping it for the primary language (current keyboard layout).

Now I can go to italian layout and write:

1. `Mi piacciono i cani e i gatti and the sky is cloudy today.`

Then I switch to English layout and write:

1. `Ask is working all right now, do you think` **I** `should keep override default dictionary on?`
