### PR TITLE
Fix double call to pickSuggestionManually when swiping after correction

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -374,7 +374,6 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     private void confirmLastGesture(boolean withAutoSpace) {
         if (mJustPerformedGesture) {
             pickSuggestionManually(0, getCurrentComposedWord().getTypedWord(), withAutoSpace);
-            mJustPerformedGesture = false;
         }
     }
 
@@ -455,5 +454,12 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
 
             currentGestureDetector.clearGesture();
         }
+    }
+
+    @Override
+    public void pickSuggestionManually(
+            int index, CharSequence suggestion, boolean withAutoSpaceEnabled) {
+        mJustPerformedGesture = false;
+        super.pickSuggestionManually(index, suggestion, withAutoSpaceEnabled);
     }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -245,6 +245,17 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
     }
 
     @Test
+    public void testOnlySingleSpaceAfterPickingGestureSuggestion() {
+        simulateGestureProcess("hello");
+        Assert.assertEquals("hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        mAnySoftKeyboardUnderTest.pickSuggestionManually(0, "hello", true);
+        Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+        simulateGestureProcess("welcome");
+        Assert.assertEquals(
+                "hello welcome", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
     public void testDeleteGesturedWordOnWholeWord() {
         simulateGestureProcess("hello");
         simulateGestureProcess("welcome");


### PR DESCRIPTION
There is currently an issue with the way ASK handles word selection during gesture typing such that if the user selects an option from the suggestions bar after swiping a word, ASK will internally select the suggestion _again_ when the user begins swiping the next word. This change ensures that pickSuggestionManually will only be called once per word during gesture typing.

This fixes #2817 and #2846, but does not fix #2813 or #2841. I believe those are (at least partly) separate issues.