### PR TITLE
Automatic spacing for punctuations added

### DIFF
--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -676,7 +676,6 @@
     <string name="user_dict_restore_fail_text_with_error">Failed to restore words due to:\u0020
         <xliff:g id="error">%s</xliff:g>
     </string>
-
     <string name="should_swap_punctuation_and_space_title">Swap punctuation and space</string>
     <string name="should_swap_punctuation_and_space_off_summary">Do not swap space and
         punctuation.

--- a/ime/app/src/main/res/xml/prefs_addtional_language_prefs.xml
+++ b/ime/app/src/main/res/xml/prefs_addtional_language_prefs.xml
@@ -74,3 +74,4 @@
         android:title="@string/tweaks_group"/>
 
 </android.support.v7.preference.PreferenceScreen>
+

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardDictionaryGetWordsTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardDictionaryGetWordsTest.java
@@ -195,6 +195,30 @@ public class AnySoftKeyboardDictionaryGetWordsTest extends AnySoftKeyboardBaseTe
         mAnySoftKeyboardUnderTest.simulateKeyPress('?');
         Assert.assertEquals("hell", inputConnection.getLastCommitCorrection());
         // we should also see the question mark
+        Assert.assertEquals("hell? ", inputConnection.getCurrentTextInInputConnection());
+        // now, if we press DELETE, the word should be reverted
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        Assert.assertEquals("hel", inputConnection.getCurrentTextInInputConnection());
+    }
+
+    @Test
+    public void testAutoPickWordWhenCursorAtTheEndOfTheWordWithWordSeparatorSwapPunctuationOFF() {
+        SharedPrefsHelper.setPrefsValue(
+                R.string.settings_key_bool_should_swap_punctuation_and_space, false);
+        TestInputConnection inputConnection =
+                (TestInputConnection) mAnySoftKeyboardUnderTest.getCurrentInputConnection();
+        verifyNoSuggestionsInteractions();
+        mAnySoftKeyboardUnderTest.simulateTextTyping("h");
+        verifySuggestions(true, "h");
+        mAnySoftKeyboardUnderTest.simulateTextTyping("e");
+        verifySuggestions(true, "he", "he'll", "hell", "hello");
+        mAnySoftKeyboardUnderTest.simulateTextTyping("l");
+        verifySuggestions(true, "hel", "hell", "hello");
+
+        Assert.assertEquals("", inputConnection.getLastCommitCorrection());
+        mAnySoftKeyboardUnderTest.simulateKeyPress('?');
+        Assert.assertEquals("hell", inputConnection.getLastCommitCorrection());
+        // we should also see the question mark
         Assert.assertEquals("hell?", inputConnection.getCurrentTextInInputConnection());
         // now, if we press DELETE, the word should be reverted
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -518,9 +518,22 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
 
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('!');
-        Assert.assertEquals("hell!", inputConnection.getCurrentTextInInputConnection());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(' ');
         Assert.assertEquals("hell! ", inputConnection.getCurrentTextInInputConnection());
+
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hel");
+        verifySuggestions(true, "hel", "hell", "hello");
+
+        // typing punctuation
+        mAnySoftKeyboardUnderTest.simulateKeyPress('(');
+        Assert.assertEquals("hell! hell (", inputConnection.getCurrentTextInInputConnection());
+
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hel");
+        verifySuggestions(true, "hel", "hell", "hello");
+
+        // typing punctuation
+        mAnySoftKeyboardUnderTest.simulateKeyPress(')');
+        Assert.assertEquals(
+                "hell! hell (hell) ", inputConnection.getCurrentTextInInputConnection());
     }
 
     @Test
@@ -532,10 +545,10 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
 
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('.');
-        Assert.assertEquals("hell.", inputConnection.getCurrentTextInInputConnection());
+        Assert.assertEquals("hell. ", inputConnection.getCurrentTextInInputConnection());
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('h');
-        Assert.assertEquals("hell.h", inputConnection.getCurrentTextInInputConnection());
+        Assert.assertEquals("hell. h", inputConnection.getCurrentTextInInputConnection());
     }
 
     @Test
@@ -547,11 +560,11 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
 
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('.');
-        Assert.assertEquals("hell.", inputConnection.getCurrentTextInInputConnection());
+        Assert.assertEquals("hell. ", inputConnection.getCurrentTextInInputConnection());
         mAnySoftKeyboardUnderTest.simulateKeyPress('.');
-        Assert.assertEquals("hell..", inputConnection.getCurrentTextInInputConnection());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(' ');
         Assert.assertEquals("hell.. ", inputConnection.getCurrentTextInInputConnection());
+        mAnySoftKeyboardUnderTest.simulateKeyPress(' ');
+        Assert.assertEquals("hell..  ", inputConnection.getCurrentTextInInputConnection());
     }
 
     @Test
@@ -1065,9 +1078,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("hell ", inputConnection.getCurrentTextInInputConnection());
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('!');
-        Assert.assertEquals("hell !", inputConnection.getCurrentTextInInputConnection());
-
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hell ! ", inputConnection.getCurrentTextInInputConnection());
 
         mAnySoftKeyboardUnderTest.simulateTextTyping("hel");
 
@@ -1075,9 +1086,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("hell ! hell ", inputConnection.getCurrentTextInInputConnection());
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress('?');
-        Assert.assertEquals("hell ! hell ?", inputConnection.getCurrentTextInInputConnection());
-
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertEquals("hell ! hell ? ", inputConnection.getCurrentTextInInputConnection());
 
         mAnySoftKeyboardUnderTest.simulateTextTyping("hel");
 
@@ -1087,9 +1096,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress(':');
         Assert.assertEquals(
-                "hell ! hell ? hell :", inputConnection.getCurrentTextInInputConnection());
-
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+                "hell ! hell ? hell : ", inputConnection.getCurrentTextInInputConnection());
 
         mAnySoftKeyboardUnderTest.simulateTextTyping("hel");
 
@@ -1099,7 +1106,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         // typing punctuation
         mAnySoftKeyboardUnderTest.simulateKeyPress(';');
         Assert.assertEquals(
-                "hell ! hell ? hell : hell ;", inputConnection.getCurrentTextInInputConnection());
+                "hell ! hell ? hell : hell ; ", inputConnection.getCurrentTextInInputConnection());
     }
 
     private void assertKeyDimensions(Keyboard.Key key, int x, int y, int width) {


### PR DESCRIPTION
This feature takes care of spacing after and before punctuation. It extends the behaviour of `swap punctuation and space`

Here a few examples:

1. `"hi ,"`--> `"hi, "`
2. `"hi!"`--> `"hi! "`
3. `"hi !"` --> `"hi! "`
4. `"this is("` --> `"this is ("`
6. `"(good)"` --> `"(good) "`
7. `"(good )"` --> `"(good) "`

With French keyboard:
1. `"hi ,"`--> `"hi, "`
2. `"hi!"`--> `"hi ! "`
3. `"hi !"` --> `"hi ! "`
4. `"this is("` --> `"this is ("`
6. `"(good)"` --> `"(good) "`
7. `"(good )"` --> `"(good) "`
