### PR TITLE
Add single and double quotes to DEFAULT_SENTENCE_SEPARATORS

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardFactory.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardFactory.java
@@ -36,7 +36,7 @@ public class KeyboardFactory extends AddOnsFactory.MultipleAddOnsFactory<Keyboar
     private static final String XML_ADDITIONAL_IS_LETTER_EXCEPTIONS_ATTRIBUTE =
             "additionalIsLetterExceptions";
     private static final String XML_SENTENCE_SEPARATOR_CHARACTERS_ATTRIBUTE = "sentenceSeparators";
-    private static final String DEFAULT_SENTENCE_SEPARATORS = ".,!?)]:;";
+    private static final String DEFAULT_SENTENCE_SEPARATORS = ".,!?)]:;'\"";
     private static final String XML_PHYSICAL_TRANSLATION_RES_ID_ATTRIBUTE =
             "physicalKeyboardMappingResId";
     private static final String XML_DEFAULT_ATTRIBUTE = "defaultEnabled";


### PR DESCRIPTION
Proposal for issue #2623 by adding single quotes and doubles quotes to DEFAULT_SENTENCE_SEPARATORS

Note that for sentenceSeparators to be updated, the application data needs to be wiped (if the app settings are restored from a backup, sentenceSeparators will be restored also)


I think quotes (both singles and doubles) pretty much separate a sentence the same way a parenthesis does, so I think it would make sens to add them to DEFAULT_SENTENCE_SEPARATORS.

Otherwise, another way to fix it would be to add a seperate check in isSpaceSwapCharacter().

That's my first PR so I may not be doing it correctly
Let me know if you want me to change anything