### PR TITLE
New layout with wider spacebar

### DIFF
--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings.xml
@@ -13,4 +13,5 @@
     <string name="halmak_keyboard_description">Nikolay Nemshilov\'s Halmak layout, implemented by Zorkedon</string>
     <string name="english_keyboard_qwertz_symbols_description">QWERTZ Latin keyboard with symbols, by LuKe</string>
     <string name="minimal_qwerty_keyboard_description">Minimal QWERTY layout by Luc Street</string>
+    <string name="english_keyboard_wide_space_description">QWERTY Latin keyboard with wider spacebar</string>
 </resources>

--- a/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
+++ b/addons/languages/english/pack/src/main/res/values/english_pack_strings_dont_translate.xml
@@ -6,6 +6,7 @@
     <string name="english_dictionary">English</string>
     <string name="english_keyboard">English</string>
     <string name="english_keyboard_symbols">English</string>
+    <string name="english_keyboard_wide_space">English</string>
     <string name="dvorak_keyboard">Dvorak</string>
     <string name="compact_keyboard">EN Compact</string>
     <string name="compact_dvorak_keyboard">Dv Compact</string>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -61,4 +61,9 @@
               layoutResId="@xml/minimal_qwerty" id="a59067bb-46d3-48a6-9ede-ccc3ace13a04"
               defaultDictionaryLocale="en" description="@string/minimal_qwerty_keyboard_description"
               index="13"/>
+    <Keyboard nameResId="@string/english_keyboard" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_wide_spacebar" id="TODO"
+              defaultDictionaryLocale="en" description="@string/english_keyboard_wide_space_description"
+              index="1" defaultEnabled="false"
+              physicalKeyboardMappingResId="@xml/english_physical" />
 </Keyboards>

--- a/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
+++ b/addons/languages/english/pack/src/main/res/xml/english_keyboards.xml
@@ -61,8 +61,8 @@
               layoutResId="@xml/minimal_qwerty" id="a59067bb-46d3-48a6-9ede-ccc3ace13a04"
               defaultDictionaryLocale="en" description="@string/minimal_qwerty_keyboard_description"
               index="13"/>
-    <Keyboard nameResId="@string/english_keyboard" iconResId="@drawable/ic_status_english"
-              layoutResId="@xml/qwerty_wide_spacebar" id="TODO"
+    <Keyboard nameResId="@string/english_keyboard_wide_space" iconResId="@drawable/ic_status_english"
+              layoutResId="@xml/qwerty_wide_spacebar" id="2abfe253-995f-1242-d861-3b3a78910491"
               defaultDictionaryLocale="en" description="@string/english_keyboard_wide_space_description"
               index="1" defaultEnabled="false"
               physicalKeyboardMappingResId="@xml/english_physical" />

--- a/addons/languages/english/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty.xml
@@ -1,23 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:keyWidth="10%p"
-    android:keyHeight="@integer/key_normal_height">
-    <!-- for testing shiftCodes 
-    <Row>
-        <Key android:codes="113" android:keyLabel="q" ask:mShiftedCodes="80" android:keyEdgeFlags="left"/>
-        <Key android:codes="119" android:keyLabel="w" ask:mShiftedCodes="86" ask:shiftedKeyLabel="V"/>
-        <Key android:codes="101" android:keyLabel="e" ask:mShiftedCodes="68" ask:shiftedKeyLabel="D"/>
-        <Key android:codes="114" android:keyLabel="r" ask:mShiftedCodes="81" ask:shiftedKeyLabel="Q"/>
-        <Key android:codes="116" android:keyLabel="t" ask:mShiftedCodes="83" ask:shiftedKeyLabel="S"/>
-        <Key android:codes="121" android:keyLabel="y" ask:mShiftedCodes="88" ask:shiftedKeyLabel="X"/>
-        <Key android:codes="117" android:keyLabel="u" ask:mShiftedCodes="84" ask:shiftedKeyLabel="T"/>
-        <Key android:codes="105" android:keyLabel="i" ask:mShiftedCodes="72" ask:shiftedKeyLabel="H"/>
-        <Key android:codes="111" android:keyLabel="o" ask:mShiftedCodes="78" ask:shiftedKeyLabel="M"/>
-        <Key android:codes="112" android:keyLabel="p" ask:mShiftedCodes="80" ask:shiftedKeyLabel="P" android:keyEdgeFlags="right"/>
-    </Row>
-    -->
-    <!-- original -->
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
     <Row>
         <Key android:codes="113" android:popupCharacters="1" android:keyEdgeFlags="left"/>
         <Key android:codes="119" android:popupCharacters="2ŵω"/>
@@ -55,5 +41,18 @@
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñńňν"/>
         <Key android:codes="109" android:keyLabel="m"  android:popupCharacters="μ"/>
         <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:keyWidth="15%p" android:codes="-10" ask:longPressCode="-102" android:keyEdgeFlags="left"/>
