### PR TITLE
Bump compile and target SDKs to 29

### DIFF
--- a/gradle/root_all_projects_ext.gradle
+++ b/gradle/root_all_projects_ext.gradle
@@ -4,8 +4,8 @@ allprojects {
         supportLibVersion = '25.4.0'
         robolectricVersion = '4.3.1'
 
-        sdkTargetVersion = 28
-        sdkCompileVersion = 28
+        sdkTargetVersion = 29
+        sdkCompileVersion = 29
         sdkMinimumVersion = 9
 
         isCircleCi = 'true' == System.getenv("CIRCLECI")


### PR DESCRIPTION
So far, I'm able to run the app on API 29 and above without any crashes from the screens that I visited. Let me know if there' are specific things I need to check for this dump that I'm not aware of.

Here are sample screenshots of my tests so far.

| Screenshots 1 | Screenshots 2|
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/73175/97093019-1410c880-1649-11eb-99c3-c56bf2893bdf.gif" width="280" /> | <img src="https://user-images.githubusercontent.com/73175/97093032-27239880-1649-11eb-8edd-ce6cecb2f502.gif" width="280" /> |
| Screenshots 3 | Screenshots 4 |
| <img src="https://user-images.githubusercontent.com/73175/97093140-ccd70780-1649-11eb-8450-39a552b12904.gif" width="280" /> | <img src="https://user-images.githubusercontent.com/73175/97093340-50ddbf00-164b-11eb-89e5-bd2fa7fa59d5.gif" width=280 />|