### PR TITLE
add KOY variant of AdNW to German language pack

### DIFF
--- a/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -22,7 +22,9 @@
     <string name="de_keyboard_neo2">German neo2</string>
     <string name="de_keyboard_neo2_simple">German neo2 simple</string>
     <string name="de_keyboard_adnw">German adnw</string>
+    <string name="de_keyboard_adnw_koy">German adnw KOY</string>
     <string name="de_keyboard_adnw_description">Aus der Neo Welt (Christoph Bauer)</string>
+    <string name="de_keyboard_adnw_koy_description">Aus der Neo Welt (KOY-Variante)</string>
     <string name="de_keyboard_dvorak_compact">DE Dv Compact</string>
     <string name="de_keyboard_dvorak_compact_description">German version of Dvorak compact, two letters per button, for Wurstfinger</string>
            

--- a/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
@@ -1,24 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2016, kertase, 2020, chrbauer, 2020 duchampdev
 
-    This file is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:ask="http://schemas.android.com/apk/res-auto"
           android:keyWidth="9%p" android:keyHeight="50dip"
           android:horizontalGap="0px" android:verticalGap="0px">
 <Row android:rowEdgeFlags="top" android:keyWidth="8%p" >
-    <!-- key codes: http://r12a.github.io/apps/conversion/ -->
     <Key android:codes="49" android:keyLabel="1" ask:shiftedCodes="176" android:keyEdgeFlags="left" android:popupCharacters="°¹ª₁¬"/>
     <Key android:codes="50" android:keyLabel="2" ask:shiftedCodes="167" android:popupCharacters="§²º₂∨"/>
     <Key android:codes="51" android:keyLabel="3" ask:shiftedCodes="8467" android:popupCharacters="ℓ³№₃∧"/>
@@ -72,7 +58,6 @@
     <Key android:codes="769" android:keyLabel="´" ask:shiftedCodes="771" android:keyEdgeFlags="right" android:popupCharacters="\u0300\u0302\u0303\u0327\u030C\u0337\u030A\u030B\u0308\u0307\u0314\u0313\u02DE\u0306\u0304\u0323"/>
 </Row>
 <Row android:rowEdgeFlags="bottom">
