### PR TITLE
Handle keyHeight if given as dimension/fraction

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
@@ -673,6 +673,8 @@ public abstract class Keyboard {
         if (value == null) {
             // means that it was not provided. So I take my mParent's
             return defaultHeightCode;
+        } else if (value.type == TypedValue.TYPE_DIMENSION) {
+            return a.getDimensionPixelOffset(remoteIndex, defaultHeightCode);
         } else if (value.type >= TypedValue.TYPE_FIRST_INT
                 && value.type <= TypedValue.TYPE_LAST_INT
                 && value.data <= 0

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
@@ -81,9 +81,7 @@ public class KeyboardSupport {
                 height = keyboardDimens.getLargeKeyHeight();
                 break;
             default:
-                height = heightCode >= 0
-                    ? heightCode
-                    : keyboardDimens.getNormalKeyHeight();
+                height = heightCode >= 0 ? heightCode : keyboardDimens.getNormalKeyHeight();
                 break;
         }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/KeyboardSupport.java
@@ -71,8 +71,8 @@ public class KeyboardSupport {
             KeyboardDimens keyboardDimens, int heightCode, float heightFactor) {
         int height;
         switch (heightCode) {
-            case 0:
-                height = 0;
+            case -1:
+                height = keyboardDimens.getNormalKeyHeight();
                 break;
             case -2:
                 height = keyboardDimens.getSmallKeyHeight();
@@ -80,8 +80,10 @@ public class KeyboardSupport {
             case -3:
                 height = keyboardDimens.getLargeKeyHeight();
                 break;
-            default: // -1
-                height = keyboardDimens.getNormalKeyHeight();
+            default:
+                height = heightCode >= 0
+                    ? heightCode
+                    : keyboardDimens.getNormalKeyHeight();
                 break;
         }
 


### PR DESCRIPTION
When running aapt on keyboard XML files, it allows android:keyHeight to be a dimension or fraction as well as a reference to one of the height codes. Previously, values like "20dp" or "10%p" were ignored and replaced with the default key height. This commit allows layouts to specify precise dimensions if desired.