### PR TITLE
English QWERTY with symbols on long press and numbers row

### DIFF
--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -2,6 +2,7 @@
     <string name="english_dictionary_description">English</string>
     <string name="english_keyboard_description">QWERTY Latin keyboard</string>
     <string name="english_keyboard_symbols_description">QWERTY Latin keyboard with symbols (on long press)</string>
+    <string name="english_keyboard_symbols_number_row_description">QWERTY Latin keyboard with symbols and numbers row</string>
     <string name="dvorak_keyboard_description">Dvorak layout. Created with Stephen Paul Weber</string>
     <string name="compact_keyboard_description">Compact in portrait</string>
     <string name="compact_dvorak_keyboard_description">Compact Dvorak in portrait</string>

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -6,6 +6,7 @@
     <string name="english_dictionary">English</string>
     <string name="english_keyboard">English</string>
     <string name="english_keyboard_symbols">English</string>
+    <string name="english_keyboard_symbols_number_row">English</string>
     <string name="dvorak_keyboard">Dvorak</string>
     <string name="compact_keyboard">EN Compact</string>
     <string name="compact_dvorak_keyboard">Dv Compact</string>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -17,35 +17,42 @@
               defaultDictionaryLocale="en" description="@string/english_keyboard_symbols_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />
+    <Keyboard nameResId="@string/english_keyboard_symbols_number_row" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_with_symbols_number_row" landscapeResId="@xml/qwerty_with_symbols"
+              id="f3286fee-b3b3-41aa-90d7-4ed637a5c3f9"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_symbols_number_row_description"
+              index="4" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
+
     <Keyboard nameResId="@string/compact_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/qwerty_compact" landscapeResId="@xml/qwerty"
               id="233838da-ed6c-4765-8fcc-b3e8f4090633"
               defaultDictionaryLocale="en" description="@string/compact_keyboard_description"
-              index="4" />
+              index="5" />
     <Keyboard nameResId="@string/dvorak_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/dvorak" id="4100d602-ba06-40e5-b169-61881b065def"
               defaultDictionaryLocale="en" description="@string/dvorak_keyboard_description"
-              index="5"/>
+              index="6"/>
     <Keyboard nameResId="@string/compact_dvorak_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/dvorak_compact" landscapeResId="@xml/dvorak"
               id="53baf0a3-389d-4257-815b-5820d7d219f7"
               defaultDictionaryLocale="en" description="@string/compact_dvorak_keyboard_description"
-              index="6" />
+              index="7" />
     <Keyboard nameResId="@string/colemak_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/colemak" id="86770389-9f38-4654-9e29-68d503410fcd"
               defaultDictionaryLocale="en" description="@string/colemak_keyboard_description"
-              index="7"/>
+              index="8"/>
     <Keyboard nameResId="@string/workman_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/workman" id="37334220-b0ca-11e8-8c82-0b99ca86e03e"
               defaultDictionaryLocale="en" description="@string/workman_keyboard_description"
-              index="8"/>
+              index="9"/>
     <Keyboard nameResId="@string/terminal_keyboard"
               layoutResId="@xml/terminal" id="b1c24b40-02ce-4857-9fb8-fb9e4e3b4318"
               description="@string/terminal_keyboard_description"
-              index="9"/>
+              index="10"/>
     <Keyboard nameResId="@string/halmak_keyboard"
               layoutResId="@xml/halmak" id="546b29d0-2563-11e9-b56e-0800200c9a66"
               description="@string/halmak_keyboard_description"
