### PR TITLE
Set to capitalize when deleting whole line with shift + backspace

### DIFF
--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -316,6 +316,49 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
 
         Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
+        // Expectations: if you delete the whole typed string, the keyboard should shift again at
+        // the beginning
+        mAnySoftKeyboardUnderTest.onRelease(KeyCodes.SHIFT);
+        Assert.assertEquals(
+                true, mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().isShifted());
+    }
+
+    @Test
+    public void testDeleteWholeWordWhenShiftAndBackSpaceArePressedButNotAllString() {
+        TestInputConnection inputConnection = getCurrentTestInputConnection();
+
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello world");
+        Assert.assertEquals("hello world", inputConnection.getCurrentTextInInputConnection());
+
+        mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+
+        Assert.assertEquals("hello ", inputConnection.getCurrentTextInInputConnection());
+        // Expectations: if you delete the whole typed string, the keyboard should shift again at
+        // the beginning
+        mAnySoftKeyboardUnderTest.onRelease(KeyCodes.SHIFT);
+        Assert.assertEquals(
+                false, mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().isShifted());
+    }
+
+    @Test
+    public void testDeleteWholeWordWhenShiftAndBackSpaceArePressedButNotAllStringWithMorePress() {
+        TestInputConnection inputConnection = getCurrentTestInputConnection();
+
+        mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+        Assert.assertEquals("hello", inputConnection.getCurrentTextInInputConnection());
+
+        mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+
+        Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
+        // Expectations: if you delete the whole typed string, the keyboard should shift again at
+        // the beginning
+        mAnySoftKeyboardUnderTest.onRelease(KeyCodes.SHIFT);
+        Assert.assertEquals(
+                true, mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().isShifted());
     }
 
     @Test


### PR DESCRIPTION
When using the Shift + backspace shortcut to delete the whole line, the shift state was not resetting to enabled, meaning you had to reclick on the shift key. 

This PR take care of this.

I do not know if my code is the most optimised way to do it. I am maybe missing something, and i do not like calls to ```ic.getTextBeforeCursor```

Maybe there is a another way to do it ?