### PR TITLE
Fix MIME type for media insertion

### DIFF
--- a/ime/fileprovider/src/main/java/com/anysoftkeyboard/fileprovider/LocalProxy.java
+++ b/ime/fileprovider/src/main/java/com/anysoftkeyboard/fileprovider/LocalProxy.java
@@ -4,6 +4,7 @@ import static androidx.core.content.FileProvider.getUriForFile;
 
 import android.content.Context;
 import android.net.Uri;
+import android.webkit.MimeTypeMap;
 import androidx.annotation.NonNull;
 import com.anysoftkeyboard.base.utils.Logger;
 import com.anysoftkeyboard.rx.RxSchedulers;
@@ -27,9 +28,14 @@ public class LocalProxy {
             throws IOException {
         try (InputStream remoteInputStream =
                 context.getContentResolver().openInputStream(remoteUri)) {
+            final String ext =
+                    MimeTypeMap.getSingleton()
+                            .getExtensionFromMimeType(
+                                    context.getContentResolver().getType(remoteUri));
             final File localFilesFolder = new File(context.getFilesDir(), "media");
             if (localFilesFolder.isDirectory() || localFilesFolder.mkdirs()) {
-                final File targetFile = new File(localFilesFolder, remoteUri.getLastPathSegment());
+                final File targetFile =
+                        new File(localFilesFolder, remoteUri.getLastPathSegment() + "." + ext);
 
                 Logger.d(
                         "ASKLocalProxy",

--- a/ime/fileprovider/src/main/java/com/anysoftkeyboard/fileprovider/LocalProxy.java
+++ b/ime/fileprovider/src/main/java/com/anysoftkeyboard/fileprovider/LocalProxy.java
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 
 public class LocalProxy {
     public static Single<Uri> proxy(@NonNull Context context, @NonNull Uri data) {
@@ -28,14 +29,31 @@ public class LocalProxy {
             throws IOException {
         try (InputStream remoteInputStream =
                 context.getContentResolver().openInputStream(remoteUri)) {
-            final String ext =
-                    MimeTypeMap.getSingleton()
-                            .getExtensionFromMimeType(
-                                    context.getContentResolver().getType(remoteUri));
+            final var mimeType = context.getContentResolver().getType(remoteUri);
+            final var ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+            Logger.d(
+                    "ASKLocalProxy",
+                    "Got mime-type '%s' and ext '%s' for url '%s'",
+                    mimeType,
+                    ext,
+                    remoteUri);
+
             final File localFilesFolder = new File(context.getFilesDir(), "media");
+
             if (localFilesFolder.isDirectory() || localFilesFolder.mkdirs()) {
-                final File targetFile =
-                        new File(localFilesFolder, remoteUri.getLastPathSegment() + "." + ext);
+                final File targetFile;
+                if (ext == null) {
+                    targetFile = new File(localFilesFolder, remoteUri.getLastPathSegment());
+                } else {
+                    targetFile =
+                            new File(
+                                    localFilesFolder,
+                                    String.format(
+                                            Locale.ROOT,
+                                            "%s.%s",
+                                            remoteUri.getLastPathSegment(),
+                                            ext));
+                }
 
                 Logger.d(
                         "ASKLocalProxy",

--- a/ime/fileprovider/src/test/java/com/anysoftkeyboard/fileprovider/LocalProxyTest.java
+++ b/ime/fileprovider/src/test/java/com/anysoftkeyboard/fileprovider/LocalProxyTest.java
@@ -1,14 +1,17 @@
 package com.anysoftkeyboard.fileprovider;
 
 import android.content.Context;
+import android.content.pm.ProviderInfo;
 import android.net.Uri;
+import android.webkit.MimeTypeMap;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
 import androidx.test.core.app.ApplicationProvider;
 import com.anysoftkeyboard.AnySoftKeyboardRobolectricTestRunner;
 import com.anysoftkeyboard.base.Charsets;
 import com.anysoftkeyboard.rx.TestRxSchedulers;
 import com.google.common.io.Files;
-import io.reactivex.Single;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -19,7 +22,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
+import org.robolectric.android.controller.ContentProviderController;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -29,27 +34,60 @@ public class LocalProxyTest {
 
     private Uri mUri;
     private FileInputStream mInputStream;
+    private ContentProviderController<FileProvider> mFileProvider;
 
     @Before
     public void setup() throws IOException {
-        final File tempFile = File.createTempFile("LocalProxyTest", ".txt");
+        final var appId = ApplicationProvider.getApplicationContext().getPackageName();
+        final File tempFile = File.createTempFile("LocalProxyTest", ".png");
         Files.write("testing 123".getBytes(Charsets.UTF8), tempFile);
-        mUri = Uri.parse("content://some.remote.app/file.png");
+        mUri = Uri.parse("content://" + appId + "/file.png");
         mInputStream = new FileInputStream(tempFile);
-        Shadows.shadowOf(ApplicationProvider.getApplicationContext().getContentResolver())
-                .registerInputStream(mUri, mInputStream);
+        var shadowContentResolver =
+                Shadows.shadowOf(ApplicationProvider.getApplicationContext().getContentResolver());
+        shadowContentResolver.registerInputStream(mUri, mInputStream);
+        var providerInfo = new ProviderInfo();
+        providerInfo.authority = appId;
+        providerInfo.grantUriPermissions = true;
+        mFileProvider = Robolectric.buildContentProvider(FileProvider.class).create(providerInfo);
     }
 
     @After
     public void tearDown() throws IOException {
         mInputStream.close();
+        mFileProvider.shutdown();
     }
 
     @Test
     @Config(shadows = ShadowFileProvider.class)
-    public void testHappyPath() throws IOException {
-        final Single<Uri> uriSingle =
-                LocalProxy.proxy(ApplicationProvider.getApplicationContext(), mUri);
+    public void testHappyPathKnownMime() throws IOException {
+        var shadowMimeTypeMap = Shadows.shadowOf(MimeTypeMap.getSingleton());
+        shadowMimeTypeMap.addExtensionMimeTypMapping("png", "image/png");
+        final var uriSingle = LocalProxy.proxy(ApplicationProvider.getApplicationContext(), mUri);
+        final Uri localUri = TestRxSchedulers.blockingGet(uriSingle);
+
+        Assert.assertNotNull(localUri);
+        Assert.assertEquals("content", localUri.getScheme());
+        Assert.assertEquals("com.anysoftkeyboard.fileprovider.test", localUri.getAuthority());
+        Assert.assertTrue(
+                localUri.getPath() + " should have a different value!",
+                localUri.getPath()
+                        .endsWith(
+                                "com.anysoftkeyboard.fileprovider.test-dataDir/files/media/file.png.png"));
+
+        File actualFile = new File(localUri.getPath());
+        Assert.assertTrue(
+                "File " + actualFile.getAbsolutePath() + " does not exist", actualFile.isFile());
+
+        final List<String> copiedData = Files.readLines(actualFile, Charsets.UTF8);
+        Assert.assertEquals(1, copiedData.size());
+        Assert.assertEquals("testing 123", copiedData.get(0));
+    }
+
+    @Test
+    @Config(shadows = ShadowFileProvider.class)
+    public void testHappyPathUnknownMime() throws IOException {
+        final var uriSingle = LocalProxy.proxy(ApplicationProvider.getApplicationContext(), mUri);
         final Uri localUri = TestRxSchedulers.blockingGet(uriSingle);
 
         Assert.assertNotNull(localUri);
@@ -71,6 +109,22 @@ public class LocalProxyTest {
 
     @Implements(FileProvider.class)
     public static class ShadowFileProvider {
+        @Nullable
+        @Implementation
+        public static String getType(@NonNull Uri uri) {
+            String fileName = uri.getLastPathSegment();
+            final int lastDot = fileName.lastIndexOf('.');
+            if (lastDot >= 0) {
+                final String extension = fileName.substring(lastDot + 1);
+                final String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+                if (mime != null) {
+                    return mime;
+                }
+            }
+
+            return "application/octet-stream";
+        }
+
         @Implementation
         public static Uri getUriForFile(Context context, String authority, File file) {
             return Uri.parse(


### PR DESCRIPTION
When we proxy we lose the MIME type information, so set the file extension based on the MIME type so that contentResolver.getType() will still work on the new URI, this fixes image preview in the text box etc.

Fixes #3542