### PR TITLE
Added BDS Modern Bulgarian keyboard layout

### DIFF
--- a/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/values/bulgarian_pack_strings_dont_translate.xml
@@ -13,4 +13,7 @@
 
     <string name="bulgarian_keyboard_bekl">Bulgarian BEKL</string>
     <string name="bulgarian_keyboard_bekl_description">Bulgarian BEKL keyboard</string>
+    
+    <string name="bulgarian_keyboard_bds_modern">Bulgarian BDS Modern</string>
+    <string name="bulgarian_keyboard_bds_modern_description">Bulgarian BDS Modern keyboard</string>
 </resources>

--- a/addons/languages/bulgarian/pack/src/main/res/xml/bds_modern.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/xml/bds_modern.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="9.09%p"
+    xmlns:ask="http://schemas.android.com/apk/res-auto"
+    android:keyHeight="@integer/key_normal_height">
+    <Row>
+        <Key android:codes="у" android:popupCharacters="1" ask:hintLabel="1" android:keyEdgeFlags="left"/>
+        <Key android:codes="е" android:popupCharacters="2" ask:hintLabel="2"/>
+        <Key android:codes="и" android:popupCharacters="3ѝ" ask:hintLabel="3"/>
+        <Key android:codes="ш" android:popupCharacters="4" ask:hintLabel="4"/>
+        <Key android:codes="щ" android:popupCharacters="5" ask:hintLabel="5"/>
+        <Key android:codes="к" android:popupCharacters="6" ask:hintLabel="6"/>
+        <Key android:codes="с" android:popupCharacters="7" ask:hintLabel="7"/>
+        <Key android:codes="д" android:popupCharacters="8" ask:hintLabel="8"/>
+        <Key android:codes="з" android:popupCharacters="9" ask:hintLabel="9"/>
+        <Key android:codes="ц" android:popupCharacters="0" ask:hintLabel="0"/>
+        <Key android:codes="б" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="ь" android:popupCharacters="" android:keyEdgeFlags="left"/>
+        <Key android:codes="я" android:popupCharacters=""/>
+        <Key android:codes="а" android:popupCharacters=""/>
+        <Key android:codes="о" android:popupCharacters=""/>
+        <Key android:codes="ж" android:popupCharacters=""/>
+        <Key android:codes="г" android:popupCharacters=""/>
+        <Key android:codes="т" android:popupCharacters=""/>
+        <Key android:codes="н" android:popupCharacters=""/>
+        <Key android:codes="в" android:popupCharacters=""/>
+        <Key android:codes="м" android:popupCharacters=""/>
+        <Key android:codes="ч" android:popupCharacters="" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1"
+             android:isModifier="true" android:isSticky="true" android:keyWidth="13.6%p" android:keyEdgeFlags="left"/>
+        <Key android:codes="ю" android:popupCharacters=""/>
+        <Key android:codes="й" android:popupCharacters=""/>
+        <Key android:codes="ъ" android:popupCharacters=""/>
+        <Key android:codes="ф" android:popupCharacters=""/>
+        <Key android:codes="х" android:popupCharacters=""/>
+        <Key android:codes="п" android:popupCharacters=""/>
+        <Key android:codes="р" android:popupCharacters=""/>
+        <Key android:codes="л" android:popupCharacters=""/>
+        <Key android:codes="-5" android:keyWidth="13.6%p" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>

--- a/addons/languages/bulgarian/pack/src/main/res/xml/bulgarian_keyboards.xml
+++ b/addons/languages/bulgarian/pack/src/main/res/xml/bulgarian_keyboards.xml
@@ -15,4 +15,9 @@
               defaultDictionaryLocale="bg" description="@string/bulgarian_keyboard_bekl_description"
               index="3" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/bulgarian_physical" />
+    <Keyboard nameResId="@string/bulgarian_keyboard_bds_modern" iconResId="@drawable/ic_status_bulgarian"
+              layoutResId="@xml/bds_modern" id="341f8ab5-7ce8-4bba-9c45-58d4a0a7b784"
+              defaultDictionaryLocale="bg" description="@string/bulgarian_keyboard_bds_modern_description"
+              index="4" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/bulgarian_physical" />
 </Keyboards>


### PR DESCRIPTION
Added a new keyboard layout - Bulgarian BDS Modern - that removes unused symbols from the Bulgarian national standard (Български държавен стандарт) layout and optimizes wasted space that is present in the regular BDS layout.

I have also added number hints and numbers as popup characters.

![image](https://user-images.githubusercontent.com/16917926/209964935-93a7b19e-a831-4c69-9df9-def6bed44d21.png)