+
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="!/@\u0026\u00bf\u00a1\u061F"/>
+        <Key android:codes="44" android:keyLabel="," android:popupCharacters="()"/>
+
+        <Key android:codes="32" android:keyWidth="40%p"/>
+
+<!--        <Key android:codes="46" android:keyLabel="." android:popupCharacters=";:-_\u00b7\u2026"/>-->
+        <Key android:codes="39" android:keyLabel="\'" android:popupCharacters="&#34;\u201c\u201e\u201d\u2018\u2019"/>
+
+        <Key android:codes="10" android:keyWidth="15%p" android:keyEdgeFlags="right" ask:longPressCode="-100"/>
     </Row>
 </Keyboard>

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
@@ -1,23 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
-    android:keyWidth="10%p"
-    android:keyHeight="@integer/key_normal_height">
-    <!-- for testing shiftCodes 
-    <Row>
-        <Key android:codes="113" android:keyLabel="q" ask:mShiftedCodes="80" android:keyEdgeFlags="left"/>
-        <Key android:codes="119" android:keyLabel="w" ask:mShiftedCodes="86" ask:shiftedKeyLabel="V"/>
-        <Key android:codes="101" android:keyLabel="e" ask:mShiftedCodes="68" ask:shiftedKeyLabel="D"/>
-        <Key android:codes="114" android:keyLabel="r" ask:mShiftedCodes="81" ask:shiftedKeyLabel="Q"/>
-        <Key android:codes="116" android:keyLabel="t" ask:mShiftedCodes="83" ask:shiftedKeyLabel="S"/>
-        <Key android:codes="121" android:keyLabel="y" ask:mShiftedCodes="88" ask:shiftedKeyLabel="X"/>
-        <Key android:codes="117" android:keyLabel="u" ask:mShiftedCodes="84" ask:shiftedKeyLabel="T"/>
-        <Key android:codes="105" android:keyLabel="i" ask:mShiftedCodes="72" ask:shiftedKeyLabel="H"/>
-        <Key android:codes="111" android:keyLabel="o" ask:mShiftedCodes="78" ask:shiftedKeyLabel="M"/>
-        <Key android:codes="112" android:keyLabel="p" ask:mShiftedCodes="80" ask:shiftedKeyLabel="P" android:keyEdgeFlags="right"/>
-    </Row>
-    -->
-    <!-- original -->
+          xmlns:ask="http://schemas.android.com/apk/res-auto"
+          android:keyWidth="10%p"
+          android:keyHeight="@integer/key_normal_height">
     <Row>
         <Key android:codes="113" android:popupCharacters="1" android:keyEdgeFlags="left"/>
         <Key android:codes="119" android:popupCharacters="2ŵω"/>
@@ -55,5 +41,18 @@
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñńňν"/>
         <Key android:codes="109" android:keyLabel="m"  android:popupCharacters="μ"/>
         <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+    <Row android:rowEdgeFlags="bottom">
+        <Key android:keyWidth="15%p" android:codes="-10" ask:longPressCode="-102" android:keyEdgeFlags="left"/>
+
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="!/@\u0026\u00bf\u00a1\u061F"/>
+        <Key android:codes="44" android:keyLabel="," android:popupCharacters="()"/>
+
+        <Key android:codes="32" android:keyWidth="40%p"/>
+
+<!--        <Key android:codes="46" android:keyLabel="." android:popupCharacters=";:-_\u00b7\u2026"/>-->
+        <Key android:codes="39" android:keyLabel="\'" android:popupCharacters="&#34;\u201c\u201e\u201d\u2018\u2019"/>
+
+        <Key android:codes="10" android:keyWidth="15%p" android:keyEdgeFlags="right" ask:longPressCode="-100"/>
     </Row>
 </Keyboard>

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
@@ -46,11 +46,10 @@
         <Key android:keyWidth="15%p" android:codes="-10" ask:longPressCode="-102" android:keyEdgeFlags="left"/>
 
         <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="!/@\u0026\u00bf\u00a1\u061F"/>
-        <Key android:codes="44" android:keyLabel="," android:popupCharacters="()"/>
+        <Key android:codes="44" android:keyLabel="," android:popupCharacters="();:-_\u00b7\u2026"/>
 
         <Key android:codes="32" android:keyWidth="40%p"/>
 
-<!--        <Key android:codes="46" android:keyLabel="." android:popupCharacters=";:-_\u00b7\u2026"/>-->
         <Key android:codes="39" android:keyLabel="\'" android:popupCharacters="&#34;\u201c\u201e\u201d\u2018\u2019"/>
 
         <Key android:codes="10" android:keyWidth="15%p" android:keyEdgeFlags="right" ask:longPressCode="-100"/>

--- a/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty_wide_spacebar.xml
@@ -50,7 +50,7 @@
 
         <Key android:codes="32" android:keyWidth="40%p"/>
 
-        <Key android:codes="39" android:keyLabel="\'" android:popupCharacters="&#34;\u201c\u201e\u201d\u2018\u2019"/>
+        <Key android:codes="46" android:keyLabel="." android:popupCharacters="\'&#34;\u201c\u201e\u201d\u2018\u2019"/>
 
         <Key android:codes="10" android:keyWidth="15%p" android:keyEdgeFlags="right" ask:longPressCode="-100"/>
     </Row>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/26749912/233477745-0c57929c-e326-4ab0-ad10-ebe0f848bcd3.png)


I prefer the wider spacebar on the right because I don't have to reach as far with my thumb so it gets strained less. Also, it's closer to what GBoard has so maybe easier for new users to get used to. We could maybe add one that stretches the spacebar to the left instead for left-handed people.

I'm not experienced with android studio or this project so I still need help 1. setting the `id` field for the new entry in english_keyboards.xml 2. changing the colour of the new bottom row - they're the same look and feel as the regular letter keys right now which I don't think is right

many thanks!