### PR TITLE
Improve English Dvorak usability

### DIFF
--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -3,6 +3,7 @@
     <string name="english_keyboard_description">QWERTY Latin keyboard</string>
     <string name="english_keyboard_symbols_description">QWERTY Latin keyboard with symbols (on long press)</string>
     <string name="dvorak_keyboard_description">Dvorak layout. Created with Stephen Paul Weber</string>
+    <string name="dvorak_keyboard_symbols_description">Dvorak layout with symbols (on long press)</string>
     <string name="compact_keyboard_description">Compact in portrait</string>
     <string name="compact_dvorak_keyboard_description">Compact Dvorak in portrait</string>
     <string name="compact_keyboard_16keys_description">16 keys English layout</string>

--- a/addons/languages/english/pack/src/main/res/xml/dvorak_with_symbols.xml
+++ b/addons/languages/english/pack/src/main/res/xml/dvorak_with_symbols.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
     android:keyWidth="10%p"    >
     
     <Row>
-        <Key android:codes="39,34"  android:keyLabel="" android:keyEdgeFlags="left" android:popupCharacters="1\u0022¹₁ʾʿʻ" />
-        <Key android:codes="44,60"  android:keyLabel="" android:popupCharacters="2&lt;«²₂"/>
-        <Key android:codes="46,62"  android:keyLabel="" android:popupCharacters="3&gt;»³₃"/>
-        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="4³₃π"/>
-        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="5ýÿ"/>
+        <Key android:codes="39,34"  android:keyLabel="" android:keyEdgeFlags="left" android:popupCharacters="1\u0022¹₁ʾʿʻ" ask:hintLabel="1\u0022"/>
+        <Key android:codes="44,60"  android:keyLabel="" android:popupCharacters="2&lt;«²₂" ask:hintLabel="2&lt;"/>
+        <Key android:codes="46,62"  android:keyLabel="" android:popupCharacters="3&gt;»³₃" ask:hintLabel="3&gt;"/>
+        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="4³₃π" ask:hintLabel="4"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="5ýÿ" ask:hintLabel="5"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="6"/>
-        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="7ĝ"/>
-        <Key android:codes="99"  android:keyLabel="c" android:popupCharacters="8ç"/>
-        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="9řŕ"/>
-        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="0¶ľĺł£" android:keyEdgeFlags="right"/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="7ĝ" ask:hintLabel="7"/>
+        <Key android:codes="99"  android:keyLabel="c" android:popupCharacters="8ç" ask:hintLabel="8"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="9řŕ" ask:hintLabel="9"/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="0¶ľĺł£" ask:hintLabel="0" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row>
-        <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left" android:popupCharacters="\@àáâãāäåæą"/>
-        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="#òóôõöøőœō"/>
-        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="$%èéêëęē€"/>
+        <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left" android:popupCharacters="\@àáâãāäåæą" ask:hintLabel="\@"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="#òóôõöøőœō" ask:hintLabel="#"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="$%èéêëęē€" ask:hintLabel="$%"/>
         <Key android:codes="117" android:keyLabel="u" android:popupCharacters="^\u0026`°ùúûüŭűūµ"/>
