### PR TITLE
add ŷ to popup

### DIFF
--- a/addons/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_with_symbols.xml
@@ -11,7 +11,7 @@
         <Key android:codes="e" android:popupCharacters="3³₃èéêëęē€" ask:hintLabel="3"/>
         <Key android:codes="r" android:popupCharacters="4⁴₄řŕ" ask:hintLabel="4"/>
         <Key android:codes="t" android:popupCharacters="5ťṭṯ" ask:hintLabel="5"/>
-        <Key android:codes="y" android:popupCharacters="6ýÿ" ask:hintLabel="6"/>
+        <Key android:codes="y" android:popupCharacters="6ýÿŷ" ask:hintLabel="6"/>
         <Key android:codes="u" android:popupCharacters="7ùúûüŭűūµ" ask:hintLabel="7"/>
         <Key android:codes="i" android:popupCharacters="8ìíîïłīι*" ask:hintLabel="8"/>
         <Key android:codes="o" android:popupCharacters="9òóôõöøőœōº" ask:hintLabel="9"/>


### PR DESCRIPTION
this would add the ŷ (y with ^ diacritic) symbol to the english qwerty with symbols keyboard, when you long press y, added at the end of the popup options because they appear to be arranged in UTF8 symbol order and ŷ comes after the other current popup options