### PR TITLE
Added a german keyboard with symbols

### DIFF
--- a/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
+++ b/addons/languages/german/pack/src/main/res/values/german_pack_strings_dont_translate.xml
@@ -11,6 +11,8 @@
     <string name="de_keyboard_broad_description">Slightly broader layout with umlauts as popups (saving keys)</string>
     <string name="de_keyboard_extra">German broad+</string>
     <string name="de_keyboard_extra_description">Slightly broader layout with umlauts as popups (saving keys), also additional characters</string>
+    <string name="de_keyboard_symbols">German</string>
+    <string name="de_keyboard_symbols_description">QWERTZ layout with umlauts, symbols and numbers as popups (by LuKe)</string>
     <string name="de_keyboard_qwerty">German QWERTY</string>
     <string name="de_keyboard_qwerty_description">Created by Thomas Eizinger</string>
     <string name="de_keyboard_qwerty_broad">German QWERTY broad</string>

--- a/addons/languages/german/pack/src/main/res/xml/de_qwertz_symbols.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwertz_symbols.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="10%p">
+        <Key android:codes="q"  android:popupCharacters="1¹₁!" ask:hintLabel="1" android:keyEdgeFlags="left" />
+        <Key android:codes="w"  android:popupCharacters="2²₂&quot;ŵ" ask:hintLabel="2" />
+        <Key android:codes="e"  android:popupCharacters="3³₃€§èéêëęē" ask:hintLabel="3" />
+        <Key android:codes="r"  android:popupCharacters="4⁴₄$řŕ" ask:hintLabel="4" />
+        <Key android:codes="t"  android:popupCharacters="5%ťṭṯ" ask:hintLabel="5" />
+        <Key android:codes="z"  android:popupCharacters="6&amp;żžź" ask:hintLabel="6" />
+        <Key android:codes="u"  android:popupCharacters="ü7/µùúûŭűū" ask:hintLabel="7" />
+        <Key android:codes="i"  android:popupCharacters="8(ìíîïłīι" ask:hintLabel="8" />
+        <Key android:codes="o"  android:popupCharacters="ö9)òóôõøőœō" ask:hintLabel="9" />
+        <Key android:codes="p"  android:popupCharacters="0=¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="11.111%p">
+        <Key android:codes="a"  android:popupCharacters="ä\@àáâãāåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="s"  android:popupCharacters="ßẞ#§ſ$śŝšṣ" ask:hintLabel="#" />
+        <Key android:codes="d"  android:popupCharacters="€đďḏ" ask:hintLabel="€" />
+        <Key android:codes="f"  android:popupCharacters="_" ask:hintLabel="_" />
+        <Key android:codes="g"  android:popupCharacters="&amp;ĝ" ask:hintLabel="&amp;" />
+        <Key android:codes="h"  android:popupCharacters="-—ḫẖḥĥ" ask:hintLabel="−" />
+        <Key android:codes="j"  android:popupCharacters="+±ĵ" ask:hintLabel="+" />
+        <Key android:codes="k"  android:popupCharacters="([{&lt;«⸢" ask:hintLabel="(" />
+        <Key android:codes="l"  android:popupCharacters=")]}&gt;»⸣ľĺł£" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="10.625%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="y" android:popupCharacters="*·×ýÿ" ask:hintLabel="*" />
+        <Key android:codes="x" android:popupCharacters="&quot;" ask:hintLabel="&quot;" />
+        <Key android:codes="c" android:popupCharacters="'çćĉč" ask:hintLabel="'" />
+        <Key android:codes="v" android:popupCharacters=":." ask:hintLabel=":" />
+        <Key android:codes="b" android:popupCharacters=";," ask:hintLabel=";" />
+        <Key android:codes="n" android:popupCharacters="!ńňñ" ask:hintLabel="!" />
+        <Key android:codes="m" android:popupCharacters="\?µ" ask:hintLabel="\?" />
+        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
+++ b/addons/languages/german/pack/src/main/res/xml/german_keyboards.xml
@@ -33,10 +33,20 @@
     <Keyboard
         defaultDictionaryLocale="de"
         defaultEnabled="false"
+        description="@string/de_keyboard_symbols_description"
+        iconResId="@drawable/ic_status_german"
+        id="bbafdfbe-a151-496b-b838-3ef7812587ff"
+        index="4"
+        layoutResId="@xml/de_qwertz_symbols"
+        nameResId="@string/de_keyboard_symbols"
+        physicalKeyboardMappingResId="@xml/german_physical" />
+    <Keyboard
+        defaultDictionaryLocale="de"
+        defaultEnabled="false"
         description="@string/de_keyboard_qwerty_description"
         iconResId="@drawable/ic_status_german"
         id="797fbddf-346b-4216-b67c-80834638d7ce"
