### PR TITLE
add Long-S (ſ, U+017F) to all german keyboards

### DIFF
--- a/addons/languages/german/pack/src/main/res/xml/de_adnw.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_adnw.xml
@@ -56,7 +56,7 @@
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="(4νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="-6τ∂"/>
-    <Key android:codes="115" android:keyLabel="s" android:popupCharacters=":,δΔ"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters=":,δΔſ"/>
     <Key android:codes="223" android:keyLabel="ß" android:keyEdgeFlags="right" android:popupCharacters="\@.υ∇"/>
 </Row>
 <Row>

--- a/addons/languages/german/pack/src/main/res/xml/de_dvorak_compact.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_dvorak_compact.xml
@@ -18,7 +18,7 @@
         <Key android:codes="100,109" android:keyLabel="dm"/>
         <Key android:codes="114,119" android:keyLabel="rw"/>
         <Key android:codes="110,118" android:keyLabel="nv"/>
-        <Key android:codes="115,122" android:keyLabel="sz" android:popupCharacters="ß" android:keyEdgeFlags="right"/>
+        <Key android:codes="115,122" android:keyLabel="sz" android:popupCharacters="ßſ" android:keyEdgeFlags="right"/>
     </Row>
 
     <!-- Top-row of the Dvorak layout. -->

--- a/addons/languages/german/pack/src/main/res/xml/de_neo2.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_neo2.xml
@@ -52,7 +52,7 @@
     <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
     <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
-    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σΣ"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σΣſ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(4νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-6τ∂"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
@@ -50,7 +50,7 @@
     <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
     <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
-    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σ"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σſ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")ρℝ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-τ∂"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="9.09%p">
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßẞśŝš"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßẞśŝšſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_broad.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_broad.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="11.111%p">
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="ä" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§ſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_extra.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_extra.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="11.111%p">
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝš"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝšſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
@@ -20,7 +20,7 @@
     
     <Row>
         <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝš"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝšſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwertz.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwertz.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="9.09%p">
         <Key android:codes="97"  android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßẞśŝš"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßẞśŝšſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwertz_broad.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwertz_broad.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="11.111%p">
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="ä" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§ſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters=""/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters=""/>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwertz_extra.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwertz_extra.xml
@@ -20,7 +20,7 @@
     
     <Row android:keyWidth="11.111%p">
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="äàáâãåæą" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝš"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßẞ§śŝšſ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters=""/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>


### PR DESCRIPTION
I added the Long-S (ſ, U+017F) to all German keyboards as popup on s . This is very useful for people trying to distinguish Long-S from Round-S in old(-style) texts and communication. For all other people it should at least do no harm :) 

<del>P.S. I have no running build environment. "But what could possibly go wrong."<del>

[addons-languages-german-apk-1.zip](https://github.com/AnySoftKeyboard/AnySoftKeyboard/files/5471239/addons-languages-german-apk-1.zip)

CC: @xoomerq @nicoursi @chrbauer @thomaseizinger ; as all of you have edited the German pack.