### PR TITLE
Spanish: prioritize accents over numbers in popups

### DIFF
--- a/addons/languages/spain/pack/src/main/res/xml/es_qwerty.xml
+++ b/addons/languages/spain/pack/src/main/res/xml/es_qwerty.xml
@@ -5,13 +5,13 @@
     <Row>
         <Key android:codes="113" android:popupCharacters="1" android:keyEdgeFlags="left"/>
         <Key android:codes="119" android:popupCharacters="2ŵς"/>
-        <Key android:codes="101" android:popupCharacters="3éèëêęėēẽẻε€" />
+        <Key android:codes="101" android:popupCharacters="é3èëêęėēẽẻε€" />
         <Key android:codes="114" android:popupCharacters="4řŕρ"/>
         <Key android:codes="116" android:popupCharacters="5țťţτ"/>
         <Key android:codes="121" android:popupCharacters="6ýÿυ"/>
-        <Key android:codes="117" android:popupCharacters="7úùüûŭűūųṷůθ"/>
-        <Key android:codes="105" android:popupCharacters="8íìïîīǐįïɨι"/>
-        <Key android:codes="111" android:popupCharacters="9óòöõôǒōőøœoº"/>
+        <Key android:codes="117" android:popupCharacters="ú7ùüûŭűūųṷůθ"/>
+        <Key android:codes="105" android:popupCharacters="í8ìïîīǐįïɨι"/>
+        <Key android:codes="111" android:popupCharacters="ó9òöõôǒōőøœoº"/>
         <Key android:codes="112" android:popupCharacters="0π" android:keyEdgeFlags="right"/>
     </Row>
 

--- a/addons/languages/spain/pack/src/main/res/xml/es_qwerty_with_symbols.xml
+++ b/addons/languages/spain/pack/src/main/res/xml/es_qwerty_with_symbols.xml
@@ -7,18 +7,18 @@
     <Row>
         <Key android:codes="q" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
-        <Key android:codes="e" android:popupCharacters="3€³₃êéèëęē" ask:hintLabel="3"/>
+        <Key android:codes="e" android:popupCharacters="é3€³₃êèëęē" ask:hintLabel="3"/>
         <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
         <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
         <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
-        <Key android:codes="u" android:popupCharacters="7ùûüŭúűūµ" ask:hintLabel="7"/>
-        <Key android:codes="i" android:popupCharacters="8ìîïłíīι*" ask:hintLabel="8"/>
-        <Key android:codes="o" android:popupCharacters="9òôõöóøőœō" ask:hintLabel="9"/>
+        <Key android:codes="u" android:popupCharacters="ú7ùûüŭűūµ" ask:hintLabel="7"/>
+        <Key android:codes="i" android:popupCharacters="í8ìîïłīι*" ask:hintLabel="8"/>
+        <Key android:codes="o" android:popupCharacters="ó9òôõöøőœō" ask:hintLabel="9"/>
         <Key android:codes="p" android:popupCharacters="0¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>
-        <Key android:codes="a" android:popupCharacters="\@àâãāáäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="a" android:popupCharacters="á\@àâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
         <Key android:codes="s" android:popupCharacters="$§ßśŝšṣ" ask:hintLabel="$"/>
         <Key android:codes="d" android:popupCharacters="#%đďḏ" ask:hintLabel="# %"/>
         <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>

--- a/addons/languages/spain/pack/src/main/res/xml/es_qwerty_with_symbols_alt.xml
+++ b/addons/languages/spain/pack/src/main/res/xml/es_qwerty_with_symbols_alt.xml
@@ -7,18 +7,18 @@
     <Row>
         <Key android:codes="q" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="w" android:popupCharacters="2²₂ŵ" ask:hintLabel="2"/>
-        <Key android:codes="e" android:popupCharacters="3€³₃êéèëęē" ask:hintLabel="3"/>
+        <Key android:codes="e" android:popupCharacters="é3€³₃êèëęē" ask:hintLabel="3"/>
         <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
         <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
         <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
-        <Key android:codes="u" android:popupCharacters="7ùûüŭúűūµ" ask:hintLabel="7"/>
-        <Key android:codes="i" android:popupCharacters="8ìîïłíīι*" ask:hintLabel="8"/>
-        <Key android:codes="o" android:popupCharacters="9òôõöóøőœō" ask:hintLabel="9"/>
+        <Key android:codes="u" android:popupCharacters="ú7ùûüŭűūµ" ask:hintLabel="7"/>
+        <Key android:codes="i" android:popupCharacters="í8ìîïłīι*" ask:hintLabel="8"/>
+        <Key android:codes="o" android:popupCharacters="ó9òôõöøőœō" ask:hintLabel="9"/>
         <Key android:codes="p" android:popupCharacters="0¶" ask:hintLabel="0" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>
-        <Key android:codes="a" android:popupCharacters="\@àâãāáäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
+        <Key android:codes="a" android:popupCharacters="á\@àâãāäåæą" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
         <Key android:codes="s" android:popupCharacters="$§ßśŝšṣ" ask:hintLabel="$"/>
         <Key android:codes="d" android:popupCharacters="#%đďḏ" ask:hintLabel="# %"/>
         <Key android:codes="f" android:popupCharacters="^\u0026" ask:hintLabel="^ \u0026"/>


### PR DESCRIPTION
See https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/2915.

In Spanish, graphic accents ("[acentos gráficos](https://es.wikipedia.org/wiki/Acento_gr%C3%A1fico)" or "tildes") are extremely common. These accents appear only on the vowels (áéíóú). Right now, the default popup keys for these letters on long-press are numbers, which makes it cumbersome to add accents.

This PR prioritizes accents over numbers on the letters "aeiou", since (at least in Spanish) it is more common to long-press to add an accent than to add a number (plus generally there are more suitable options to add numbers: number row, symbols/numeric keyboard).