### PR TITLE
Bump AndroidX Navigation 2.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,4 @@ org.gradle.caching=true
 android.useAndroidX=true
 android.testConfig.useRelativePath=true
 android.enableJetifier=true
-android.enableD8=true
-android.enableR8=true
 android.enableR8.fullMode=true

--- a/gradle/root_all_projects_ext.gradle
+++ b/gradle/root_all_projects_ext.gradle
@@ -4,7 +4,7 @@ allprojects {
         robolectricVersion = '4.7.3'
 
         androidxCore = '1.3.2'
-        androidxNavigation = '2.3.5'
+        androidxNavigation = '2.4.0'
         androidxTestCore = '1.4.0'
         androidxAppCompat = '1.4.0'
         androidxFragement = '1.4.0'


### PR DESCRIPTION
Fixes opening ASK settings from launcher on master in release build.

https://developer.android.com/jetpack/androidx/releases/navigation#2.4.0
Relevant bug fix (since 2.4.0-alpha04):
> Add ProGuard rules for @Navigator.Name, fixing issues when using R8 3.1 full mode.

See https://issuetracker.google.com/issues/191654433

Also remove deprecated options from gradle.properties.

