### PR TITLE
Generic rows 2

### DIFF
--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -528,6 +528,7 @@
     <string name="extension_kbd_top_numbers_alt">Alternate number keys</string>
     <string name="extension_kbd_top_nav">Navigation keys</string>
     <string name="extension_kbd_top_nav_alt">Navigation keys alternative</string>
+    <string name="extension_kbd_top_nav_alt_no_numb">Navigation keys alternative. No numbers row in pwd mode</string>
     <string name="extension_kbd_top_numbers_simple">Simple, numbers only</string>
     <string name="extension_kbd_top_terminal">Terminal</string>
     <string name="extension_kbd_top_text_editing">Quick text editing</string>

--- a/ime/app/src/main/res/xml/ext_kbd_bottom_row_minimal.xml
+++ b/ime/app/src/main/res/xml/ext_kbd_bottom_row_minimal.xml
@@ -6,11 +6,13 @@
           android:keyHeight="@integer/key_normal_height">
 
     <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_normal" android:rowEdgeFlags="bottom">
-        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
         <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" ask:shiftedCodes="33"
              android:popupCharacters="!/@\u0026\u00bf\u00a1&#11822;&#8253;"/>
         <Key ask:isFunctional="true" android:codes="44" android:keyLabel="," android:popupCharacters=";"/>
-        <Key android:keyWidth="45%p" android:codes="@integer/key_code_space" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key android:keyWidth="45%p" android:codes="@integer/key_code_space" 
+             android:isRepeatable="true" ask:hintLabel=" "/>
         <Key ask:isFunctional="true" android:codes="46" android:keyLabel="."
              android:popupCharacters=":;-\u2014_\u00b7\u2026"/>
         <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
@@ -31,7 +33,8 @@
     </Row>
     <Row android:keyboardMode="@integer/keyboard_mode_password" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
         android:keyHeight="@integer/key_normal_height">
-        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
         <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" android:popupCharacters="!@#$%^\u0026*"/>
         <Key ask:isFunctional="true" android:codes="44" android:keyLabel="," android:popupCharacters="()"/>
         <Key android:keyWidth="45%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
@@ -57,11 +60,13 @@
     </Row>
     <Row android:keyboardMode="@integer/keyboard_mode_im" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
          android:keyHeight="@integer/key_normal_height">
-        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
         <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" ask:shiftedCodes="33"
              android:popupCharacters="!/@\u0026\u00bf\u00a1&#11822;&#8253;"/>
         <Key ask:isFunctional="true" android:codes="44" android:keyLabel="," android:popupCharacters="()"/>
-        <Key android:keyWidth="45%p" android:codes="@integer/key_code_space" ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key android:keyWidth="45%p" android:codes="@integer/key_code_space" android:isRepeatable="true" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
         <Key ask:isFunctional="true" android:codes="46" android:keyLabel="."
              android:popupCharacters=":;-\u2014_\u00b7\u2026"/>
         <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"

--- a/ime/app/src/main/res/xml/ext_kbd_top_row_nav_alt_no_numb.xml
+++ b/ime/app/src/main/res/xml/ext_kbd_top_row_nav_alt_no_numb.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto">
+    <Row android:rowEdgeFlags="top"
+         android:keyHeight="@integer/key_short_height">
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_tab" ask:hintLabel=" "
+             android:keyEdgeFlags="left"/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true"
+             android:codes="@integer/key_code_arrow_up" android:isRepeatable="true" ask:hintLabel=" "/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_arrow_down"
+             android:isRepeatable="true" ask:hintLabel=" "/>
+        <Key android:keyWidth="20%p" ask:isFunctional="true" android:codes="@integer/key_code_arrow_left"
+             android:isRepeatable="true" ask:hintLabel=" "/>
+        <Key android:keyWidth="20%p" ask:isFunctional="true" android:codes="@integer/key_code_arrow_right"
+             android:isRepeatable="true" ask:hintLabel=" "/>
+        <Key android:keyWidth="15%p"  ask:isFunctional="true" android:codes="@integer/key_code_ctrl"
+             android:isRepeatable="true" ask:hintLabel=" "  android:keyEdgeFlags="right"/>
+
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/extension_keyboards.xml
+++ b/ime/app/src/main/res/xml/extension_keyboards.xml
@@ -58,12 +58,20 @@
             index="7"
     />
     <ExtensionKeyboard
+            id="6187a431-f737-49b2-baa6-78cc49ec8214"
+            nameResId="@string/extension_kbd_top_nav_alt_no_numb"
+            extensionKeyboardResId="@xml/ext_kbd_top_row_nav_alt_no_numb"
+            extensionKeyboardType="2"
+            description=""
+            index="8"
+    />
+    <ExtensionKeyboard
             id="d9d6f590-db8b-11e7-8f1a-0800200c9a66"
             nameResId="@string/extension_kbd_top_numbers_simple"
             extensionKeyboardResId="@xml/ext_kbd_top_row_numbers_simple"
             extensionKeyboardType="@integer/extension_keyboard_type_top_row"
             description=""
-            index="8"
+            index="9"
             />
     <ExtensionKeyboard
             id="49c8c4b0-b3bc-11e8-933e-975e4dcf2c13"
@@ -71,7 +79,7 @@
             extensionKeyboardResId="@xml/ext_kbd_top_row_terminal"
             extensionKeyboardType="2"
             description=""
-            index="9"
+            index="10"
             />
     <ExtensionKeyboard
             id="16bbcd88-5532-4fd6-92ff-db57977dd815"
@@ -79,7 +87,7 @@
             extensionKeyboardResId="@xml/ext_kbd_top_row_text_editing"
             extensionKeyboardType="@integer/extension_keyboard_type_top_row"
             description=""
-            index="10"
+            index="11"
             />
 
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
@@ -78,7 +78,7 @@ public class KeyboardExtensionFactoryTest {
                 KeyboardExtension.TYPE_BOTTOM);
         assertBasicListDetails(
                 AnyApplication.getTopRowFactory(getApplicationContext()).getAllAddOns(),
-                10,
+                11,
                 KeyboardExtension.TYPE_TOP);
         assertBasicListDetails(
                 AnyApplication.getKeyboardExtensionFactory(getApplicationContext()).getAllAddOns(),


### PR DESCRIPTION
This PR adds a new variant of the `Navigation keys alternative` top row with no numbers row on password mode. This is to make it compatible with the  the new coming PR: [2207](https://github.com/AnySoftKeyboard/AnySoftKeyboard/pull/2207)

It also removes emoji on long press on the space bar for the `Minimal` generic bottom row as this bottom row already has an emoji key.