-        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="*ìíîïłīι"/>
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\|đďḏ"/>
-        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="([{⸢ḫẖḥĥ"/>
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters=")]}⸣ťṭṯ"/>
-        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="+=±ńňñ"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="_-~—§ßśŝšṣ" android:keyEdgeFlags="right"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupKeyboard="@xml/popup_dvorak_with_symbols_i" ask:hintLabel="*"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\|đďḏ" ask:hintLabel="\|"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupKeyboard="@xml/popup_dvorak_with_symbols_h" ask:hintLabel="("/>
+        <Key android:codes="116" android:keyLabel="t" android:popupKeyboard="@xml/popup_dvorak_with_symbols_t" ask:hintLabel=")"/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="+=±ńňñ" ask:hintLabel="+="/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="-_~—§ßśŝšṣ" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">
         <Key android:codes="-1" 
                 android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
         <Key android:codes="113" android:keyLabel="q" android:popupCharacters=";:"/>
-        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="!¡ĵ"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="!¡ĵ" ask:hintLabel="!"/>
         <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
-        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="*·×"/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="×*·" ask:hintLabel="×"/>
         <Key android:codes="98"  android:keyLabel="b" android:popupCharacters="β"/>
         <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
         <Key android:codes="119" android:keyLabel="w" android:popupCharacters="ŵ"/>
-        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="↓↑←→"/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="↓↑←→" ask:hintLabel="↓↑"/>
         <Key android:codes="122" android:keyLabel="z" android:popupCharacters="/\u003f÷żžź"/>
         <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
     </Row>

--- a/addons/languages/english/pack/src/main/res/xml/dvorak_with_symbols.xml
+++ b/addons/languages/english/pack/src/main/res/xml/dvorak_with_symbols.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"    >
+    
+    <Row>
+        <Key android:codes="39,34"  android:keyLabel="" android:keyEdgeFlags="left" android:popupCharacters="1\u0022¹₁ʾʿʻ" />
+        <Key android:codes="44,60"  android:keyLabel="" android:popupCharacters="2&lt;«²₂"/>
+        <Key android:codes="46,62"  android:keyLabel="" android:popupCharacters="3&gt;»³₃"/>
+        <Key android:codes="112" android:keyLabel="p" android:popupCharacters="4³₃π"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="5ýÿ"/>
+        <Key android:codes="102" android:keyLabel="f" android:popupCharacters="6"/>
+        <Key android:codes="103" android:keyLabel="g" android:popupCharacters="7ĝ"/>
+        <Key android:codes="99"  android:keyLabel="c" android:popupCharacters="8ç"/>
+        <Key android:codes="114" android:keyLabel="r" android:popupCharacters="9řŕ"/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="0¶ľĺł£" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row>
+        <Key android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left" android:popupCharacters="\@àáâãāäåæą"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="#òóôõöøőœō"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="$%èéêëęē€"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="^\u0026`°ùúûüŭűūµ"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="*ìíîïłīι"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\|đďḏ"/>
+        <Key android:codes="104" android:keyLabel="h" android:popupCharacters="([{⸢ḫẖḥĥ"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters=")]}⸣ťṭṯ"/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="+=±ńňñ"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="_-~—§ßśŝšṣ" android:keyEdgeFlags="right"/>
+    </Row>
+    
+    <Row android:keyWidth="9.09%p">
+        <Key android:codes="-1" 
+                android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="113" android:keyLabel="q" android:popupCharacters=";:"/>
+        <Key android:codes="106" android:keyLabel="j" android:popupCharacters="!¡ĵ"/>
+        <Key android:codes="107" android:keyLabel="k" android:popupCharacters=""/>
+        <Key android:codes="120" android:keyLabel="x" android:popupCharacters="*·×"/>
+        <Key android:codes="98"  android:keyLabel="b" android:popupCharacters="β"/>
+        <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
+        <Key android:codes="119" android:keyLabel="w" android:popupCharacters="ŵ"/>
+        <Key android:codes="118" android:keyLabel="v" android:popupCharacters="↓↑←→"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="/\u003f÷żžź"/>
+        <Key android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -31,27 +31,31 @@
               id="53baf0a3-389d-4257-815b-5820d7d219f7"
               defaultDictionaryLocale="en" description="@string/compact_dvorak_keyboard_description"
               index="6" />
+    <Keyboard nameResId="@string/dvorak_keyboard" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/dvorak_with_symbols" id="9a174a0b-fe10-4244-aceb-1ef73f698954"
+              defaultDictionaryLocale="en" description="@string/dvorak_keyboard_symbols_description"
+              index="7" />
     <Keyboard nameResId="@string/colemak_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/colemak" id="86770389-9f38-4654-9e29-68d503410fcd"
               defaultDictionaryLocale="en" description="@string/colemak_keyboard_description"
-              index="7"/>
+              index="8"/>
     <Keyboard nameResId="@string/workman_keyboard" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/workman" id="37334220-b0ca-11e8-8c82-0b99ca86e03e"
               defaultDictionaryLocale="en" description="@string/workman_keyboard_description"
-              index="8"/>
+              index="9"/>
     <Keyboard nameResId="@string/terminal_keyboard"
               layoutResId="@xml/terminal" id="b1c24b40-02ce-4857-9fb8-fb9e4e3b4318"
               description="@string/terminal_keyboard_description"
-              index="9"/>
+              index="10"/>
     <Keyboard nameResId="@string/halmak_keyboard"
               layoutResId="@xml/halmak" id="546b29d0-2563-11e9-b56e-0800200c9a66"
               description="@string/halmak_keyboard_description"
-              index="10"/>
+              index="11"/>
     <Keyboard nameResId="@string/english_keyboard_qwertz_symbols" iconResId="@drawable/ic_status_english"
               layoutResId="@xml/qwertz_symbols" landscapeResId="@xml/qwertz_symbols"
               id="5403a53a-6369-4dee-bf6e-32901634ae08"
               defaultDictionaryLocale="en" description="@string/english_keyboard_qwertz_symbols_description"
-              index="11" defaultEnabled="false"
+              index="12" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />
 
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_h.xml
+++ b/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_h.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:rowEdgeFlags="top">
+        <!-- ḫẖḥĥ -->
+        <Key android:codes="ḫ" android:keyEdgeFlags="left"/>
+        <Key android:codes="ẖ" />
+        <Key android:codes="ḥ" />
+        <Key android:codes="ĥ" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <!-- ([{⸢ -->
+        <Key android:codes="(" android:keyEdgeFlags="left"/>
+        <Key android:codes="["/>
+        <Key android:codes="{"/>
+        <Key android:codes="⸢" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_i.xml
+++ b/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_i.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:rowEdgeFlags="top">
+        <!-- ïłīι -->
+        <Key android:codes="ï" android:keyEdgeFlags="left"/>
+        <Key android:codes="ł" />
+        <Key android:codes="ī" />
+        <Key android:codes="ι" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <!-- *ìíî -->
+        <Key android:codes="*" android:keyEdgeFlags="left"/>
+        <Key android:codes="ì"/>
+        <Key android:codes="í"/>
+        <Key android:codes="î" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_t.xml
+++ b/addons/languages/english/pack/src/main/res/xml/popup_dvorak_with_symbols_t.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android">
+    <Row android:rowEdgeFlags="top">
+        <!-- ťṭṯ -->
+        <Key android:codes="ť" android:keyEdgeFlags="left"/>
+        <Key android:codes="ṭ" />
+        <Key android:codes="ṯ" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <!-- )]}⸣ -->
+        <Key android:codes=")" android:keyEdgeFlags="left"/>
+        <Key android:codes="]"/>
+        <Key android:codes="}"/>
+        <Key android:codes="⸣" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>

--- a/ime/app/src/main/res/values-es/strings.xml
+++ b/ime/app/src/main/res/values-es/strings.xml
@@ -404,6 +404,7 @@
     <string name="extension_kbd_extension_numbers_symbols">Números y símbolos</string>
     <string name="extension_kbd_bottom_minimal">Mínimo</string>
     <string name="extension_kbd_bottom_minimal_no_emoji">Mínimo (sin emojis)</string>
+    <string name="extension_kbd_bottom_minimal_less_punctuation">Mínimo (menos puntuación)</string>
     <!-- Tutorials -->
     <!-- Special soft keyboard keys text -->
     <string name="label_go_key">Ir</string>

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -552,6 +552,7 @@
     <string name="extension_kbd_extension_numbers_symbols">Numbers and symbols</string>
     <string name="extension_kbd_bottom_minimal">Minimal</string>
     <string name="extension_kbd_bottom_minimal_no_emoji">Minimal (no emoji)</string>
+    <string name="extension_kbd_bottom_minimal_less_punctuation">Minimal (less punctuation)</string>
 
     <!-- Tutorials -->
     <!-- Special soft keyboard keys text -->
@@ -945,6 +946,5 @@
     <!-- this URL should be localized - it should point to a web-site with information in the locale language. -->
     <string name="codvid_info_url">https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public</string>
 
-    
-    
+
 </resources>

--- a/ime/app/src/main/res/xml/ext_kbd_bottom_row_minimal_less_punctuation.xml
+++ b/ime/app/src/main/res/xml/ext_kbd_bottom_row_minimal_less_punctuation.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
+
+    <Row android:keyWidth="10%p" android:keyboardMode="@integer/keyboard_mode_normal" android:rowEdgeFlags="bottom">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" ask:shiftedCodes="33"
+             android:popupCharacters="!/@\u0026\u00bf\u00a1&#11822;&#8253;"/>
+        <Key android:keyWidth="65%p" android:codes="@integer/key_code_space"
+             android:isRepeatable="true" ask:hintLabel=" "/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_url" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_domain" android:keyEdgeFlags="left"/>
+        <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" ask:shiftedCodes="33"
+             android:popupCharacters="!/@\u0026\u00bf\u00a1&#11822;&#8253;"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="50%p"/>
+        <Key ask:isFunctional="true" android:codes="47" android:keyLabel="/" android:popupCharacters=":"/>
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_enter" android:keyWidth="15%p" android:keyEdgeFlags="right"
+             ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_password" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+        android:keyHeight="@integer/key_normal_height">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" android:popupCharacters="!@#$%^\u0026*"/>
+        <Key android:keyWidth="65%p" android:codes="@integer/key_code_space" ask:hintLabel=" "/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_email" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+        <Key ask:isFunctional="true" android:keyWidth="15%p" android:codes="@integer/key_code_domain" android:keyEdgeFlags="left"/>
+
+        <Key ask:isFunctional="true" android:codes="64" android:keyLabel="\@"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_space" android:keyWidth="50%p"/>
+
+        <Key ask:isFunctional="true" android:codes="45" android:keyLabel="-" android:popupCharacters="_"/>
+
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_enter" android:keyWidth="15%p" android:keyEdgeFlags="right"
+             ask:longPressCode="@integer/key_code_settings"/>
+    </Row>
+    <Row android:keyboardMode="@integer/keyboard_mode_im" android:rowEdgeFlags="bottom" android:keyWidth="10%p"
+         android:keyHeight="@integer/key_normal_height">
+        <Key ask:isFunctional="true" android:codes="@integer/key_code_quick_text" 
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key ask:isFunctional="true" android:codes="63" android:keyLabel="\?" ask:shiftedCodes="33"
+             android:popupCharacters="!/@\u0026\u00bf\u00a1&#11822;&#8253;"/>
+        <Key android:keyWidth="65%p" android:codes="@integer/key_code_space" android:isRepeatable="true"
+             ask:longPressCode="@integer/key_code_quick_text_popup" ask:hintLabel=" "/>
+        <Key android:keyWidth="15%p" ask:isFunctional="true" android:codes="@integer/key_code_enter"
+             ask:longPressCode="@integer/key_code_settings" ask:hintLabel=" " android:keyEdgeFlags="right"/>
+    </Row>
+
+</Keyboard>
+

--- a/ime/app/src/main/res/xml/extension_keyboards.xml
+++ b/ime/app/src/main/res/xml/extension_keyboards.xml
@@ -196,6 +196,14 @@
         description=""
         index="13"
         />
+    <ExtensionKeyboard
+        id="f6196797-62b7-4f98-b1fa-7fe151ec7b3d"
+        nameResId="@string/extension_kbd_bottom_minimal_less_punctuation"
+        extensionKeyboardResId="@xml/ext_kbd_bottom_row_minimal_less_punctuation"
+        extensionKeyboardType="@integer/extension_keyboard_type_bottom_row"
+        description=""
+        index="14"
+        />
 
     <ExtensionKeyboard
         id="4bd88cea-f31e-4500-b20d-f51757350d8d"
@@ -203,7 +211,7 @@
         extensionKeyboardResId="@xml/ext_kbd_bottom_row_aosp"
         extensionKeyboardType="@integer/extension_keyboard_type_bottom_row"
         description=""
-        index="14"
+        index="15"
         />
 
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSubtypeTest.java
@@ -68,8 +68,8 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
 
         InputMethodSubtype[] reportedSubtypes = subtypesCaptor.getValue();
         Assert.assertNotNull(reportedSubtypes);
-        Assert.assertEquals(11, keyboardBuilders.size());
-        Assert.assertEquals(9, reportedSubtypes.length);
+        Assert.assertEquals(12, keyboardBuilders.size());
+        Assert.assertEquals(10, reportedSubtypes.length);
         final int[] expectedSubtypeId =
                 new int[] {
                     1912895432,
@@ -78,6 +78,7 @@ public class AnySoftKeyboardKeyboardSubtypeTest extends AnySoftKeyboardBaseTest 
                     1819490062,
                     1618259652,
                     -517805346,
+                    -611797928,
                     -1601329810,
                     -1835196376,
                     -2134687081

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboardextensions/KeyboardExtensionFactoryTest.java
@@ -74,7 +74,7 @@ public class KeyboardExtensionFactoryTest {
     public void testGetAllAvailableExtensions() throws Exception {
         assertBasicListDetails(
                 AnyApplication.getBottomRowFactory(getApplicationContext()).getAllAddOns(),
-                14,
+                15,
                 KeyboardExtension.TYPE_BOTTOM);
         assertBasicListDetails(
                 AnyApplication.getTopRowFactory(getApplicationContext()).getAllAddOns(),

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardAddOnTest.java
@@ -51,7 +51,7 @@ public class KeyboardAddOnTest {
                     addOnAndBuilder.getId(), addOnAndBuilder.getKeyboardDefaultEnabled());
         }
 
-        Assert.assertEquals(11, keyboardsEnabled.size());
+        Assert.assertEquals(12, keyboardsEnabled.size());
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.get(ASK_ENGLISH_1_ID));
         Assert.assertTrue(keyboardsEnabled.containsKey(ASK_ENGLISH_16_KEYS_ID));

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/KeyboardFactoryTest.java
@@ -35,7 +35,7 @@ public class KeyboardFactoryTest {
     @Test
     public void testDefaultKeyboardId() {
         final List<KeyboardAddOnAndBuilder> allAddOns = mKeyboardFactory.getAllAddOns();
-        Assert.assertEquals(11, allAddOns.size());
+        Assert.assertEquals(12, allAddOns.size());
         KeyboardAddOnAndBuilder addon = mKeyboardFactory.getEnabledAddOn();
         Assert.assertNotNull(addon);
         Assert.assertEquals("c7535083-4fe6-49dc-81aa-c5438a1a343a", addon.getId());


### PR DESCRIPTION
This pull request adds an English Dvorak layout with common symbols above the keys, similar to the existing QWERTY with symbols layout. It also adds a bottom row variant without the "." and "," keys, which are redundant when using Dvorak. This partially addresses the concerns in #1667.