### PR TITLE
Fixed short backspace on the German QWERTY slim layout

### DIFF
--- a/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_qwerty_slim.xml
@@ -39,6 +39,6 @@
         <Key android:codes="98" android:keyLabel="b" android:popupCharacters=""/>
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñ"/>
         <Key android:codes="109" android:keyLabel="m" android:popupCharacters="µ"/>
-        <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
+        <Key android:keyWidth="15%p" android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>
 </Keyboard>


### PR DESCRIPTION
Goes from this:
![Screenshot_20220920-132058_Finder](https://user-images.githubusercontent.com/31864305/191245928-0e1763f4-1da8-4376-9d0c-13a592fff976.jpg)
to this:
![Screenshot_20220920-132058_Finder](https://user-images.githubusercontent.com/31864305/191246249-10233509-6ad0-4165-9306-1cdc7a62e06a.jpg)
Notice the backspace key.