### PR TITLE
add "ə" to Italian layout

### DIFF
--- a/addons/languages/italian/pack/src/main/res/xml/italian_qwerty_with_symbols.xml
+++ b/addons/languages/italian/pack/src/main/res/xml/italian_qwerty_with_symbols.xml
@@ -8,7 +8,7 @@
     <Row>
         <Key android:codes="q" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
-        <Key android:codes="e" android:popupCharacters="3€³₃êèéëęē" ask:hintLabel="3"/>
+        <Key android:codes="e" android:popupCharacters="3€³₃êèéëęēə" ask:hintLabel="3"/>
         <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
         <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
         <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>


### PR DESCRIPTION
Also done [here](https://github.com/rkkr/simple-keyboard/pull/214) and [here](https://github.com/dslul/openboard/pull/241).
A non-disruptive yet useful introduction for the communities using the schwa in [Italy](https://it.wikipedia.org/wiki/Scev%C3%A0#In_Italia) and in Italian. (several sources: [[0](https://globalvoices.org/2020/09/11/are-romance-languages-becoming-more-gender-neutral/)][[1](https://thesubmarine.it/2020/08/03/schwa-linguaggio-inclusivo-vera-gheno/)][[2](https://asteriscoedizioni.com/prodotto/il-corpo-del-testo-elementi-di-traduzione-transfemminista-queer-uscita-9-dicembre/)][[3](https://www.effequ.it/femminili-singolari/)][[4](https://www.valigiablu.it/linguaggio-inclusivo-dibattito/)][[5](https://jacobinitalia.it/linvidia-dellasterisco/)], also compare [this](https://web.archive.org/web/20201209001726/https://hastebin.com/raw/lilegapujo) as [Streisand effect](https://en.wikipedia.org/wiki/Streisand_effect))

(cw: autobio) My former Grand Prime (years old!) and Italian layout had the schwa. My new mobile has not.
As happened with other keyobards, people continuously switch between Italian and Azerbaijani layouts just to get the character. I still have the muscle memory of it even after the introduction of the schwa in other keyboards.