### PR TITLE
Make backword remove trailing spaces

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -913,12 +913,12 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         // then when the user press backspace (for some reason),
         // the entire previous word deletes.
 
-        // 2) Or we delete all the characters till we encounter a separator, but
-        // delete at least one character.
+        // 2) Or we delete all whitespaces and then all the characters
+        // till we encounter a separator, but delete at least one character.
         /*
-         * What to do: We delete until we find a separator (the function
-         * isBackWordDeleteCodePoint). Note that we MUST delete a delete at least one
-         * character "test this, " -> "test this," -> "test this" -> "test "
+         * What to do: We first delete all whitespaces, and then we delete until we find
+         * a separator (the function isBackWordDeleteCodePoint).
+         * Note that we MUST delete at least one character "test this, " -> "test this" -> "test "
          */
         // Pro: Supports auto-caps, and mostly similar to desktop OSes
         // Con: Not all desktop use-cases are here.
@@ -931,10 +931,18 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         int idx = inputLength;
         int lastCodePoint = Character.codePointBefore(cs, idx);
         // This while-loop isn't guaranteed to run even once...
-        while (isBackWordDeleteCodePoint(lastCodePoint)) {
+        while (Character.isWhitespace(lastCodePoint)) {
             idx -= Character.charCount(lastCodePoint);
             if (idx == 0) break;
             lastCodePoint = Character.codePointBefore(cs, idx);
+        }
+        if (idx > 0) {
+            // This while-loop also isn't guaranteed to run even once...
+            while (isBackWordDeleteCodePoint(lastCodePoint)) {
+                idx -= Character.charCount(lastCodePoint);
+                if (idx == 0) break;
+                lastCodePoint = Character.codePointBefore(cs, idx);
+            }
         }
         // but we're supposed to delete at least one Unicode codepoint.
         if (idx == inputLength) {

--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -930,16 +930,17 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
         final int inputLength = cs.length();
         int idx = inputLength;
         int lastCodePoint = Character.codePointBefore(cs, idx);
-        // This while-loop isn't guaranteed to run even once...
+        // First delete all trailing whitespaces, if there are any...
         while (Character.isWhitespace(lastCodePoint)) {
             idx -= Character.charCount(lastCodePoint);
             if (idx == 0) break;
             lastCodePoint = Character.codePointBefore(cs, idx);
         }
+        // If there is still something left to delete...
         if (idx > 0) {
             final int remainingLength = idx;
 
-            // This while-loop also isn't guaranteed to run even once...
+            // This while-loop isn't guaranteed to run even once...
             while (isBackWordDeleteCodePoint(lastCodePoint)) {
                 idx -= Character.charCount(lastCodePoint);
                 if (idx == 0) break;

--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -937,16 +937,19 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
             lastCodePoint = Character.codePointBefore(cs, idx);
         }
         if (idx > 0) {
+            final int remainingLength = idx;
+
             // This while-loop also isn't guaranteed to run even once...
             while (isBackWordDeleteCodePoint(lastCodePoint)) {
                 idx -= Character.charCount(lastCodePoint);
                 if (idx == 0) break;
                 lastCodePoint = Character.codePointBefore(cs, idx);
             }
-        }
-        // but we're supposed to delete at least one Unicode codepoint.
-        if (idx == inputLength) {
-            idx -= Character.charCount(lastCodePoint);
+
+            // but we're supposed to delete at least one Unicode codepoint.
+            if (idx == remainingLength) {
+                idx -= Character.charCount(lastCodePoint);
+            }
         }
         ic.deleteSurroundingText(inputLength - idx, 0); // it is always > 0 !
     }

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -375,11 +375,6 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
 
-        Assert.assertEquals("Auto", inputConnection.getCurrentTextInInputConnection());
-
-        mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-
         Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
     }
 
@@ -396,11 +391,6 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
 
         Assert.assertEquals("Auto ", inputConnection.getCurrentTextInInputConnection());
-
-        mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
-
-        Assert.assertEquals("Auto", inputConnection.getCurrentTextInInputConnection());
 
         mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -254,8 +254,6 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
         Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
-        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
-        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
         Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
     }
 


### PR DESCRIPTION
This implements part of #1682 that is about removing trailing spaces before actually removing a word.

The intended effect:

```
Before: "test this, " -> "test this," -> "test this" -> "test "
After:  "test this, " -> "test this" -> "test "
```

This actually makes the code respect the example that is already specified in the comment in the current code on line 928, this one:

> // 2b) "test this, " -> "test this"

What do you think?