### PR TITLE
Backspace after gesture clears word

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,8 +31,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: check
@@ -66,8 +66,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: check
@@ -117,8 +117,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: tests
@@ -155,8 +155,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: tests
@@ -193,8 +193,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: global-gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: tests
@@ -231,8 +231,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: verify-add-ons
@@ -267,8 +267,8 @@ jobs:
       - uses: actions/cache@v1.1.2
         with:
           path: .github_cache_gradle/
-          key: gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
-          restore-keys: gradle-v5-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
+          key: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: global-gradle-v6-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-
       - name: setup
         run: ./scripts/ci/ci_setup.sh
       - name: dry-run-release-build

--- a/ime/app/src/main/res/layout/clear_gesture_action.xml
+++ b/ime/app/src/main/res/layout/clear_gesture_action.xml
@@ -13,7 +13,7 @@
         android:layout_height="@dimen/candidate_strip_height"
         android:layout_gravity="center_vertical"
         android:background="@android:color/transparent"
-        android:contentDescription="Undo gesture typing"
+        android:contentDescription="@string/undo_gesture_typing"
         android:scaleType="centerInside"
         android:src="@drawable/yochees_dark_backspace" />
 </LinearLayout>

--- a/ime/app/src/main/res/layout/clear_gesture_action.xml
+++ b/ime/app/src/main/res/layout/clear_gesture_action.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/clear_gesture_strip_root"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/clear_gesture_action_icon"
+        android:layout_width="@dimen/candidate_strip_height"
+        android:layout_height="@dimen/candidate_strip_height"
+        android:layout_gravity="center_vertical"
+        android:background="@android:color/transparent"
+        android:contentDescription="Undo gesture typing"
+        android:scaleType="centerInside"
+        android:src="@drawable/yochees_dark_backspace" />
+</LinearLayout>

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -933,6 +933,7 @@
     <string name="gesture_typing_alert_title">BETA Feature!</string>
     <string name="gesture_typing_alert_message">The gesture-typing ➿ feature is at <b>beta</b> maturity. It has some bugs, not that fast, and not that complete.\nSaying that, you should try it out.</string>
     <string name="gesture_typing_alert_button">Got it</string>
+    <string name="undo_gesture_typing">Undo gesture typing</string>
     <string name="apply_remote_app_colors_to_theme">Change theme colors based on used app</string>
     <string name="apply_overlay_summary_on">Keyboard\'s colors will match active app (to the best of our ability).</string>
     <string name="apply_overlay_summary_off">Always use theme\'s colors.</string>
@@ -947,7 +948,7 @@
     <string name="app_share_title">Hello from AnySoftKeyboard</string>
     <string name="app_share_menu_title">Share AnySoftKeyboard using</string>
     <string name="app_share_text">Let me recommend the open-source, privacy-focus, free, highly customizable, multi-language Android keyboard app AnySoftKeyboard.\nGet it from:\nPlay Store: https://play.google.com/store/apps/details?id=com.menny.android.anysoftkeyboard\nF-Droid: https://f-droid.org/en/packages/com.menny.android.anysoftkeyboard/</string>
