### PR TITLE
fix to #2252 added fe/male ordinals to pt keyboard

### DIFF
--- a/addons/languages/portuguese/pack/src/main/res/xml/qwerty_with_symbols.xml
+++ b/addons/languages/portuguese/pack/src/main/res/xml/qwerty_with_symbols.xml
@@ -33,14 +33,14 @@
         <Key android:codes="y" android:popupCharacters="ýÿ"/>
         <Key android:codes="u" android:popupCharacters="ùúûüŭűūµ"/>
         <Key android:codes="i" android:popupCharacters="ìíîïłīι*"/>
-        <Key android:codes="o" android:popupCharacters="òóôõöøőœō"/>
+        <Key android:codes="o" android:popupCharacters="ºòóôõöøőœō"/>
         <Key android:codes="p" android:popupCharacters="+*`¶þ·×±ʾʿ" ask:hintLabel="+*`" android:keyEdgeFlags="right"/>
         <!-- "+*" would be a separate key on the first row -->
         <!-- "`'" would be a separate key on the first row -->
     </Row>
 
     <Row>
-        <Key android:codes="a" android:popupCharacters="àáâãāäåæą" android:keyEdgeFlags="left"/>
+        <Key android:codes="a" android:popupCharacters="ªàáâãāäåæą" android:keyEdgeFlags="left"/>
         <Key android:codes="s" android:popupCharacters="ßśŝšṣ"/>
         <Key android:codes="d" android:popupCharacters="đďḏ"/>
         <Key android:codes="f"/>


### PR DESCRIPTION
The ordinals ("first" can be written as "1º" or "1ª" depending on gender) are in very common use in Portuguese, even having a dedicated key on Portuguese keyboards.
In software keyboards they are usually implemented as alternative symbols to A and O.
This was the only file i found where these changes made sense.
This is a proposed fix to #2252 