### PR TITLE
Removed duplicate smiley categories

### DIFF
--- a/ime/app/src/main/res/xml-v22/quick_text_keys.xml
+++ b/ime/app/src/main/res/xml-v22/quick_text_keys.xml
@@ -136,15 +136,6 @@
         description=""
         index="15"/>
     <QuickTextKey
-        id="0077b34d-770f-4083-83e4-081957e06c27"
-        nameResId="@string/simley_key_name"
-        popupKeyboard="@xml/popup_smileys"
-        keyIcon="@drawable/ic_quick_text_dark_theme"
-        keyLabel="@string/quick_text_smiley_key_label"
-        keyOutputText="@string/quick_text_smiley_key_output"
-        description=""
-        index="15"/>
-    <QuickTextKey
         id="085020ea-f496-4c0c-80cb-45ca50635c59"
         nameResId="@string/short_smiley_key_name"
         popupKeyboard="@xml/popup_smileys_short"

--- a/ime/app/src/main/res/xml-v24/quick_text_keys.xml
+++ b/ime/app/src/main/res/xml-v24/quick_text_keys.xml
@@ -127,15 +127,6 @@
         description=""
         index="15"/>
     <QuickTextKey
-        id="0077b34d-770f-4083-83e4-081957e06c27"
-        nameResId="@string/simley_key_name"
-        popupKeyboard="@xml/popup_smileys"
-        keyIcon="@drawable/ic_quick_text_dark_theme"
-        keyLabel="@string/quick_text_smiley_key_label"
-        keyOutputText="@string/quick_text_smiley_key_output"
-        description=""
-        index="15"/>
-    <QuickTextKey
         id="085020ea-f496-4c0c-80cb-45ca50635c59"
         nameResId="@string/short_smiley_key_name"
         popupKeyboard="@xml/popup_smileys_short"


### PR DESCRIPTION
In smileys categories, there was the same twice. 
This is now fixed.
Explanation picture: 

![20200726_111303](https://user-images.githubusercontent.com/42534397/88654181-4c961a00-d0cd-11ea-92ef-10b6b24bc8a7.jpg)
