### PR TITLE
add english_qwerty_no_apstrophe layout

### DIFF
--- a/.github/actions/deploy-request/action.yml
+++ b/.github/actions/deploy-request/action.yml
@@ -4,7 +4,7 @@ author: "menny"
 
 inputs:
   sha:
-    description: "SHA to deploy"
+    description: "SHA to deploy. Either a specific commit, or HEAD."
     required: true
   ref:
     description: "branch to deploy"

--- a/.github/actions/deploy-request/deployment_request.sh
+++ b/.github/actions/deploy-request/deployment_request.sh
@@ -12,6 +12,12 @@ shift
 API_TOKEN="${1}"
 shift
 
+if [[ "${SHA}" == "HEAD" ]]; then
+  echo "HEAD was specified as SHA. Taking from git:"
+  SHA="$(git show-ref --head --hash "${REF}" | tail -n 1)"
+  echo "HEAD SHA was found to be '${SHA}'."
+fi
+
 echo "Request deployment flow for sha ${SHA} on branch ${REF}. New deployment: ${NEW_DEPLOY}."
 ./gradlew :deployment:deploymentRequestProcess -PRequest.sha="${SHA}" -PRequest.ref="${REF}" -PRequest.new_deploy="${NEW_DEPLOY}" -PRequest.apiUsername="${API_USERNAME}" -PRequest.apiUserToken="${API_TOKEN}"
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -211,6 +211,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.BOT_MASTER_RW_GITHUB_TOKEN }}
+          fetch-depth: 0
           ref: master
       - name: create-merge-commit
         run: ./scripts/ci/ci_merge_to_master.sh ${{ github.ref }}

--- a/.github/workflows/deployment_promote.yml
+++ b/.github/workflows/deployment_promote.yml
@@ -23,7 +23,7 @@ jobs:
       - name: request-scheduled-promote
         uses: ./.github/actions/deploy-request
         with:
-          sha: ${{ github.sha }}
+          sha: HEAD
           ref: ${{ matrix.refname }}
           new_deploy: false
           api_username: ${{ secrets.BOT_MASTER_RW_GITHUB_USERNAME }}

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -2,6 +2,7 @@
     <string name="english_dictionary_description">English</string>
     <string name="english_keyboard_description">QWERTY Latin keyboard</string>
     <string name="english_keyboard_symbols_description">QWERTY Latin keyboard with symbols (on long press)</string>
+    <string name="english_keyboard_no_apostrophe_description">QWERTY Latin keyboard with symbols (no apostrophe)</string>
     <string name="dvorak_keyboard_description">Dvorak layout. Created with Stephen Paul Weber</string>
     <string name="compact_keyboard_description">Compact in portrait</string>
     <string name="compact_dvorak_keyboard_description">Compact Dvorak in portrait</string>

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -6,6 +6,7 @@
     <string name="english_dictionary">English</string>
     <string name="english_keyboard">English</string>
     <string name="english_keyboard_symbols">English</string>
+    <string name="english_keyboard_no_apostrophe">English</string>
     <string name="dvorak_keyboard">Dvorak</string>
     <string name="compact_keyboard">EN Compact</string>
     <string name="compact_dvorak_keyboard">Dv Compact</string>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -17,12 +17,6 @@
               defaultDictionaryLocale="en" description="@string/english_keyboard_symbols_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />
-    <Keyboard nameResId="@string/english_keyboard_no_apostrophe" iconResId="@drawable/ic_status_english"
-              layoutResId="@xml/qwerty_no_apostrophe" landscapeResId="@xml/qwerty_no_apostrophe"
-              id="7ddbb891-c967-4566-94bb-25357864837e"
-              defaultDictionaryLocale="en" description="@string/english_keyboard_no_apostrophe_description"
-              index="3" defaultEnabled="false"
-              physicalKeyboardMappingResId="@xml/english_physical" />
     <Keyboard nameResId="@string/compact_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/qwerty_compact" landscapeResId="@xml/qwerty"
               id="233838da-ed6c-4765-8fcc-b3e8f4090633"
@@ -53,5 +47,10 @@
               layoutResId="@xml/halmak" id="546b29d0-2563-11e9-b56e-0800200c9a66"
               description="@string/halmak_keyboard_description"
               index="10"/>
-
+    <Keyboard nameResId="@string/english_keyboard_no_apostrophe" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_no_apostrophe" landscapeResId="@xml/qwerty_no_apostrophe"
+              id="7ddbb891-c967-4566-94bb-25357864837e"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_no_apostrophe_description"
+              index="11" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -19,7 +19,7 @@
               physicalKeyboardMappingResId="@xml/english_physical" />
     <Keyboard nameResId="@string/english_keyboard_no_apostrophe" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/qwerty_no_apostrophe" landscapeResId="@xml/qwerty_no_apostrophe"
