### PR TITLE
Avoid "jacoco.exec: open failed: EROFS (Read-only file system)

### DIFF
--- a/ime/app/src/main/resources/jacoco-agent.properties
+++ b/ime/app/src/main/resources/jacoco-agent.properties
@@ -1,0 +1,1 @@
+destfile=/sdcard/Android/data/com.menny.android.anysoftkeyboard/files/jacoco.exec


### PR DESCRIPTION
The text in the commit is all I know. I'm not really all that familiar with Jacoco.

It's a problem I only found lately and seems to be caused by an upgrade in Jacoco. While I was typing, AnySoftKeyboard would randomly stop responding, but stay painted on the screen for 10 or 15 seconds (blocking the lower half of the screen), then close itself. Opening a logcat always showed the same error:
```
java.io.FileNotFoundException: /jacoco.exec: open failed: EROFS (Read-only file system)
```

(I neglected to save the rest of the logcat.)

I looked online for possible fixes to this problem and this solution seems to work, at least in my device. The file `jacoco.exec` is written in the same folder configuration files are exported to.