### PR TITLE
German Dvorak Compact Layout

### DIFF
--- a/addons/languages/german/pack/src/main/res/values-de/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values-de/german_pack_strings_dont_translate.xml
@@ -12,4 +12,5 @@
     <string name="de_keyboard_qwerty_broad">Deutsch QWERTY breit</string>
     <string name="de_keyboard_qwerty_extra">Deutsch QWERTY breit+</string>
     <string name="de_keyboard_qwerty_slim">Deutsch QWERTY slim</string>
+    <string name="de_keyboard_dvorak_compact">DE Dv Compact</string>
 </resources>

--- a/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -23,7 +23,7 @@
     <string name="de_keyboard_neo2_simple">German neo2 simple</string>
     <string name="de_keyboard_adnw">German adnw</string>
     <string name="de_keyboard_adnw_description">Aus der Neo Welt (Christoph Bauer)</string>
-    <string name="de_keyboard_dvorak_compact">German Dv-c</string>
+    <string name="de_keyboard_dvorak_compact">DE Dv Compact</string>
     <string name="de_keyboard_dvorak_compact_description">German version of Dvorak compact, two letters per button, for Wurstfinger</string>
            
 </resources>

--- a/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -23,4 +23,7 @@
     <string name="de_keyboard_neo2_simple">German neo2 simple</string>
     <string name="de_keyboard_adnw">German adnw</string>
     <string name="de_keyboard_adnw_description">Aus der Neo Welt (Christoph Bauer)</string>
+    <string name="de_keyboard_dvorak_compact">German Dv-c</string>
+    <string name="de_keyboard_dvorak_compact_description">German version of Dvorak compact, two letters per button, for Wurstfinger</string>
+           
 </resources>

--- a/addons/languages/german/pack/src/main/res/xml/de_dvorak_compact.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_dvorak_compact.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="20%p">
+
+    <!-- Left hand of the Dvorak layout. Primaries: home-row, secondaries: bottom-row -->
+    <Row>
+        <Key android:codes="97" android:keyLabel="a" android:popupCharacters="ä@" android:keyEdgeFlags="left"/>
+        <Key android:codes="111,113" android:keyLabel="oq" android:popupCharacters="ö"/>
+        <Key android:codes="101,106" android:keyLabel="ej" android:popupCharacters="€"/>
+        <Key android:codes="105,107" android:keyLabel="ik"/>
+        <Key android:codes="117,120" android:keyLabel="ux" android:popupCharacters="ü" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <!-- Right hand of the Dvorak layout. Primaries: home-row, secondaries: bottom-row -->
+    <Row>
+        <Key android:codes="104,98" android:keyLabel="hb" android:keyEdgeFlags="left"/>
+        <Key android:codes="100,109" android:keyLabel="dm"/>
+        <Key android:codes="114,119" android:keyLabel="rw"/>
+        <Key android:codes="110,118" android:keyLabel="nv"/>
+        <Key android:codes="115,122" android:keyLabel="sz" android:popupCharacters="ß" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <!-- Top-row of the Dvorak layout. -->
+    <Row>
+        <Key android:keyWidth="15%p" android:codes="-1"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:horizontalGap="5%p"
+             android:keyWidth="15%p" android:codes="112,121" android:keyLabel="py"/>
+        <Key android:keyWidth="15%p" android:codes="102,103" android:keyLabel="fg"/>
+        <Key android:keyWidth="15%p" android:codes="99,116" android:keyLabel="ct"/>
+        <Key android:keyWidth="15%p" android:codes="108" android:keyLabel="l"/>
+        <Key android:horizontalGap="5%p"
+             android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -100,4 +100,14 @@
         layoutResId="@xml/de_adnw"
         nameResId="@string/de_keyboard_adnw"
         physicalKeyboardMappingResId="@xml/german_neo2_physical" />
+    <Keyboard
+        defaultDictionaryLocale="de"
+        defaultEnabled="false"
+        description="@string/de_dvorak_compact_description"
+        iconResId="@drawable/ic_status_german"
+        id="7132bd21-0932-49c7-9306-c06cfec89dda"
+        index="11"
+        layoutResId="@xml/de_dvorak_compact"
+        nameResId="@string/de_dvorak_compact"
+        physicalKeyboardMappingResId="@xml/german_physical" />
 </Keyboards>

--- a/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -103,11 +103,11 @@
     <Keyboard
         defaultDictionaryLocale="de"
         defaultEnabled="false"
-        description="@string/de_dvorak_compact_description"
+        description="@string/de_keyboard_dvorak_compact_description"
         iconResId="@drawable/ic_status_german"
         id="7132bd21-0932-49c7-9306-c06cfec89dda"
         index="11"
         layoutResId="@xml/de_dvorak_compact"
-        nameResId="@string/de_dvorak_compact"
+        nameResId="@string/de_keyboard_dvorak_compact"
         physicalKeyboardMappingResId="@xml/german_physical" />
 </Keyboards>


### PR DESCRIPTION
Hello,
I tweaked this nice English Dvorak-Compact layout into a German Layout.
Unfortunately, I am not a developer, so I apologise for my mistakes upfront. 
I am more a power user and tried my best at "copy&paste" :)

All what I did was:
-copy En Dv Compact to the german addons folder with an unique name,
-update german_keyboards.xml
-update lists with strings

Would it be possible to merge this, as it is, in the master branch?
Feedback appreciated!