-    <!-- key codes:http://r12a.github.io/apps/conversion/ -->
     <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left" android:keyWidth="12%p"/>
     <Key android:isModifier="true" android:codes="-10" ask:longPressCode="-102" ask:isFunctional="true" android:keyWidth="8%p"/>
     <Key android:codes="-20" android:keyLabel="←" ask:isFunctional="true" ask:shiftedKeyLabel="←" android:isRepeatable="true" android:keyWidth="8%p"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016, kertase, 2020, chrbauer, 2020 duchampdev
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="9%p" android:keyHeight="50dip"
+          android:horizontalGap="0px" android:verticalGap="0px">
+<Row android:rowEdgeFlags="top" android:keyWidth="8%p" >
+    <!-- key codes: http://r12a.github.io/apps/conversion/ -->
+    <Key android:codes="49" android:keyLabel="1" ask:shiftedCodes="176" android:keyEdgeFlags="left" android:popupCharacters="°¹ª₁¬"/>
+    <Key android:codes="50" android:keyLabel="2" ask:shiftedCodes="167" android:popupCharacters="§²º₂∨"/>
+    <Key android:codes="51" android:keyLabel="3" ask:shiftedCodes="8467" android:popupCharacters="ℓ³№₃∧"/>
+    <Key android:codes="52" android:keyLabel="4" ask:shiftedCodes="187" android:popupCharacters="»›♀⊥"/>
+    <Key android:codes="53" android:keyLabel="5" ask:shiftedCodes="171" android:popupCharacters="«‹·♂∡"/>
+    <Key android:codes="54" android:keyLabel="6" ask:shiftedCodes="36" android:popupCharacters="$¢£⚥∥"/>
+    <Key android:codes="55" android:keyLabel="7" ask:shiftedCodes="8364" android:popupCharacters="€¥¤ϰ→"/>
+    <Key android:codes="56" android:keyLabel="8" ask:shiftedCodes="8222" android:popupCharacters="„‚\u0009⟨∞"/>
+    <Key android:codes="57" android:keyLabel="9" ask:shiftedCodes="8220" android:popupCharacters="“‘/⟩∝"/>
+    <Key android:codes="48" android:keyLabel="0" ask:shiftedCodes="8221" android:popupCharacters="”’*₀∅"/>
+    <Key android:codes="45" android:keyLabel="-" ask:shiftedCodes="8212" android:popupCharacters="—-‑­"/>
+    <Key android:keyWidth="12%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+</Row>
+<Row>
+    <Key android:codes="107" android:keyLabel="k" android:keyEdgeFlags="left" android:popupCharacters="…ξΞ"/>
+    <Key android:codes="46" android:keyLabel="." android:popupCharacters="_√"/>
+    <Key android:codes="111" android:keyLabel="o" android:popupCharacters="[λΛ"/>
+    <Key android:codes="44" android:keyLabel="," android:popupCharacters="]χℂ"/>
+    <Key android:codes="121" android:keyLabel="y" android:popupCharacters="^ωΩ"/>
+    <Key android:codes="118" android:keyLabel="v" android:popupCharacters="!¡κ×"/>
+    <Key android:codes="103" android:keyLabel="g" android:popupCharacters="\u003c7ψΨ"/>
+    <Key android:codes="99" android:keyLabel="c" android:popupCharacters="\u003e8γΓ"/>
+    <Key android:codes="108" android:keyLabel="l" android:popupCharacters="=9φΦ"/>
+    <Key android:codes="223" android:keyLabel="ß" android:popupCharacters="\u0026+ϕℚ"/>
+    <Key android:codes="122" android:keyLabel="z" android:popupCharacters="ſ−ς∘"/>
+</Row>
+<Row>
+    <Key android:codes="104" android:keyLabel="h" android:keyEdgeFlags="left" android:popupCharacters="\\⊂"/>
+    <Key android:codes="97" android:keyLabel="a" android:popupCharacters="/ι∫"/>
+    <Key android:codes="101" android:keyLabel="e" android:popupCharacters="{α∀"/>
+    <Key android:codes="105" android:keyLabel="i" android:popupCharacters="}ε∃"/>
+    <Key android:codes="117" android:keyLabel="u" android:popupCharacters="*ο∈"/>
+    <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\?¿σΣ"/>
+    <Key android:codes="116" android:keyLabel="t" android:popupCharacters="(4νℕ"/>
+    <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
+    <Key android:codes="110" android:keyLabel="n" android:popupCharacters="-6τ∂"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters=":,δΔſ"/>
+    <Key android:codes="102" android:keyLabel="f" android:keyEdgeFlags="right" android:popupCharacters="\@.υ∇"/>
+</Row>
+<Row>
+    <Key android:codes="120" android:keyLabel="x" android:popupCharacters="#∪"/>
+    <Key android:codes="113" android:keyLabel="q" android:popupCharacters="$ϵ∩"/>
+    <Key android:codes="228" android:keyLabel="ä" android:popupCharacters="|ηℵ"/>
+    <Key android:codes="252" android:keyLabel="ü" android:popupCharacters="~πΠ"/>
+    <Key android:codes="246" android:keyLabel="ö" android:popupCharacters="`ζℤ"/>
+    <Key android:codes="98" android:keyLabel="b" android:popupCharacters="+:β⇐"/>
+    <Key android:codes="112" android:keyLabel="p" android:popupCharacters="%1μ⇔"/>
+    <Key android:codes="119" android:keyLabel="w" android:popupCharacters="–\u00222ϱ⇒"/>
+    <Key android:codes="109" android:keyLabel="m"  android:popupCharacters="•\'3ϑ↦"/>
+    <Key android:codes="106" android:keyLabel="j" android:popupCharacters=";θΘ"/>
+    <Key android:codes="769" android:keyLabel="´" ask:shiftedCodes="771" android:keyEdgeFlags="right" android:popupCharacters="\u0300\u0302\u0303\u0327\u030C\u0337\u030A\u030B\u0308\u0307\u0314\u0313\u02DE\u0306\u0304\u0323"/>
+</Row>
+<Row android:rowEdgeFlags="bottom">
+    <!-- key codes:http://r12a.github.io/apps/conversion/ -->
+    <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left" android:keyWidth="12%p"/>
+    <Key android:isModifier="true" android:codes="-10" ask:longPressCode="-102" ask:isFunctional="true" android:keyWidth="8%p"/>
+    <Key android:codes="-20" android:keyLabel="←" ask:isFunctional="true" ask:shiftedKeyLabel="←" android:isRepeatable="true" android:keyWidth="8%p"/>
+    <Key android:codes="32" android:keyWidth="38%p" ask:isFunctional="true" android:isRepeatable="true"/>
+    <Key android:codes="-21" android:keyLabel="→" ask:isFunctional="true" ask:shiftedKeyLabel="→" android:isRepeatable="true" android:keyWidth="8%p"/>
+    <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="right" android:keyWidth="8%p"/>
+    <Key android:codes="10" android:keyEdgeFlags="right" android:keyWidth="18%p" ask:longPressCode="-100"/>
+</Row>
+</Keyboard>
+

--- a/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -103,10 +103,20 @@
     <Keyboard
         defaultDictionaryLocale="de"
         defaultEnabled="false"
+        description="@string/de_keyboard_adnw_koy_description"
+        iconResId="@drawable/ic_status_german"
+        id="638f65ba-4b64-11eb-9610-002b67b6309a"
+        index="11"
+        layoutResId="@xml/de_adnw_koy"
+        nameResId="@string/de_keyboard_adnw_koy"
+        physicalKeyboardMappingResId="@xml/german_neo2_physical" />
+    <Keyboard
+        defaultDictionaryLocale="de"
+        defaultEnabled="false"
         description="@string/de_keyboard_dvorak_compact_description"
         iconResId="@drawable/ic_status_german"
         id="7132bd21-0932-49c7-9306-c06cfec89dda"
-        index="11"
+        index="12"
         layoutResId="@xml/de_dvorak_compact"
         nameResId="@string/de_keyboard_dvorak_compact"
         physicalKeyboardMappingResId="@xml/german_physical" />


### PR DESCRIPTION
This PR contains the KOY-variant of the AdNW layout (w/ some minor changes, see below) in the German language pack.
For ease of use, I used an ortholinear layout like some ergonomic keyboards do and rearranged one key. Furthermore, I moved the shift keys to the bottom row, sacrificing the up/down arrows. This way, broader keys (9% vs. 8%) are possible. I found this alternative to be a rather minor change compared to the normal key alignment of AdNW in ASK but being much more usable.
If you wish, I can also add a layout with the default arrangement. And in general, just let me know, if you'd like to see something changed in order to make the PR more adequate to merge, @menny .