### PR TITLE
removing jitpack.io

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ buildscript {
         mavenLocal()
         maven { url 'https://repo1.maven.org/maven2' /*maven-central with HTTPS*/ }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-        maven { url 'https://jitpack.io' }
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
@@ -40,7 +39,6 @@ allprojects {
         gradlePluginPortal()
         maven { url 'https://repo1.maven.org/maven2' /*maven-central with HTTPS*/ }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Seems to be unrelayable. Hopefully we can get without it.