### PR TITLE
Include Bulgarian (enhanced) keyboard, proposed by group of 500 people in May 2020.

### DIFF
--- a/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
+++ b/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
@@ -1,5 +1,5 @@
 Bulgarian layouts and dictionary for AnySoftKeyboard keyboard app.
-Includes BDS and Phonetic layouts.
+Includes BDS, BEKL and Phonetic layouts.
 
 This is an expansion layouts pack for AnySoftKeyboard.
 Install AnySoftKeyboard first, and then select the desired layout from AnySoftKeyboard's Settings->Keyboards menu.

--- a/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
+++ b/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
@@ -1,5 +1,0 @@
-Bulgarian layouts and dictionary for AnySoftKeyboard keyboard app.
-Includes BDS, BEKL and Phonetic layouts.
-
-This is an expansion layouts pack for AnySoftKeyboard.
-Install AnySoftKeyboard first, and then select the desired layout from AnySoftKeyboard's Settings->Keyboards menu.

--- a/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
+++ b/addons/languages/bulgarian/apk/src/main/play/listings/en-US/full-description.txt
@@ -1,0 +1,5 @@
+Bulgarian layouts and dictionary for AnySoftKeyboard keyboard app.
+Includes BDS, BEKL and Phonetic layouts.
+
+This is an expansion layouts pack for AnySoftKeyboard.
+Install AnySoftKeyboard first, and then select the desired layout from AnySoftKeyboard's Settings->Keyboards menu.

--- a/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
@@ -10,7 +10,7 @@
 
     <string name="bulgarian_keyboard_bds">Bulgarian BDS</string>
     <string name="bulgarian_keyboard_bds_description">Bulgarian BDS keyboard</string>
-	
+
     <string name="bulgarian_keyboard_bekl">Bulgarian BEKL</string>
     <string name="bulgarian_keyboard_bekl_description">Bulgarian BEKL keyboard</string>
 </resources>

--- a/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
@@ -10,4 +10,7 @@
 
     <string name="bulgarian_keyboard_bds">Bulgarian BDS</string>
     <string name="bulgarian_keyboard_bds_description">Bulgarian BDS keyboard</string>
+	
+    <string name="bulgarian_keyboard_bekl">Bulgarian BEKL</string>
+    <string name="bulgarian_keyboard_bekl_description">Bulgarian BEKL keyboard</string>
 </resources>

--- a/addons/languages/bulgarian/pack/src/main/res/xml/bekl.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/xml/bekl.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="8.3%p"
+    android:keyHeight="@integer/key_normal_height">
+    <Row>
+        <Key android:horizontalGap="4.35%p"
+             android:codes="ѫ" android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="у" android:popupCharacters=""/>
+        <Key android:codes="е" android:popupCharacters=""/>
+        <Key android:codes="и" android:popupCharacters="ѝ"/>
+        <Key android:codes="ш" android:popupCharacters=""/>
+        <Key android:codes="щ" android:popupCharacters=""/>
+        <Key android:codes="к" android:popupCharacters=""/>
+        <Key android:codes="с" android:popupCharacters=""/>
+        <Key android:codes="д" android:popupCharacters=""/>
+        <Key android:codes="з" android:popupCharacters=""/>
+        <Key android:codes="ц" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:horizontalGap="4.35%p"
+             android:codes="ь" android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="я" android:popupCharacters=""/>
+        <Key android:codes="а" android:popupCharacters=""/>
+        <Key android:codes="о" android:popupCharacters=""/>
+        <Key android:codes="ж" android:popupCharacters=""/>
+        <Key android:codes="г" android:popupCharacters=""/>
+        <Key android:codes="т" android:popupCharacters=""/>
+        <Key android:codes="н" android:popupCharacters=""/>
+        <Key android:codes="в" android:popupCharacters=""/>
+        <Key android:codes="м" android:popupCharacters=""/>
+        <Key android:codes="ч" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1"
+             android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="ю" android:popupCharacters=""/>
+        <Key android:codes="й" android:popupCharacters="ѭ"/>
+        <Key android:codes="ъ" android:popupCharacters=""/>
+        <Key android:codes="ѣ" android:popupCharacters=""/>
+        <Key android:codes="ф" android:popupCharacters=""/>
+        <Key android:codes="х" android:popupCharacters=""/>
+        <Key android:codes="п" android:popupCharacters=""/>
+        <Key android:codes="р" android:popupCharacters=""/>
+        <Key android:codes="л" android:popupCharacters=""/>
+        <Key android:codes="б" android:popupCharacters=""/>
+        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/bulgarian/pack/src/main/res/xml/bulgarian_keyboards.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/xml/bulgarian_keyboards.xml
@@ -10,4 +10,9 @@
               defaultDictionaryLocale="bg" description="@string/bulgarian_keyboard_bds_description"
               index="2" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/bulgarian_physical" />
+    <Keyboard nameResId="@string/bulgarian_keyboard_bekl" iconResId="@drawable/ic_status_bulgarian"
+              layoutResId="@xml/bekl" id="498c9088-bde5-4e67-b318-5a247505ff27"
+              defaultDictionaryLocale="bg" description="@string/bulgarian_keyboard_bekl_description"
+              index="3" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/bulgarian_physical" />
 </Keyboards>


### PR DESCRIPTION
An enhanced variant of the Bulgarian BDS keyboard, proposed in May 2020 by a group of more than 500 linguists, teachers, writers, translators, IT specialists, professors and many more.