### PR TITLE
Added an English QWERTZ keyboard

### DIFF
--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -10,4 +10,5 @@
     <string name="colemak_keyboard_description">Colemak layout. Created with Hugo Lopes</string>
     <string name="workman_keyboard_description">Layout by OJ Bucao</string>
     <string name="halmak_keyboard_description">Nikolay Nemshilov\'s Halmak layout, implemented by Zorkedon</string>
+    <string name="english_keyboard_qwertz_symbols_description">QWERTZ Latin keyboard with symbols, by LuKe</string>
 </resources>

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -14,6 +14,7 @@
     <string name="colemak_keyboard">Colemak</string>
     <string name="workman_keyboard">Workman</string>
     <string name="halmak_keyboard">Halmak</string>
+    <string name="english_keyboard_qwertz_symbols">English</string>
     <string name="main_english_keyboard_id">c7535083-4fe6-49dc-81aa-c5438a1a343a</string>
 
     <string-array name="english_initial_suggestions">

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -47,5 +47,11 @@
               layoutResId="@xml/halmak" id="546b29d0-2563-11e9-b56e-0800200c9a66"
               description="@string/halmak_keyboard_description"
               index="10"/>
+    <Keyboard nameResId="@string/english_keyboard_qwertz_symbols" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwertz_symbols" landscapeResId="@xml/qwertz_symbols"
+              id="5403a53a-6369-4dee-bf6e-32901634ae08"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_qwertz_symbols_description"
+              index="11" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
 
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/qwertz_symbols.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwertz_symbols.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyWidth="10%p">
+    
+    <Row android:keyWidth="10%p">
+        <Key android:codes="q"  android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left" />
+        <Key android:codes="w"  android:popupCharacters="2²₂ŵ" ask:hintLabel="2" />
+        <Key android:codes="e"  android:popupCharacters="3³₃§èéêëęē" ask:hintLabel="3" />
+        <Key android:codes="r"  android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4" />
+        <Key android:codes="t"  android:popupCharacters="5ťṭṯ" ask:hintLabel="5" />
+        <Key android:codes="z"  android:popupCharacters="6ýÿ" ask:hintLabel="6" />
+        <Key android:codes="u"  android:popupCharacters="7üµùúûŭűū" ask:hintLabel="7" />
+        <Key android:codes="i"  android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8" />
+        <Key android:codes="o"  android:popupCharacters="9öòóôõøőœō" ask:hintLabel="9" />
+        <Key android:codes="p"  android:popupCharacters="0=¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="11.111%p">
+        <Key android:codes="a"  android:popupCharacters="\@äàáâãāåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="s"  android:popupCharacters="ßẞ#§ſ$śŝšṣ" ask:hintLabel="#" />
+        <Key android:codes="d"  android:popupCharacters="€đďḏ" ask:hintLabel="€" />
+        <Key android:codes="f"  android:popupCharacters="_" ask:hintLabel="_" />
+        <Key android:codes="g"  android:popupCharacters="&amp;ĝ" ask:hintLabel="&amp;" />
+        <Key android:codes="h"  android:popupCharacters="-—ḫẖḥĥ" ask:hintLabel="−" />
+        <Key android:codes="j"  android:popupCharacters="+±ĵ" ask:hintLabel="+" />
+        <Key android:codes="k"  android:popupCharacters="([{⸢" ask:hintLabel="(" />
+        <Key android:codes="l"  android:popupCharacters=")]}⸣ľĺł£" ask:hintLabel=")" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="10.625%p">
+        <Key android:codes="-1" android:keyWidth="15%p" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="y" android:popupCharacters="*·×" ask:hintLabel="*" />
+        <Key android:codes="x" android:popupCharacters="&quot;" ask:hintLabel="&quot;" />
+        <Key android:codes="c" android:popupCharacters="'" ask:hintLabel="'" />
+        <Key android:codes="v" android:popupCharacters=":." ask:hintLabel=":" />
+        <Key android:codes="b" android:popupCharacters=";," ask:hintLabel=";" />
+        <Key android:codes="n" android:popupCharacters="!" ask:hintLabel="!" />
+        <Key android:codes="m" android:popupCharacters="\?µ" ask:hintLabel="\?" />
+        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -68,7 +68,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
-        Assert.assertEquals(10, keyboardBuilders.size());
+        Assert.assertEquals(11, keyboardBuilders.size());
         Assert.assertEquals(8, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -69,7 +69,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
         Assert.assertEquals(11, keyboardBuilders.size());
-        Assert.assertEquals(8, reportedSubtypes.length);
+        Assert.assertEquals(9, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {
                     1912895432,
@@ -79,7 +79,8 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
                     1618259652,
                     -517805346,
                     -1601329810,
-                    -1835196376
+                    -1835196376,
+                    -2134687081
                 };
         Assert.assertEquals(reportedSubtypes.length, expectedSubtypeId.length);
         int reportedIndex = 0;

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
@@ -51,7 +51,7 @@ public class KeyboardAddOnTest {
                     addOnAndBuilder.getId(), addOnAndBuilder.getKeyboardDefaultEnabled());
         }
 
-        Assert.assertEquals(10, keyboardsEnabled.size());
+        Assert.assertEquals(11, keyboardsEnabled.size());
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.get(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_16_KEYS_ID));

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
@@ -35,7 +35,7 @@ public class KeyboardFactoryTest {
     @Test
     public void testDefaultKeyboardId() {
         final List<KeyboardAddOnAndBuilder> allAddOns = mKeyboardFactory.getAllAddOns();
-        Assert.assertEquals(10, allAddOns.size());
+        Assert.assertEquals(11, allAddOns.size());
         KeyboardAddOnAndBuilder addon = mKeyboardFactory.getEnabledAddOn();
         Assert.assertNotNull(addon);
         Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a", addon.getId());


### PR DESCRIPTION
Added an English QWERTZ keyboard with symbols as popups, very similar to the Gboard layout. In the German comments on PlayStore some were complaining that there is no WERTZ keyboard for English language. 
By the way: do you need someone who responds to these comments in German? Some people complain about stuff which could be changed in the settings. They couldn't find it or haven't even had a look the settings..