-        index="4"
+        index="5"
         layoutResId="@xml/de_qwerty"
         nameResId="@string/de_keyboard_qwerty"
         physicalKeyboardMappingResId="@xml/german_physical" />
@@ -46,7 +56,7 @@
         description="@string/de_keyboard_qwerty_broad_description"
         iconResId="@drawable/ic_status_german"
         id="9f5e0409-849b-423c-8d5f-46acbfe4e934"
-        index="5"
+        index="6"
         layoutResId="@xml/de_qwerty_broad"
         nameResId="@string/de_keyboard_qwerty_broad"
         physicalKeyboardMappingResId="@xml/german_physical" />
@@ -56,7 +66,7 @@
         description="@string/de_keyboard_qwerty_extra_description"
         iconResId="@drawable/ic_status_german"
         id="6755ccc0-1015-4364-bd87-2b755bf9ab4b"
-        index="6"
+        index="7"
         layoutResId="@xml/de_qwerty_extra"
         nameResId="@string/de_keyboard_qwerty_extra"
         physicalKeyboardMappingResId="@xml/german_physical" />
@@ -66,7 +76,7 @@
         description="@string/de_keyboard_qwerty_slim_description"
         iconResId="@drawable/ic_status_german"
         id="33421de8-0d71-456c-90f1-3935fcb4e30f"
-        index="7"
+        index="8"
         layoutResId="@xml/de_qwerty_slim"
         nameResId="@string/de_keyboard_qwerty_slim"
         physicalKeyboardMappingResId="@xml/german_physical" />
@@ -76,7 +86,7 @@
         description="German NEO2 layout"
         iconResId="@drawable/ic_status_german"
         id="ad1b5ffa-15cc-4ba4-abb7-68df2c0874e7"
-        index="8"
+        index="9"
         layoutResId="@xml/de_neo2"
         nameResId="@string/de_keyboard_neo2"
         physicalKeyboardMappingResId="@xml/german_neo2_physical" />
@@ -85,7 +95,7 @@
         defaultEnabled="false"
         iconResId="@drawable/ic_status_german"
         id="37606729-66c1-4e04-9968-b32314c7094a"
-        index="9"
+        index="10"
         layoutResId="@xml/de_neo2_simple"
         nameResId="@string/de_keyboard_neo2_simple"
         description="German NEO2 Simple layout with neo2 physical layout"
@@ -96,7 +106,7 @@
         description="@string/de_keyboard_adnw_description"
         iconResId="@drawable/ic_status_german"
         id="e482c64e-fa24-45ab-a785-68c65fe5bf7b"
-        index="10"
+        index="11"
         layoutResId="@xml/de_adnw"
         nameResId="@string/de_keyboard_adnw"
         physicalKeyboardMappingResId="@xml/german_neo2_physical" />
@@ -106,7 +116,7 @@
         description="@string/de_keyboard_adnw_koy_description"
         iconResId="@drawable/ic_status_german"
         id="638f65ba-4b64-11eb-9610-002b67b6309a"
-        index="11"
+        index="12"
         layoutResId="@xml/de_adnw_koy"
         nameResId="@string/de_keyboard_adnw_koy"
         physicalKeyboardMappingResId="@xml/german_neo2_physical" />
@@ -116,7 +126,7 @@
         description="@string/de_keyboard_dvorak_compact_description"
         iconResId="@drawable/ic_status_german"
         id="7132bd21-0932-49c7-9306-c06cfec89dda"
-        index="12"
+        index="13"
         layoutResId="@xml/de_dvorak_compact"
         nameResId="@string/de_keyboard_dvorak_compact"
         physicalKeyboardMappingResId="@xml/german_physical" />


### PR DESCRIPTION
What was definitely missing for me was a keyboard which is similar to the one from Gboard - from where i switched recently. So I added this one.
Here is how it looks: 
![image](https://user-images.githubusercontent.com/31316050/105707275-f8041800-5f12-11eb-9a06-bc0da487abad.png)

And here for comparison the Gboard:
![image](https://user-images.githubusercontent.com/31316050/105707472-4a453900-5f13-11eb-9914-cf7319d1a1f5.png)