-              index="10"/>
+              index="11"/>
 
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_with_symbols_number_row.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_with_symbols_number_row.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
+
+    <Row
+        android:keyWidth="10%p"
+        android:keyHeight="@integer/key_short_height">
+        <Key android:codes="49" android:keyLabel="1" ask:shiftedCodes="33" 
+             android:popupCharacters="|¹₁" ask:hintLabel="|" android:keyEdgeFlags="left"/>
+        <Key android:codes="50" android:keyLabel="2" ask:shiftedCodes="64" 
+             android:popupCharacters="½²₂" ask:hintLabel="½"/>
+        <Key android:codes="51" android:keyLabel="3" ask:shiftedCodes="35" 
+             android:popupCharacters="⅔⅓³₃" ask:hintLabel="⅔"/>
+        <Key android:codes="52" android:keyLabel="4" ask:shiftedCodes="36" 
+             android:popupCharacters="{¼¾⁴₄" ask:hintLabel="{"/>
+        <Key android:codes="53" android:keyLabel="5" ask:shiftedCodes="37" 
+             android:popupCharacters="}⁵₅" ask:hintLabel="}"/>
+        <Key android:codes="54" android:keyLabel="6" ask:shiftedCodes="94" 
+             android:popupCharacters="&amp;⁶₆" ask:hintLabel="&amp;"/>
+        <Key android:codes="55" android:keyLabel="7" ask:shiftedCodes="38" 
+             android:popupCharacters="%‰⁷₇" ask:hintLabel="%"/>
+        <Key android:codes="56" android:keyLabel="8" ask:shiftedCodes="42" 
+             android:popupCharacters="&#8594;⅛⅜⅞⁸₈" ask:hintLabel="&#8594;"/>
+        <Key android:codes="57" android:keyLabel="9" ask:shiftedCodes="40" 
+             android:popupCharacters="&#8592;⁹₉" ask:hintLabel="&#8592;"/>
+        <Key android:codes="48" android:keyLabel="0" ask:shiftedCodes="41" 
+             android:popupCharacters="°⁰₀" ask:hintLabel="°" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row>
+        <Key android:codes="q" android:popupCharacters="\@" ask:hintLabel="\@" 
+             android:keyEdgeFlags="left"/>
+        <Key android:codes="w" android:popupCharacters="€" ask:hintLabel="€"/>
+        <Key android:codes="e" android:popupCharacters="£" ask:hintLabel="£"/>
+        <Key android:codes="r" android:popupCharacters="[" ask:hintLabel="["/>
+        <Key android:codes="t" android:popupCharacters="]" ask:hintLabel="]"/>
+        <Key android:codes="y" android:popupCharacters="~" ask:hintLabel="~"/>
+        <Key android:codes="u" android:popupCharacters="✓✗" ask:hintLabel="✓"/>
+        <Key android:codes="i" android:popupCharacters="↑…" ask:hintLabel="↑"/>
+        <Key android:codes="o" android:popupCharacters="↓♀♂" ask:hintLabel="↓"/>
+        <Key android:codes="p" android:popupCharacters="¶π" ask:hintLabel="" 
+             android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="a" android:popupCharacters="§" ask:hintLabel="§" 
+             android:keyEdgeFlags="left"/>
+        <Key android:codes="s" android:popupCharacters="$" ask:hintLabel="$"/>
+        <Key android:codes="d" android:popupCharacters="\\" ask:hintLabel="\\"/>
+        <Key android:codes="f" android:popupCharacters="^" ask:hintLabel="^"/>
+        <Key android:codes="g" android:popupCharacters="`" ask:hintLabel="`"/>
+        <Key android:codes="h" android:popupCharacters="_" ask:hintLabel="_"/>
+        <Key android:codes="j" android:popupCharacters="#" ask:hintLabel="#"/>
+        <Key android:codes="k" android:popupCharacters="(" ask:hintLabel="("/>
+        <Key android:codes="l" android:popupCharacters=")" ask:hintLabel=")"/>
+        <Key ask:isFunctional="true" android:codes="\u0027" android:popupCharacters="\u0022"
+             android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyWidth="15%p"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="z" android:popupCharacters="/÷" ask:hintLabel="/"/>
+        <Key android:codes="x" android:popupCharacters="*·×" ask:hintLabel="*"/>
+        <Key android:codes="c" android:popupCharacters="-—" ask:hintLabel="−"/>
+        <Key android:codes="v" android:popupCharacters="+±" ask:hintLabel="+"/>
+        <Key android:codes="b" android:popupCharacters="\u003D≠" ask:hintLabel="\u003D"/>
+        <Key android:codes="n" android:popupCharacters="&lt;≤«" ask:hintLabel="&lt;"/>
+        <Key android:codes="m" android:popupCharacters="&gt;≥»µ" ask:hintLabel="&gt;"/>
+        <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>
+    

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -68,7 +68,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
-        Assert.assertEquals(10, keyboardBuilders.size());
+        Assert.assertEquals(11, keyboardBuilders.size());
         Assert.assertEquals(8, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -69,7 +69,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
         Assert.assertEquals(11, keyboardBuilders.size());
-        Assert.assertEquals(8, reportedSubtypes.length);
+        Assert.assertEquals(9, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {
                     1912895432,

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
@@ -51,7 +51,7 @@ public class KeyboardAddOnTest {
                     addOnAndBuilder.getId(), addOnAndBuilder.getKeyboardDefaultEnabled());
         }
 
-        Assert.assertEquals(10, keyboardsEnabled.size());
+        Assert.assertEquals(11, keyboardsEnabled.size());
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.get(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_16_KEYS_ID));

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
@@ -35,7 +35,7 @@ public class KeyboardFactoryTest {
     @Test
     public void testDefaultKeyboardId() {
         final List<KeyboardAddOnAndBuilder> allAddOns = mKeyboardFactory.getAllAddOns();
-        Assert.assertEquals(10, allAddOns.size());
+        Assert.assertEquals(11, allAddOns.size());
         KeyboardAddOnAndBuilder addon = mKeyboardFactory.getEnabledAddOn();
         Assert.assertNotNull(addon);
         Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a", addon.getId());


### PR DESCRIPTION
This adds a new layout for English: `English with symbols and numbers row`.

This offers the chance to most symbols to be accessible as first choice on long press, and numbers will have their own key.

This is also for people who enjoy having a number row + a top row of their choice too. 
<img src="https://user-images.githubusercontent.com/16888339/78834076-45e47980-79ee-11ea-87ef-b58aa270a261.jpg" width=200 height=160>
