### PR TITLE
add embedding RTL, LTR and PDF for bidi support

### DIFF
--- a/addons/languages/persian/pack/src/main/res/xml/persian_qwerty.xml
+++ b/addons/languages/persian/pack/src/main/res/xml/persian_qwerty.xml
@@ -64,7 +64,7 @@
              ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"/>
         <Key android:codes="1548" android:keyLabel="،" android:popupCharacters="&#1563;,;&#1614;&#1616;&#1615;&#1611;&#1613;&#1612;&#1619;&#1618;&#1617;&#1648;&#1622;"/>
         <Key android:codes="8204" android:keyLabel=".|." android:popupCharacters="&#39;&#34;\u201c\u201e\u201d\u2018\u2019"/>
-        <Key android:codes="32" android:keyWidth="30%p"/>
+        <Key android:codes="32" android:keyWidth="30%p" android:popupKeyboard="@xml/popup_qwerty_space"/>
         <Key android:codes="1567" android:keyLabel="؟" android:popupCharacters="/@\u0026\u00bf\u00a1&#11822;&#8253;_-?"/>
         <Key android:codes="46" android:keyLabel="." android:popupCharacters="!:-\u2014_\u00b7\u2026&#171;&#187;"/>
         <Key android:codes="10" android:keyWidth="15.45%p" android:keyEdgeFlags="right"/>

--- a/addons/languages/persian/pack/src/main/res/xml/persian_qwerty_compact.xml
+++ b/addons/languages/persian/pack/src/main/res/xml/persian_qwerty_compact.xml
@@ -49,7 +49,7 @@
              ask:longPressCode="@integer/key_code_mode_alphabet_popup" ask:keyDynamicEmblem="icon"/>
         <Key android:codes="1548" android:keyWidth="10%p" android:keyLabel="،" android:popupCharacters="&#1563;,;&#1614;&#1616;&#1615;&#1611;&#1613;&#1612;&#1619;&#1618;&#1617;&#1648;&#1622;"/>
         <Key android:codes="8204" android:keyWidth="10%p" android:keyLabel=".|." android:popupCharacters="&#39;&#34;\u201c\u201e\u201d\u2018\u2019"/>
-        <Key android:codes="32" android:keyWidth="30%p" android:popupCharacters="&#8206;"/>
+        <Key android:codes="32" android:keyWidth="30%p" android:popupKeyboard="@xml/popup_qwerty_space"/>
         <Key android:codes="1567" android:keyWidth="10%p" android:keyLabel="؟" android:popupCharacters="/@\u0026\u00bf\u00a1&#11822;&#8253;_-?"/>
         <Key android:codes="46" android:keyWidth="10%p" android:keyLabel="." android:popupCharacters="!:-\u2014_\u00b7\u2026&#171;&#187;"/>
         <Key android:codes="10" android:keyWidth="10%p" android:keyEdgeFlags="right"/>

--- a/addons/languages/persian/pack/src/main/res/xml/popup_qwerty_space.xml
+++ b/addons/languages/persian/pack/src/main/res/xml/popup_qwerty_space.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+          android:keyWidth="15%p">
+    <Row android:rowEdgeFlags="top">
+        <!-- LTR Embedding, Pop Directional Formatting, RTL Embedding -->
+        <Key android:codes="8234" android:keyLabel="↳" android:keyEdgeFlags="left"/>
+        <Key android:codes="8236" android:keyLabel="⇹"/>
+        <Key android:codes="8235" android:keyLabel="↲" android:keyEdgeFlags="right"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
Add [Left-To-Right Embedding](https://unicode-table.com/en/202A/), [Right-To-Left Embedding](https://unicode-table.com/en/202B/) and [Pop Directional Formatting](https://unicode-table.com/en/202C/) as popup characters on space key for writing English text in Persian paragraphs and Persian text in English paragraphs with proper bidi formatting.