-              id="34CC76A3-91B3-4204-BB1B-421BA8FC8430"
+              id="7ddbb891-c967-4566-94bb-25357864837e"
               defaultDictionaryLocale="en" description="@string/english_keyboard_no_apostrophe_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -17,6 +17,12 @@
               defaultDictionaryLocale="en" description="@string/english_keyboard_symbols_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />
+    <Keyboard nameResId="@string/english_keyboard_no_apostrophe" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_no_apostrophe" landscapeResId="@xml/qwerty_no_apostrophe"
+              id="34CC76A3-91B3-4204-BB1B-421BA8FC8430"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_no_apostrophe_description"
+              index="3" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
     <Keyboard nameResId="@string/compact_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/qwerty_compact" landscapeResId="@xml/qwerty"
               id="233838da-ed6c-4765-8fcc-b3e8f4090633"

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_no_apostrophe.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_no_apostrophe.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
+
+    <Row>
+        <Key android:codes="q" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
+        <Key android:codes="e" android:popupCharacters="3³₃èéêëęē€" ask:hintLabel="3"/>
+        <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
+        <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
+        <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
+        <Key android:codes="u" android:popupCharacters="7ùúûüŭűūµ" ask:hintLabel="7"/>
+        <Key android:codes="i" android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8"/>
+        <Key android:codes="o" android:popupCharacters="9òóôõöøőœō" ask:hintLabel="9"/>
+        <Key android:codes="p" android:popupCharacters="0¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="a" android:horizontalGap="5%p" android:popupCharacters="\@àáâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="s" android:popupCharacters="$§ßśŝšṣ" ask:hintLabel="$"/>
+        <Key android:codes="d" android:popupCharacters="#%đďḏ" ask:hintLabel="# %"/>
+        <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>
+        <Key android:codes="g" android:popupCharacters="`°ĝ" ask:hintLabel="` °"/>
+        <Key android:codes="h" android:popupKeyboard="@xml/popup_querty_with_symbols_h" ask:hintLabel="_ ~"/>
+        <Key android:codes="j" android:popupCharacters="\\|ĵ" ask:hintLabel="\\ |"/>
+        <Key android:codes="k" android:popupCharacters="([{⸢" ask:hintLabel="("/>
+        <Key android:codes="l" android:popupCharacters=")]}⸣ľĺł£" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyWidth="15%p"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="z" android:popupCharacters="/÷żžź" ask:hintLabel="/"/>
+        <Key android:codes="x" android:popupCharacters="*·×" ask:hintLabel="*"/>
+        <Key android:codes="c" android:popupCharacters="-—çćĉč" ask:hintLabel="−"/>
+        <Key android:codes="v" android:popupCharacters="+±" ask:hintLabel="+"/>
+        <Key android:codes="b" android:popupCharacters="\u003D"/>
+        <Key android:codes="n" android:popupCharacters="&lt;«ńňñ" ask:hintLabel="&lt;"/>
+        <Key android:codes="m" android:popupCharacters="&gt;»µ" ask:hintLabel="&gt;"/>
+        <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/deployment/build.gradle
+++ b/deployment/build.gradle
@@ -42,13 +42,13 @@ long getDaysFromLastCommitFromGit() {
     Instant now = Instant.now()
     Instant timeOfLastCommit = Instant.ofEpochMilli(epochOfLastCommit)
     println("now: ${now}, timeOfLastCommit: ${timeOfLastCommit}")
-    Duration diff = Duration.between(now, timeOfLastCommit)
-    println("diff is ${diff}")
+    Duration diff = Duration.between(timeOfLastCommit, now)
+    println("diff is ${diff}, days ${diff.toDays()}")
     return diff.toDays()
 }
 
-String getTaskNameByStepFor(String processName, long step) {
-    def processSteps = deployments.named(processName).get().environmentSteps
+static String getTaskNameByStepFor(Project project, String processName, long step) {
+    def processSteps = project.deployments.named(processName).get().environmentSteps
     if (step >= processSteps.size()) {
         step = processSteps.size() - 1
     }
@@ -60,7 +60,7 @@ String getTaskNameByStepFor(String processName, long step) {
 def imeOnMasterPush = tasks.register("imeOnMasterPush") {
     it.group "Publishing"
     it.description "Deployment request on master push for IME"
-    it.dependsOn tasks.named(getTaskNameByStepFor("imeMaster", 0))
+    it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "imeMaster", 0))
 }
 
 def imePromoteMaster = tasks.register("imePromoteMaster") {
@@ -70,7 +70,7 @@ def imePromoteMaster = tasks.register("imePromoteMaster") {
     def shouldPromote = Instant.now().toCalendar().toDayOfWeek() == DayOfWeek.WEDNESDAY
     it.onlyIf { shouldPromote }
     if (shouldPromote) {
-        it.dependsOn tasks.named(getTaskNameByStepFor("imeMaster", 1))
+        it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "imeMaster", 1))
     }
 }
 
