### PR TITLE
Using suggestion close icon from theme

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -5,6 +5,7 @@ import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.SystemClock;
 import android.text.TextUtils;
+import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -15,6 +16,8 @@ import android.view.animation.AnimationUtils;
 import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.widget.ImageView;
+
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -497,6 +500,9 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         final View view = super.onCreateInputView();
         mCandidateView = getInputViewContainer().getCandidateView();
         mCandidateView.setService(this);
+        Log.d("johnny", "onCreateInputView interface setting");
+        mCandidateView.setCloseIconChangedListener(mCancelSuggestionsAction);
+        mCancelSuggestionsAction.setCloseIconDrawable(mCandidateView.getCloseIcon());
         return view;
     }
 
@@ -1372,7 +1378,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
     }
 
     @VisibleForTesting
-    static class CancelSuggestionsAction implements KeyboardViewContainerView.StripActionProvider {
+    static class CancelSuggestionsAction implements KeyboardViewContainerView.StripActionProvider, CloseIconChangedListener {
         // two seconds is enough.
         private static final long DOUBLE_TAP_TIMEOUT = 2 * 1000 - 50;
         private final Runnable mCancelPrediction;
@@ -1382,6 +1388,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         private Animation mCloseTextToVisibleAnimation;
         private View mRootView;
         private View mCloseText;
+        private Drawable mCloseIcon;
         private final Runnable mReHideTextAction =
                 () -> {
                     mCloseTextToGoneAnimation.reset();
@@ -1439,6 +1446,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             mCloseText = mRootView.findViewById(R.id.close_suggestions_strip_text);
 
+            setCloseIcon();
+
             mRootView.setOnClickListener(
                     view -> {
                         mRootView.removeCallbacks(mReHideTextAction);
@@ -1461,6 +1470,17 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
             mRootView.removeCallbacks(mReHideTextAction);
         }
 
+        public void setCloseIconDrawable(Drawable closeIcon) {
+            mCloseIcon = closeIcon;
+        }
+
+        private void setCloseIcon() {
+            ImageView closeIcon = (ImageView) mRootView.findViewById(R.id.close_suggestions_strip_icon);
+            if (mCloseIcon != null) {
+                closeIcon.setImageDrawable(mCloseIcon);
+            }
+        }
+
         void setCancelIconVisible(boolean visible) {
             if (mRootView != null) {
                 final int visibility = visible ? View.VISIBLE : View.GONE;
@@ -1473,5 +1493,15 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                 }
             }
         }
+
+        @Override
+        public void onCloseIconChanged(Drawable icon) {
+            setCloseIconDrawable(icon);
+            setCloseIcon();
+        }
+    }
+
+    public interface CloseIconChangedListener {
+        void onCloseIconChanged(Drawable icon);
     }
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -5,7 +5,6 @@ import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.SystemClock;
 import android.text.TextUtils;
-import android.util.Log;
 import android.util.SparseBooleanArray;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -500,7 +499,6 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         final View view = super.onCreateInputView();
         mCandidateView = getInputViewContainer().getCandidateView();
         mCandidateView.setService(this);
-        Log.d("johnny", "onCreateInputView interface setting");
         mCandidateView.setCloseIconChangedListener(mCancelSuggestionsAction);
         mCancelSuggestionsAction.setCloseIconDrawable(mCandidateView.getCloseIcon());
         return view;

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -500,7 +500,6 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
         mCandidateView = getInputViewContainer().getCandidateView();
         mCandidateView.setService(this);
         mCandidateView.setCloseIconChangedListener(mCancelSuggestionsAction);
-        mCancelSuggestionsAction.setCloseIconDrawable(mCandidateView.getCloseIcon());
         return view;
     }
 
@@ -1444,7 +1443,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
             mCloseText = mRootView.findViewById(R.id.close_suggestions_strip_text);
 
-            setCloseIcon();
+            ImageView closeIcon = mRootView.findViewById(R.id.close_suggestions_strip_icon);
+            closeIcon.setImageDrawable(mCloseIcon);
 
             mRootView.setOnClickListener(
                     view -> {
@@ -1468,17 +1468,6 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
             mRootView.removeCallbacks(mReHideTextAction);
         }
 
-        public void setCloseIconDrawable(Drawable closeIcon) {
-            mCloseIcon = closeIcon;
-        }
-
-        private void setCloseIcon() {
-            ImageView closeIcon = (ImageView) mRootView.findViewById(R.id.close_suggestions_strip_icon);
-            if (mCloseIcon != null) {
-                closeIcon.setImageDrawable(mCloseIcon);
-            }
-        }
-
         void setCancelIconVisible(boolean visible) {
             if (mRootView != null) {
                 final int visibility = visible ? View.VISIBLE : View.GONE;
@@ -1494,8 +1483,7 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
         @Override
         public void onCloseIconChanged(Drawable icon) {
-            setCloseIconDrawable(icon);
-            setCloseIcon();
+            mCloseIcon = icon;
         }
     }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -16,7 +16,6 @@ import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.ImageView;
-
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -1375,7 +1374,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
     }
 
     @VisibleForTesting
-    static class CancelSuggestionsAction implements KeyboardViewContainerView.StripActionProvider, CloseIconChangedListener {
+    static class CancelSuggestionsAction
+            implements KeyboardViewContainerView.StripActionProvider, CloseIconChangedListener {
         // two seconds is enough.
         private static final long DOUBLE_TAP_TIMEOUT = 2 * 1000 - 50;
         private final Runnable mCancelPrediction;

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
@@ -31,7 +31,6 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
@@ -561,7 +561,8 @@ public class CandidateView extends View implements ThemeableChild {
         return mCloseDrawable;
     }
 
-    public void setCloseIconChangedListener(AnySoftKeyboardSuggestions.CloseIconChangedListener listener) {
+    public void setCloseIconChangedListener(
+            AnySoftKeyboardSuggestions.CloseIconChangedListener listener) {
         mCloseIconChangedListener = listener;
     }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/CandidateView.java
@@ -31,6 +31,7 @@ import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
@@ -84,6 +85,7 @@ public class CandidateView extends View implements ThemeableChild {
     private CharSequence mAddToDictionaryHint;
     private int mTargetScrollX;
     private int mTotalWidth;
+    private AnySoftKeyboardSuggestions.CloseIconChangedListener mCloseIconChangedListener;
 
     private boolean mAlwaysUseDrawText;
     @NonNull private Disposable mDisposable = Disposables.empty();
@@ -181,6 +183,7 @@ public class CandidateView extends View implements ThemeableChild {
                         break;
                     case R.attr.suggestionCloseImage:
                         mCloseDrawable = a.getDrawable(remoteIndex);
+                        mCloseIconChangedListener.onCloseIconChanged(mCloseDrawable);
                         break;
                     case R.attr.suggestionTextSize:
                         fontSizePixel = a.getDimension(remoteIndex, fontSizePixel);
@@ -213,6 +216,7 @@ public class CandidateView extends View implements ThemeableChild {
         if (mCloseDrawable == null) {
             mCloseDrawable =
                     ContextCompat.getDrawable(context, R.drawable.close_suggestions_strip_icon);
+            mCloseIconChangedListener.onCloseIconChanged(mCloseDrawable);
         }
         mPaint.setColor(
                 mThemeOverlayCombiner.getThemeResources().getKeyTextColor().getDefaultColor());
@@ -556,6 +560,10 @@ public class CandidateView extends View implements ThemeableChild {
 
     public Drawable getCloseIcon() {
         return mCloseDrawable;
+    }
+
+    public void setCloseIconChangedListener(AnySoftKeyboardSuggestions.CloseIconChangedListener listener) {
+        mCloseIconChangedListener = listener;
     }
 
     private class CandidateStripGestureListener extends GestureDetector.SimpleOnGestureListener {


### PR DESCRIPTION
### Issue
The keyboard is not using the close icon from the theme from `<attr name="suggestionCloseImage" format="reference"/>`

### Description
- Created an interface to update the close icon image in `CancelSuggestionsAction` that gets triggered when the `CandidateView` grabs the `suggestionCloseImage` from the theme.

The icon in question:
![close_icon](https://user-images.githubusercontent.com/14130581/124332926-5f746280-db58-11eb-9677-74bf5cfe7d70.png)
