### PR TITLE
Gesture typing respects the initial state of the shift key

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -34,6 +34,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
     @Nullable private GestureTypingDetector mCurrentGestureDetector;
     private boolean mDetectorReady = false;
     private boolean mJustPerformedGesture = false;
+    private boolean mGestureShifted = false;
 
     @NonNull private Disposable mDetectorStateSubscription = Disposables.disposed();
 
@@ -296,6 +297,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
         if (mGestureTypingEnabled
                 && currentGestureDetector != null
                 && isValidGestureTypingStart(key)) {
+            mGestureShifted = mShiftKeyState.isActive();
             // we can call this as many times as we want, it has a short-circuit check.
             confirmLastGesture(mPrefsAutoSpace);
 
@@ -387,7 +389,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
             ArrayList<String> gestureTypingPossibilities = currentGestureDetector.getCandidates();
 
             if (!gestureTypingPossibilities.isEmpty()) {
-                final boolean isShifted = mShiftKeyState.isActive();
+                final boolean isShifted = mGestureShifted;
                 final boolean isCapsLocked = mShiftKeyState.isLocked();
 
                 final Locale locale = getCurrentAlphabetKeyboard().getLocale();

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -139,6 +139,20 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
     }
 
     @Test
+    public void testOutputCapitalisedOnShiftLocked() {
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT_LOCK);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("HELLO", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testOutputTitleCaseOnShifted() {
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SHIFT);
+        simulateGestureProcess("hello");
+        Assert.assertEquals("Hello", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
     public void testCanOutputFromBothDictionaries() {
         mAnySoftKeyboardUnderTest
                 .mGestureTypingDetectors


### PR DESCRIPTION
With auto-capitalise off, the shift key would disengage when
gesture-typing and the word would be full lowercase. This ensures that
if shift is active when the gesture starts, then the word will be
shifted.