### PR TITLE
switch order of search for speech-to-text

### DIFF
--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -37,7 +37,8 @@ public class VoiceRecognitionTrigger {
     private Trigger getTrigger() {
         if (IntentApiTrigger.isInstalled(mInputMethodService)) {
             return getIntentTrigger();
-        } else if (ImeTrigger.isInstalled(mInputMethodService)) { //use Google stt as fallback
+        } else if (ImeTrigger.isInstalled(mInputMethodService)) {
+            //use Google stt as fallback
             return getImeTrigger();
         } else {
             return null;

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -35,10 +35,10 @@ public class VoiceRecognitionTrigger {
     }
 
     private Trigger getTrigger() {
-        if (ImeTrigger.isInstalled(mInputMethodService)) {
-            return getImeTrigger();
-        } else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
+        if (IntentApiTrigger.isInstalled(mInputMethodService)) {
             return getIntentTrigger();
+        } else if (ImeTrigger.isInstalled(mInputMethodService)) { //use Google stt as fallback
+            return getImeTrigger();
         } else {
             return null;
         }


### PR DESCRIPTION
This is a modification to make Google stt the non-default for ASK stt. This fix simply reverses the order of searches for the Google stt app and the intent-api based pm query. Directly addresses #3230, and indirectly addresses #3004 - specifically in the context of using vosk-android-service (as this stt service is at least partly functional as well; also see https://github.com/alphacep/vosk-android-service/issues/33). Could consider additional user preference to control this ordering in the future. 

Change not rebuilt/tested for "stability" given minimal change to underlying codebase.

Edit: included note about #3230