@@ -78,7 +78,7 @@ def imePromoteMaster = tasks.register("imePromoteMaster") {
 def imeOnReleasePush = tasks.register("imeOnReleasePush") {
     it.group "Publishing"
     it.description "Deployment request on release-branch push for IME"
-    it.dependsOn tasks.named(getTaskNameByStepFor("imeProduction", 0))
+    it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "imeProduction", 0))
 }
 
 def imePromoteRelease = tasks.register("imePromoteRelease") {
@@ -88,7 +88,7 @@ def imePromoteRelease = tasks.register("imePromoteRelease") {
     def days = getDaysFromLastCommitFromGit()
     it.onlyIf { days > 0 }
     if (days > 0) {
-        it.dependsOn tasks.named(getTaskNameByStepFor("imeProduction", days))
+        it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "imeProduction", days))
     }
 }
 //////// end - IME
@@ -99,7 +99,7 @@ def noOpTask = tasks.register("noOpDeployTask")
 def addOnsOnMasterPush = tasks.register("addOnsOnMasterPush") {
     it.group "Publishing"
     it.description "Deployment request on master push for all addons"
-    it.dependsOn tasks.named(getTaskNameByStepFor("addOnsMaster", 0))
+    it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "addOnsMaster", 0))
 }
 
 def addOnsPromoteMaster = tasks.register("addOnsPromoteMaster") {
@@ -112,7 +112,7 @@ def addOnsPromoteMaster = tasks.register("addOnsPromoteMaster") {
 def addOnsOnReleasePush = tasks.register("addOnsOnReleasePush") {
     it.group "Publishing"
     it.description "Deployment request on release-branch push for addons"
-    it.dependsOn tasks.named(getTaskNameByStepFor("addOnsProduction", 0))
+    it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "addOnsProduction", 0))
 }
 
 def addOnsPromoteRelease = tasks.register("addOnsPromoteRelease") {
@@ -122,7 +122,7 @@ def addOnsPromoteRelease = tasks.register("addOnsPromoteRelease") {
     def days = getDaysFromLastCommitFromGit()
     it.onlyIf { days > 0 }
     if (days > 0) {
-        it.dependsOn tasks.named(getTaskNameByStepFor("addOnsProduction", days))
+        it.dependsOn tasks.named(getTaskNameByStepFor(it.project, "addOnsProduction", days))
     }
 }
 //////// end - addons

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -68,7 +68,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
-        Assert.assertEquals(10, keyboardBuilders.size());
+        Assert.assertEquals(11, keyboardBuilders.size());
         Assert.assertEquals(8, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -69,7 +69,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
         Assert.assertEquals(11, keyboardBuilders.size());
-        Assert.assertEquals(8, reportedSubtypes.length);
+        Assert.assertEquals(9, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {
                     1912895432,

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -69,7 +69,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
         Assert.assertEquals(11, keyboardBuilders.size());
-        Assert.assertEquals(9, reportedSubtypes.length);
+        Assert.assertEquals(8, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {
                     1912895432,

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
@@ -51,7 +51,7 @@ public class KeyboardAddOnTest {
                     addOnAndBuilder.getId(), addOnAndBuilder.getKeyboardDefaultEnabled());
         }
 
-        Assert.assertEquals(10, keyboardsEnabled.size());
+        Assert.assertEquals(11, keyboardsEnabled.size());
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.get(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_16_KEYS_ID));

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
@@ -35,7 +35,7 @@ public class KeyboardFactoryTest {
     @Test
     public void testDefaultKeyboardId() {
         final List<KeyboardAddOnAndBuilder> allAddOns = mKeyboardFactory.getAllAddOns();
-        Assert.assertEquals(10, allAddOns.size());
+        Assert.assertEquals(11, allAddOns.size());
         KeyboardAddOnAndBuilder addon = mKeyboardFactory.getEnabledAddOn();
         Assert.assertNotNull(addon);
         Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a", addon.getId());

--- a/scripts/ci/ci_merge_to_master.sh
+++ b/scripts/ci/ci_merge_to_master.sh
@@ -5,6 +5,12 @@ set -x
 REF="${1}"
 LOCAL_REF="$(echo refs/heads/release-branch-addons-v4.0-r1 | cut -d'/' -f 3)"
 
+echo "setting git user details"
+echo "email"
+git config --global user.email "ask@evendanan.net"
+echo "name"
+git config --global user.name "Polyglot"
+  
 echo "Fetching from ${REF}, as local ${LOCAL_REF}:"
 git fetch origin "${REF}"
 echo "Merging:"


### PR DESCRIPTION
Hello,

This pull request is to address https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/1704

This PR adds a new keyboard layout named "qwerty_no_apostrophe" that is a copy of "qwerty_with_symbols", except the apostrophe key has been removed and replaced with centering for the "a" to "l" row of keys.

I originally had changed the symbols on this keyboard to be more common symbols for US users, but decided to hold back that part of the patch and keep the symbols exactly the same as "qwerty_with_symbols" for now, because I wanted to keep the PR isolated to a single issue.  I will likely make an additional pull request in the future that introduces or replaces the existing symbol layouts with more frequently used keys, but that is for another day.