-    
+
     <string name="click_me_for_easter_egg_info">click me for a surprise</string>
     <string name="backup_restore_not_support_before_kitkat">Not supported on your Android</string>
     <string name="backup_restore_not_support_before_kitkat_message">Backup and restore are not supported for devices running Android OS prior to KitKat (version 4.4). Sorry.</string>

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -313,14 +313,16 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
     @Test
     public void testShowClearGestureButton() {
         simulateGestureProcess("hello");
-        Assert.assertTrue(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
+        Assert.assertEquals(
+                View.VISIBLE, mAnySoftKeyboardUnderTest.mClearLastGestureAction.getVisibility());
     }
 
     @Test
     public void testHideClearGestureButtonOnConfirmed() {
         simulateGestureProcess("hello");
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
-        Assert.assertFalse(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
+        Assert.assertEquals(
+                View.GONE, mAnySoftKeyboardUnderTest.mClearLastGestureAction.getVisibility());
     }
 
     @Test
@@ -352,7 +354,8 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
 
         onClickListener.onClick(rootActionView);
 
-        Assert.assertFalse(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
+        Assert.assertEquals(
+                View.GONE, mAnySoftKeyboardUnderTest.mClearLastGestureAction.getVisibility());
     }
 
     @Test

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -3,7 +3,6 @@ package com.anysoftkeyboard.ime;
 import static org.mockito.ArgumentMatchers.any;
 
 import android.view.View;
-
 import com.anysoftkeyboard.AddOnTestUtils;
 import com.anysoftkeyboard.AnySoftKeyboardBaseTest;
 import com.anysoftkeyboard.AnySoftKeyboardRobolectricTestRunner;
@@ -331,7 +330,7 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
                 mAnySoftKeyboardUnderTest.mClearLastGestureAction;
         View rootActionView =
                 provider.inflateActionView(mAnySoftKeyboardUnderTest.getInputViewContainer())
-                                .findViewById(R.id.clear_gesture_strip_root);
+                        .findViewById(R.id.clear_gesture_strip_root);
         final View.OnClickListener onClickListener =
                 Shadows.shadowOf(rootActionView).getOnClickListener();
 
@@ -347,7 +346,7 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
                 mAnySoftKeyboardUnderTest.mClearLastGestureAction;
         View rootActionView =
                 provider.inflateActionView(mAnySoftKeyboardUnderTest.getInputViewContainer())
-                                .findViewById(R.id.clear_gesture_strip_root);
+                        .findViewById(R.id.clear_gesture_strip_root);
         final View.OnClickListener onClickListener =
                 Shadows.shadowOf(rootActionView).getOnClickListener();
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardGestureTypingTest.java
@@ -2,6 +2,8 @@ package com.anysoftkeyboard.ime;
 
 import static org.mockito.ArgumentMatchers.any;
 
+import android.view.View;
+
 import com.anysoftkeyboard.AddOnTestUtils;
 import com.anysoftkeyboard.AnySoftKeyboardBaseTest;
 import com.anysoftkeyboard.AnySoftKeyboardRobolectricTestRunner;
@@ -13,6 +15,7 @@ import com.anysoftkeyboard.dictionaries.GetWordsCallback;
 import com.anysoftkeyboard.gesturetyping.GestureTypingDetector;
 import com.anysoftkeyboard.keyboards.AnyKeyboard;
 import com.anysoftkeyboard.keyboards.Keyboard;
+import com.anysoftkeyboard.keyboards.views.KeyboardViewContainerView;
 import com.anysoftkeyboard.rx.TestRxSchedulers;
 import com.anysoftkeyboard.test.SharedPrefsHelper;
 import com.menny.android.anysoftkeyboard.R;
@@ -27,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.robolectric.Shadows;
 import org.robolectric.shadows.ShadowSystemClock;
 
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
@@ -305,6 +309,51 @@ public class AnySoftKeyboardGestureTypingTest extends AnySoftKeyboardBaseTest {
         Assert.assertEquals("hello ", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE_WORD);
         Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testShowClearGestureButton() {
+        simulateGestureProcess("hello");
+        Assert.assertTrue(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
+    }
+
+    @Test
+    public void testHideClearGestureButtonOnConfirmed() {
+        simulateGestureProcess("hello");
+        mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
+    }
+
+    @Test
+    public void testClearGestureButtonClearsGesture() {
+        simulateGestureProcess("hello");
+        final KeyboardViewContainerView.StripActionProvider provider =
+                mAnySoftKeyboardUnderTest.mClearLastGestureAction;
+        View rootActionView =
+                provider.inflateActionView(mAnySoftKeyboardUnderTest.getInputViewContainer())
+                                .findViewById(R.id.clear_gesture_strip_root);
+        final View.OnClickListener onClickListener =
+                Shadows.shadowOf(rootActionView).getOnClickListener();
+
+        onClickListener.onClick(rootActionView);
+
+        Assert.assertEquals("", mAnySoftKeyboardUnderTest.getCurrentInputConnectionText());
+    }
+
+    @Test
+    public void testHideClearGestureButtonOnClear() {
+        simulateGestureProcess("hello");
+        final KeyboardViewContainerView.StripActionProvider provider =
+                mAnySoftKeyboardUnderTest.mClearLastGestureAction;
+        View rootActionView =
+                provider.inflateActionView(mAnySoftKeyboardUnderTest.getInputViewContainer())
+                                .findViewById(R.id.clear_gesture_strip_root);
+        final View.OnClickListener onClickListener =
+                Shadows.shadowOf(rootActionView).getOnClickListener();
+
+        onClickListener.onClick(rootActionView);
+
+        Assert.assertFalse(mAnySoftKeyboardUnderTest.mClearLastGestureAction.isVisible());
     }
 
     @Test

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardQuickTextTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardQuickTextTest.java
@@ -9,10 +9,12 @@ import com.anysoftkeyboard.TestInputConnection;
 import com.anysoftkeyboard.TestableAnySoftKeyboard;
 import com.anysoftkeyboard.api.KeyCodes;
 import com.anysoftkeyboard.keyboards.Keyboard;
+import com.anysoftkeyboard.quicktextkeys.ui.QuickTextPagerView;
 import com.anysoftkeyboard.rx.TestRxSchedulers;
 import com.anysoftkeyboard.test.SharedPrefsHelper;
 import com.anysoftkeyboard.test.TestUtils;
 import com.menny.android.anysoftkeyboard.R;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +36,16 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
         mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.QUICK_TEXT);
 
         Assert.assertEquals(KEY_OUTPUT, inputConnection.getCurrentTextInInputConnection());
-        Assert.assertEquals(4, mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount());
+        AtomicBoolean foundQuickTextView = new AtomicBoolean(false);
+        for (int childIndex = 0;
+                childIndex < mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount();
+                childIndex++) {
+            if (mAnySoftKeyboardUnderTest.getInputViewContainer().getChildAt(childIndex)
+                    instanceof QuickTextPagerView) {
+                foundQuickTextView.set(true);
+            }
+        }
+        Assert.assertFalse(foundQuickTextView.get());
         Assert.assertFalse(mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
 
         Assert.assertSame(
@@ -381,7 +392,16 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
 
         Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
 
-        Assert.assertEquals(4, mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount());
+        AtomicBoolean foundQuickTextView = new AtomicBoolean(false);
+        for (int childIndex = 0;
+                childIndex < mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount();
+                childIndex++) {
+            if (mAnySoftKeyboardUnderTest.getInputViewContainer().getChildAt(childIndex)
+                    instanceof QuickTextPagerView) {
+                foundQuickTextView.set(true);
+            }
+        }
+        Assert.assertTrue(foundQuickTextView.get());
 
         Assert.assertSame(
                 mAnySoftKeyboardUnderTest.getInputView(),
@@ -403,7 +423,16 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
 
         Assert.assertEquals(KEY_OUTPUT, inputConnection.getCurrentTextInInputConnection());
 
-        Assert.assertEquals(4, mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount());
+        AtomicBoolean foundQuickTextView = new AtomicBoolean(false);
+        for (int childIndex = 0;
+                childIndex < mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount();
+                childIndex++) {
+            if (mAnySoftKeyboardUnderTest.getInputViewContainer().getChildAt(childIndex)
+                    instanceof QuickTextPagerView) {
+                foundQuickTextView.set(true);
+            }
+        }
+        Assert.assertFalse(foundQuickTextView.get());
 
         Assert.assertSame(
                 mAnySoftKeyboardUnderTest.getInputView(),
@@ -431,7 +460,16 @@ public class AnySoftKeyboardQuickTextTest extends AnySoftKeyboardBaseTest {
 
         Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
 
-        Assert.assertEquals(4, mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount());
+        AtomicBoolean foundQuickTextView = new AtomicBoolean(false);
+        for (int childIndex = 0;
+                childIndex < mAnySoftKeyboardUnderTest.getInputViewContainer().getChildCount();
+                childIndex++) {
+            if (mAnySoftKeyboardUnderTest.getInputViewContainer().getChildAt(childIndex)
+                    instanceof QuickTextPagerView) {
+                foundQuickTextView.set(true);
+            }
+        }
+        Assert.assertTrue(foundQuickTextView.get());
 
         Assert.assertSame(
                 mAnySoftKeyboardUnderTest.getInputView(),


### PR DESCRIPTION
Similar to Gboard, pressing backspace immediately after gesture input
will clear the word you gestured.

Good for correcting mistaken gesture input.

Marked draft since I haven't been able to run the tests yet