### PR TITLE
add english_qwerty_no_apstrophe layout

### DIFF
--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -2,6 +2,7 @@
     <string name="english_dictionary_description">English</string>
     <string name="english_keyboard_description">QWERTY Latin keyboard</string>
     <string name="english_keyboard_symbols_description">QWERTY Latin keyboard with symbols (on long press)</string>
+    <string name="english_keyboard_no_apostrophe_description">QWERTY Latin keyboard with symbols (no apostrophe)</string>
     <string name="dvorak_keyboard_description">Dvorak layout. Created with Stephen Paul Weber</string>
     <string name="compact_keyboard_description">Compact in portrait</string>
     <string name="compact_dvorak_keyboard_description">Compact Dvorak in portrait</string>

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -6,6 +6,7 @@
     <string name="english_dictionary">English</string>
     <string name="english_keyboard">English</string>
     <string name="english_keyboard_symbols">English</string>
+    <string name="english_keyboard_no_apostrophe">English</string>
     <string name="dvorak_keyboard">Dvorak</string>
     <string name="compact_keyboard">EN Compact</string>
     <string name="compact_dvorak_keyboard">Dv Compact</string>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -47,5 +47,10 @@
               layoutResId="@xml/halmak" id="546b29d0-2563-11e9-b56e-0800200c9a66"
               description="@string/halmak_keyboard_description"
               index="10"/>
-
+    <Keyboard nameResId="@string/english_keyboard_no_apostrophe" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_no_apostrophe" landscapeResId="@xml/qwerty_no_apostrophe"
+              id="7ddbb891-c967-4566-94bb-25357864837e"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_no_apostrophe_description"
+              index="11" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_no_apostrophe.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_no_apostrophe.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
+
+    <Row>
+        <Key android:codes="q" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
+        <Key android:codes="e" android:popupCharacters="3³₃èéêëęē€" ask:hintLabel="3"/>
+        <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
+        <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
+        <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
+        <Key android:codes="u" android:popupCharacters="7ùúûüŭűūµ" ask:hintLabel="7"/>
+        <Key android:codes="i" android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8"/>
+        <Key android:codes="o" android:popupCharacters="9òóôõöøőœō" ask:hintLabel="9"/>
+        <Key android:codes="p" android:popupCharacters="0¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="a" android:horizontalGap="5%p" android:popupCharacters="\@àáâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="s" android:popupCharacters="$§ßśŝšṣ" ask:hintLabel="$"/>
+        <Key android:codes="d" android:popupCharacters="#%đďḏ" ask:hintLabel="# %"/>
+        <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>
+        <Key android:codes="g" android:popupCharacters="`°ĝ" ask:hintLabel="` °"/>
+        <Key android:codes="h" android:popupKeyboard="@xml/popup_querty_with_symbols_h" ask:hintLabel="_ ~"/>
+        <Key android:codes="j" android:popupCharacters="\\|ĵ" ask:hintLabel="\\ |"/>
+        <Key android:codes="k" android:popupCharacters="([{⸢" ask:hintLabel="("/>
+        <Key android:codes="l" android:popupCharacters=")]}⸣ľĺł£" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyWidth="15%p"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="z" android:popupCharacters="/÷żžź" ask:hintLabel="/"/>
+        <Key android:codes="x" android:popupCharacters="*·×" ask:hintLabel="*"/>
+        <Key android:codes="c" android:popupCharacters="-—çćĉč" ask:hintLabel="−"/>
+        <Key android:codes="v" android:popupCharacters="+±" ask:hintLabel="+"/>
+        <Key android:codes="b" android:popupCharacters="\u003D"/>
+        <Key android:codes="n" android:popupCharacters="&lt;«ńňñ" ask:hintLabel="&lt;"/>
+        <Key android:codes="m" android:popupCharacters="&gt;»µ" ask:hintLabel="&gt;"/>
+        <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -68,7 +68,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
-        Assert.assertEquals(10, keyboardBuilders.size());
+        Assert.assertEquals(11, keyboardBuilders.size());
         Assert.assertEquals(8, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
@@ -51,7 +51,7 @@ public class KeyboardAddOnTest {
                     addOnAndBuilder.getId(), addOnAndBuilder.getKeyboardDefaultEnabled());
         }
 
-        Assert.assertEquals(10, keyboardsEnabled.size());
+        Assert.assertEquals(11, keyboardsEnabled.size());
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.get(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_16_KEYS_ID));

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
@@ -35,7 +35,7 @@ public class KeyboardFactoryTest {
     @Test
     public void testDefaultKeyboardId() {
         final List<KeyboardAddOnAndBuilder> allAddOns = mKeyboardFactory.getAllAddOns();
-        Assert.assertEquals(10, allAddOns.size());
+        Assert.assertEquals(11, allAddOns.size());
         KeyboardAddOnAndBuilder addon = mKeyboardFactory.getEnabledAddOn();
         Assert.assertNotNull(addon);
         Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a", addon.getId());


### PR DESCRIPTION
github wouldn't let me re-open the PR because I recreated the branch

This pull request is to address #1704

This PR adds a new keyboard layout named "qwerty_no_apostrophe" that is a copy of "qwerty_with_symbols", except the apostrophe key has been removed and replaced with centering for the "a" to "l" row of keys.

I originally had changed the symbols on this keyboard to be more common symbols for US users, but decided to hold back that part of the patch and keep the symbols exactly the same as "qwerty_with_symbols" for now, because I wanted to keep the PR isolated to a single issue. I will likely make an additional pull request in the future that introduces or replaces the existing symbol layouts with more frequently used keys, but that is for another day.