### PR TITLE
 Customize symbol keyboards and switch keys 

### DIFF
--- a/addons/languages/english/pack/build.gradle
+++ b/addons/languages/english/pack/build.gradle
@@ -4,3 +4,5 @@ ext.dictionaryInputPossibleCharacters = null//"".toCharArray()
 ext.dictionaryInputAdditionalInnerCharacters = null//"".toCharArray()
 
 apply from: "$rootDir/addons/gradle/language_pack_lib.gradle"
+
+tasks.named('spotlessYaml').get().dependsOn('makeDictionary')

--- a/gradle/root_all_projects_ext.gradle
+++ b/gradle/root_all_projects_ext.gradle
@@ -3,7 +3,7 @@ allprojects {
         androidBuildTools = '34.0.0'
         robolectricVersion = '4.10.3'
 
-        sideBySideNdkVersion = '23.0.7599858'
+        sideBySideNdkVersion = '25.1.8937393'
 
         sdkTargetVersion = 33
         sdkCompileVersion = 34

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewBase.java
@@ -1032,6 +1032,9 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
     mSwipeYDistanceThreshold = mSwipeYDistanceThreshold / 2;
   }
 
+  // Remember last used alphabet keyboard
+  private String mLastAlphabetKbId;
+
   /**
    * Returns the current keyboard being displayed by this view.
    *
@@ -1050,6 +1053,16 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
     if (TextUtils.isEmpty(mNextAlphabetKeyboardName)) {
       mNextAlphabetKeyboardName = getResources().getString(R.string.change_lang_regular);
     }
+
+    // If mirfatif alphabet keyboard name is longer than 4 characters, truncate it to 3
+    if (mirfatifKeyboard(mLastAlphabetKbId) && mNextAlphabetKeyboardName.length() > 4) {
+      mNextAlphabetKeyboardName = mNextAlphabetKeyboardName.subSequence(0, 3);
+    }
+    // Remember alphabet keyboard in use
+    if (!(currentKeyboard instanceof GenericKeyboard)) {
+      mLastAlphabetKbId = currentKeyboard.getKeyboardId();
+    }
+
     mNextSymbolsKeyboardName = nextSymbolsKeyboard;
     if (TextUtils.isEmpty(mNextSymbolsKeyboardName)) {
       mNextSymbolsKeyboardName = getResources().getString(R.string.change_symbols_regular);
@@ -2280,5 +2293,12 @@ public class AnyKeyboardViewBase extends View implements InputViewBinder, Pointe
           && ((TextWidthCacheKey) o).mKeyWidth == mKeyWidth
           && TextUtils.equals(((TextWidthCacheKey) o).mLabel, mLabel);
     }
+  }
+
+  // If it's one of mirfatif keyboards
+  private boolean mirfatifKeyboard(String keyboardId) {
+    return keyboardId != null
+        && (keyboardId.equals(getContext().getString(R.string.mirfatif_qwerty_with_symbols_guid))
+            || keyboardId.equals(getContext().getString(R.string.urdu_keyboard_with_symbols_guid)));
   }
 }

--- a/ime/app/src/main/res/values/mirfatif_strings.xml
+++ b/ime/app/src/main/res/values/mirfatif_strings.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="TypographyDashes">
+  <string name="mirfatif_symbols_keyboard" tools:ignore="MissingTranslation">\?123</string>
+  <string name="mirfatif_symbols_alt_keyboard" tools:ignore="MissingTranslation">Sym</string>
+
+  <!-- same in addons/languages/urdu/pack/src/main/res/values/urdu_pack_strings.xml -->
+  <string name="urdu_keyboard_with_symbols_guid" translatable="false">37F7188B-6FA1-442B-BF0F-6D8671C12808</string>
+
+  <!-- same in addons/languages/english/pack/src/main/res/values/mirfatif_strings.xml -->
+  <string name="mirfatif_qwerty_with_symbols_guid" translatable="false">9C0DF88B-5BED-4953-B988-E608F3A4F167</string>
+</resources>

--- a/ime/app/src/main/res/xml/mirfatif_simple_numbers.xml
+++ b/ime/app/src/main/res/xml/mirfatif_simple_numbers.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:ask="http://schemas.android.com/apk/res-auto"
+  android:keyHeight="@integer/key_normal_height"
+  android:keyWidth="25%p"
+  ask:showPreview="false">
+
+  <Row android:rowEdgeFlags="top">
+    <Key
+      android:codes="\1"
+      android:keyEdgeFlags="left" />
+    <Key android:codes="\2" />
+    <Key android:codes="\3" />
+    <Key
+      android:codes="."
+      android:keyEdgeFlags="right"
+      android:keyLabel=". )"
+      android:popupCharacters=",()"
+      ask:hintLabel=" " />
+  </Row>
+
+  <Row>
+    <Key
+      android:codes="\4"
+      android:keyEdgeFlags="left" />
+    <Key android:codes="\5" />
+    <Key android:codes="\6" />
+    <Key
+      android:codes="@integer/key_code_space"
+      android:isRepeatable="true"
+      android:keyEdgeFlags="right" />
+  </Row>
+
+  <Row>
+    <Key
+      android:codes="\7"
+      android:keyEdgeFlags="left" />
+    <Key android:codes="\8" />
+    <Key android:codes="\9" />
+    <Key
+      android:codes="@integer/key_code_delete"
+      android:isRepeatable="true"
+      android:keyEdgeFlags="right" />
+  </Row>
+
+  <Row android:rowEdgeFlags="bottom">
+    <Key
+      android:codes="42"
+      android:keyEdgeFlags="left"
+      android:keyLabel="* /"
+      ask:longPressCode="47" />
+    <Key android:codes="\0" />
+    <Key
+      android:codes="+"
+      android:keyLabel="+ -"
+      ask:longPressCode="45" />
+    <Key
+      android:codes="@integer/key_code_enter"
+      android:keyEdgeFlags="right"
+      ask:longPressCode="@integer/key_code_settings" />
+  </Row>
+
+</Keyboard>

--- a/ime/app/src/main/res/xml/mirfatif_simple_phone.xml
+++ b/ime/app/src/main/res/xml/mirfatif_simple_phone.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:ask="http://schemas.android.com/apk/res-auto"
+  android:keyHeight="@integer/key_normal_height"
+  android:keyWidth="25%p"
+  ask:showPreview="false">
+
+  <Row android:rowEdgeFlags="top">
+    <Key
+      android:codes="\1"
+      android:keyEdgeFlags="left"
+      android:keyIcon="@drawable/sym_keyboard_num1" />
+    <Key
+      android:codes="\2"
+      android:keyIcon="@drawable/sym_keyboard_num2" />
+    <Key
+      android:codes="\3"
+      android:keyIcon="@drawable/sym_keyboard_num3" />
+    <Key
+      android:codes="."
+      android:keyEdgeFlags="right"
+      android:keyLabel=". )"
+      android:popupCharacters=",()"
+      ask:hintLabel=" " />
+  </Row>
+
+  <Row>
+    <Key
+      android:codes="\4"
+      android:keyEdgeFlags="left"
+      android:keyIcon="@drawable/sym_keyboard_num4" />
+    <Key
+      android:codes="\5"
+      android:keyIcon="@drawable/sym_keyboard_num5" />
+    <Key
+      android:codes="\6"
+      android:keyIcon="@drawable/sym_keyboard_num6" />
+    <Key
+      android:codes="@integer/key_code_space"
+      android:keyEdgeFlags="right"
+      android:popupCharacters=";N"
+      ask:hintLabel=" " />
+  </Row>
+
+  <Row>
+    <Key
+      android:codes="\7"
+      android:keyEdgeFlags="left"
+      android:keyIcon="@drawable/sym_keyboard_num7" />
+    <Key
+      android:codes="\8"
+      android:keyIcon="@drawable/sym_keyboard_num8" />
+    <Key
+      android:codes="\9"
+      android:keyIcon="@drawable/sym_keyboard_num9" />
+    <Key
+      android:codes="@integer/key_code_delete"
+      android:isRepeatable="true"
+      android:keyEdgeFlags="right" />
+  </Row>
+
+  <Row android:rowEdgeFlags="bottom">
+    <!-- * / -->
+    <Key
+      android:codes="42"
+      android:keyEdgeFlags="left"
+      ask:longPressCode="47" />
+    <Key
+      android:codes="\0"
+      android:keyIcon="@drawable/sym_keyboard_num0"
+      ask:longPressCode="43" />
+    <!-- # - -->
+    <Key
+      android:codes="35"
+      ask:longPressCode="45" />
+    <Key
+      android:codes="@integer/key_code_enter"
+      android:keyEdgeFlags="right"
+      ask:longPressCode="@integer/key_code_settings" />
+  </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/mirfatif_symbols.xml
+++ b/ime/app/src/main/res/xml/mirfatif_symbols.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p"
+    android:keyHeight="@integer/key_normal_height">
+
+    <!-- Top row -->
+    <Row android:rowEdgeFlags="top">
+        <Key
+            android:codes="@integer/key_code_esc"
+            android:keyEdgeFlags="left"
+            android:keyLabel="Esc"
+            ask:isFunctional="true" />
+        <Key android:codes="@integer/key_code_tab" />
+        <Key
+            android:codes="@integer/key_code_ctrl"
+            android:isModifier="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_left"
+            android:horizontalGap="5%p"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_up"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_down"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_right"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_move_home"
+            android:horizontalGap="5%p"
+            android:keyLabel="Hom"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_move_end"
+            android:keyEdgeFlags="right"
+            android:keyLabel="End"
+            ask:isFunctional="true" />
+    </Row>
+
+    <Row>
+        <Key
+            android:codes="\1"
+            android:keyEdgeFlags="left"
+            android:popupKeyboard="@xml/mirfatif_symbols_one"
+            ask:hintLabel="½" />
+        <Key
+            android:codes="\2"
+            android:popupCharacters="⅔⅖²₂"
+            ask:hintLabel="⅔" />
+        <Key
+            android:codes="\3"
+            android:popupCharacters="¾⅗⅜³₃"
+            ask:hintLabel="¾" />
+        <Key
+            android:codes="\4"
+            android:popupCharacters="⅘⁴₄"
+            ask:hintLabel="⅘" />
+        <Key
+            android:codes="\5"
+            android:popupCharacters="⅚⅝⁵₅"
+            ask:hintLabel="⅚" />
+        <Key
+            android:codes="\6"
+            android:popupCharacters="⁶₆"
+            ask:hintLabel="₆" />
+        <Key
+            android:codes="\7"
+            android:popupCharacters="⅞⁷₇"
+            ask:hintLabel="⅞" />
+        <Key
+            android:codes="\8"
+            android:popupCharacters="⁸₈∞"
+            ask:hintLabel="₈" />
+        <Key
+            android:codes="\9"
+            android:popupCharacters="⁹₉"
+            ask:hintLabel="₉" />
+        <Key
+            android:codes="\0"
+            android:keyEdgeFlags="right"
+            android:popupCharacters="⁰₀°ⁿ"
+            ask:hintLabel="₀" />
+    </Row>
+    <Row>
+        <Key
+            android:codes="\@"
+            android:horizontalGap="5%p"
+            android:keyEdgeFlags="left" />
+
+        <!-- Bitcoin sign (₿) not supported by many yet -->
+        <Key
+            android:codes="@integer/default_currency_sign_unicode"
+            android:popupCharacters="₨£€₽¥¢₹₿"
+            ask:hintLabel="₨" />
+        <Key
+            android:codes="#"
+            android:popupCharacters="№" />
+        <Key
+            android:codes="%"
+            android:popupCharacters="^‰℅"
+            ask:hintLabel="^" />
+        <Key
+            android:codes="&amp;"
+            android:popupCharacters="←↑↓→"
+            ask:hintLabel="←" />
+        <Key
+            android:codes="`"
+            android:popupCharacters="~´‴⁗"
+            ask:hintLabel="~" />
+        <Key
+            android:codes="("
+            android:popupCharacters="[{&lt;≤‹«⟨"
+            ask:hintLabel="[" />
+        <Key
+            android:codes=")"
+            android:popupCharacters="]}&gt;≥›»⟩"
+            ask:hintLabel="]" />
+        <Key
+            android:codes="_"
+            android:keyLabel="_" />
+    </Row>
+    <Row>
+        <Key
+            android:codes="@integer/key_code_mode_symbols"
+            android:keyWidth="15%p"
+            android:keyEdgeFlags="left" />
+        <Key
+            android:codes="/"
+            android:popupCharacters="÷∕̸̷√"
+            ask:hintLabel="÷" />
+        <Key
+            android:codes="*"
+            android:popupCharacters="×·∗†‡★"
+            ask:hintLabel="×" />
+        <Key
+            android:codes="-"
+            android:popupCharacters="–—−"
+            ask:hintLabel="–" />
+        <Key
+            android:codes="+"
+            android:popupKeyboard="@xml/mirfatif_symbols_equal"
+            ask:hintLabel="=" />
+        <Key
+            android:codes="\\"
+            android:popupCharacters="|¦‖"
+            ask:hintLabel="|" />
+        <Key
+            android:codes=";"
+            android:popupCharacters=":"
+            ask:hintLabel=":" />
+        <Key
+            android:codes="\?"
+            android:popupCharacters="!‽⸮¿¡"
+            ask:hintLabel="!" />
+        <Key
+            android:codes="@integer/key_code_delete"
+            android:isRepeatable="true"
+            android:keyWidth="15%p"
+            android:keyEdgeFlags="right" />
+    </Row>
+
+    <!-- Bottom row -->
+    <Row android:rowEdgeFlags="bottom">
+
+        <Key
+            android:codes="@integer/key_code_keyboard_mode_change"
+            android:keyWidth="12.5%p"
+            android:keyEdgeFlags="left"
+            ask:isFunctional="true"
+            ask:keyDynamicEmblem="icon"
+            ask:longPressCode="@integer/key_code_mode_alphabet_popup" />
+
+        <!-- comma -->
+        <Key
+            android:codes="44"
+            android:popupCharacters="„"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="@integer/key_code_quick_text_popup"
+            ask:isFunctional="true"
+            ask:longPressCode="@integer/key_code_quick_text" />
+
+        <Key
+            android:codes="@integer/key_code_space"
+            android:keyWidth="35%p"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="&quot;"
+            android:popupCharacters="\'“”‘’"
+            ask:hintLabel="\'"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="."
+            android:popupCharacters="…⋯"
+            ask:hintLabel="…"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="@integer/key_code_enter"
+            android:keyWidth="12.5%p"
+            android:keyEdgeFlags="right"
+            ask:isFunctional="true"
+            ask:longPressCode="@integer/key_code_settings" />
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/mirfatif_symbols_alt.xml
+++ b/ime/app/src/main/res/xml/mirfatif_symbols_alt.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p"
+    android:keyHeight="@integer/key_normal_height"
+    ask:showPreview="false">
+
+    <!-- Top row -->
+    <Row android:rowEdgeFlags="top">
+        <Key
+            android:codes="@integer/key_code_esc"
+            android:keyEdgeFlags="left"
+            android:keyLabel="Esc"
+            ask:isFunctional="true" />
+        <Key android:codes="@integer/key_code_tab" />
+        <Key
+            android:codes="@integer/key_code_ctrl"
+            android:isModifier="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_left"
+            android:horizontalGap="5%p"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_up"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_down"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_arrow_right"
+            android:isRepeatable="true"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_move_home"
+            android:horizontalGap="5%p"
+            android:keyLabel="Hom"
+            ask:isFunctional="true" />
+        <Key
+            android:codes="@integer/key_code_move_end"
+            android:keyEdgeFlags="right"
+            android:keyLabel="End"
+            ask:isFunctional="true" />
+    </Row>
+
+    <Row>
+        <Key
+            android:codes="~"
+            android:keyEdgeFlags="left"
+            android:popupCharacters="`" />
+        <Key
+            android:codes="!"
+            android:popupCharacters="#" />
+        <Key
+            android:codes="$"
+            android:popupCharacters="%" />
+        <Key
+            android:codes="^"
+            android:popupCharacters="&amp;" />
+        <Key
+            android:codes="®"
+            android:popupCharacters="©" />
+        <Key android:codes="™" />
+        <Key android:codes="{" />
+        <Key android:codes="}" />
+        <Key android:codes="[" />
+        <Key
+            android:codes="]"
+            android:keyEdgeFlags="right" />
+    </Row>
+
+    <Row>
+        <Key
+            android:codes="←"
+            android:horizontalGap="5%p"
+            android:keyEdgeFlags="left" />
+        <Key android:codes="↑" />
+        <Key android:codes="→" />
+        <Key
+            android:codes="✔"
+            android:popupCharacters="✘" />
+        <Key
+            android:codes="&lt;"
+            android:popupCharacters="≤" />
+        <Key
+            android:codes="&gt;"
+            android:popupCharacters="≥" />
+        <Key
+            android:codes="‹"
+            android:popupCharacters="«" />
+        <Key
+            android:codes="›"
+            android:popupCharacters="»" />
+        <Key
+            android:codes="¦"
+            android:popupCharacters="‖" />
+    </Row>
+
+    <Row>
+        <Key
+            android:codes="@integer/key_code_mode_symbols"
+            android:keyWidth="15%p"
+            android:keyEdgeFlags="left" />
+        <Key android:codes="↓" />
+        <Key
+            android:codes="“"
+            android:popupCharacters="‘" />
+        <Key
+            android:codes="”"
+            android:popupCharacters="’" />
+        <Key android:codes="=" />
+        <Key android:codes="|" />
+        <Key android:codes=":" />
+        <Key android:codes="\'" />
+        <Key
+            android:codes="@integer/key_code_delete"
+            android:isRepeatable="true"
+            android:keyWidth="15%p"
+            android:keyEdgeFlags="right" />
+    </Row>
+
+    <!-- Bottom row -->
+    <Row android:rowEdgeFlags="bottom">
+
+        <Key
+            android:codes="@integer/key_code_keyboard_mode_change"
+            android:keyWidth="12.5%p"
+            android:keyEdgeFlags="left"
+            ask:isFunctional="true"
+            ask:keyDynamicEmblem="icon"
+            ask:longPressCode="@integer/key_code_mode_alphabet_popup" />
+
+        <!-- comma -->
+        <Key
+            android:codes="44"
+            android:popupCharacters="„"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="@integer/key_code_quick_text_popup"
+            ask:isFunctional="true"
+            ask:longPressCode="@integer/key_code_quick_text" />
+
+        <Key
+            android:codes="@integer/key_code_space"
+            android:keyWidth="35%p"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="&quot;"
+            android:popupCharacters="\'“”‘’"
+            ask:hintLabel="\'"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="."
+            android:popupCharacters="…⋯"
+            ask:hintLabel="…"
+            ask:isFunctional="true" />
+
+        <Key
+            android:codes="@integer/key_code_enter"
+            android:keyWidth="12.5%p"
+            android:keyEdgeFlags="right"
+            ask:isFunctional="true"
+            ask:longPressCode="@integer/key_code_settings" />
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/mirfatif_symbols_equal.xml
+++ b/ime/app/src/main/res/xml/mirfatif_symbols_equal.xml
@@ -1,0 +1,16 @@
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row>
+        <Key android:codes="≗" />
+        <Key android:codes="≙" />
+        <Key android:codes="≡" />
+        <Key android:codes="≢" />
+        <Key android:codes="≣" />
+    </Row>
+    <Row>
+        <Key android:codes="=" />
+        <Key android:codes="±" />
+        <Key android:codes="≠" />
+        <Key android:codes="≈" />
+        <Key android:codes="≘" />
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/xml/mirfatif_symbols_one.xml
+++ b/ime/app/src/main/res/xml/mirfatif_symbols_one.xml
@@ -1,0 +1,19 @@
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row>
+        <Key android:codes="⅒" />
+        <Key android:codes="¹" />
+        <Key android:codes="₁" />
+    </Row>
+    <Row>
+        <Key android:codes="⅙" />
+        <Key android:codes="⅐" />
+        <Key android:codes="⅛" />
+        <Key android:codes="⅑" />
+    </Row>
+    <Row>
+        <Key android:codes="½" />
+        <Key android:codes="⅓" />
+        <Key android:codes="¼" />
+        <Key android:codes="⅕" />
+    </Row>
+</Keyboard>


### PR DESCRIPTION
1. Always show mirfatif symbol keyboards with mirfatif alphabet keyboards
2. Modified labels for symbol keyboard switch keys for mirfatif keyboards
3. Truncate mirfatif alphabet keyboard name to 3 if is longer than 4 characters

Fit better with my customized QWERTY keyboard and Urdu keyboard.
Collectively they provide a uniform experience: https://github.com/mirfatif/AnySoftKeyboard/blob/master/english_urdu.gif
Doesn't affect other keyboards.

`scripts/ci/ci_check.sh` and `./gradlew testDebugUnitTest` pass.
No tabs in code.