### PR TITLE
Repairing assembly on F-Droid virtual machines

### DIFF
--- a/buildSrc/src/main/java/github/RestRequestPerformer.java
+++ b/buildSrc/src/main/java/github/RestRequestPerformer.java
@@ -2,7 +2,6 @@ package github;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Scanner;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -34,7 +33,7 @@ public abstract class RestRequestPerformer<R, A> {
                             httpRequest, HttpClientCreator.createContext(username, password))) {
                 System.out.println("Response status: " + httpResponse.getStatusLine());
                 final Scanner scanner =
-                        new Scanner(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+                        new Scanner(httpResponse.getEntity().getContent(), "UTF_8")
                                 .useDelimiter("\\A");
                 final String responseString = scanner.hasNext() ? scanner.next() : "";
                 System.out.println("Response content: " + responseString);

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -17,6 +17,8 @@ dependencies {
 
     //taken from https://github.com/google/error-prone/releases
     errorprone 'com.google.errorprone:error_prone_core:2.5.1'
+    //needed to compile on the new F-Droid virtual machines
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 }
 
 afterEvaluate {


### PR DESCRIPTION
How are you doing lately? A commenter said you were very busy these days. Is everything okay?

Lately I've been using F-Droid virtual machines to build Android apps, and I had to make a couple changes to be able to assemble ASK. You can check this when you have the time and verify it doesn't bring new errors; it could help fix #2798.

You'll need to tweak some parameters on your YAML, especially if you want to build on Java 11. Please double-check this excerpt (especially the version number, code and name, because I don't know your numbering conventions or your system to set those).

```yaml
  - versionName: 1.10.6521
    versionCode: 6521
    commit: 1.10-r4
    subdir: ime/app
    sudo: apt-get install -y openjdk-11-jdk-headless openjdk-11-jre-headless
    patch:
      - assembly.patch
    gradle:
      - yes
    encoding: utf-8
    prebuild: sed -i -e '/versionCode/d' -e '/versionName/aversionCode $$VERCODE$$'
        build.gradle
    scanignore:
      - addons/languages/*/pack/dictionary/*.gz
    ndk: r14b
    gradleprops:
      - forceVersionBuildCount=5386
```

Note that the `patch:` and `- assembly.patch` lines make reference to a file that is **only** needed to add these changes to your `1.10-r4` tag. You could also update your tag here on GitHub and remove those lines from YAML, but I don't know if it would be worth it to you. (I tried to make this PR point at your tag, but GitHub wouldn't let me.)

If you do keep those lines, you'll need a patch file at `metadata/com.menny.android.anysoftkeyboard/assembly.patch`. These contents work:

```patch
diff --git a/buildSrc/src/main/java/github/RestRequestPerformer.java b/buildSrc/src/main/java/github/RestRequestPerformer.java
index 9aebf98f1..8323d4b17 100644
--- a/buildSrc/src/main/java/github/RestRequestPerformer.java
+++ b/buildSrc/src/main/java/github/RestRequestPerformer.java
@@ -2,7 +2,6 @@ package github;
 
 import com.google.gson.Gson;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Scanner;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -34,7 +33,7 @@ public abstract class RestRequestPerformer<R, A> {
                             httpRequest, HttpClientCreator.createContext(username, password))) {
                 System.out.println("Response status: " + httpResponse.getStatusLine());
                 final Scanner scanner =
-                        new Scanner(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+                        new Scanner(httpResponse.getEntity().getContent(), "UTF_8")
                                 .useDelimiter("\\A");
                 final String responseString = scanner.hasNext() ? scanner.next() : "";
                 System.out.println("Response content: " + responseString);
diff --git a/gradle/errorprone.gradle b/gradle/errorprone.gradle
index d40e0351d..d69866854 100644
--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -17,6 +17,8 @@ dependencies {
 
     //taken from https://github.com/google/error-prone/releases
     errorprone 'com.google.errorprone:error_prone_core:2.5.1'
+    //needed to compile on the new F-Droid virtual machines
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 }
 
 afterEvaluate {
@@ -35,4 +37,4 @@ afterEvaluate {
 //                option("NullAway:AnnotatedPackages", "com.uber")
 //            }
     }
-}
\ No newline at end of file
+}
```

(Edited to account for `./gradlew googleJavaFormat`, which removed a now unnecessary import.)

Also, an unrelated question: do you want me to rebase and clean up the history in my other PR? Maybe it'll be easier for you to review when you get to version 1.11.