### PR TITLE
Adding Sardinian to the "force locale" setting list

### DIFF
--- a/ime/app/src/main/res/values/settings_keys_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_keys_dont_translate.xml
@@ -302,6 +302,7 @@
         <item>pt-rBR</item>
         <item>ro</item>
         <item>ru</item>
+        <item>sc</item>
         <item>se</item>
         <item>sk</item>
         <item>sl</item>


### PR DESCRIPTION
Adding Sardinian ("sc") to the list of languages for the "force locale" setting.