### PR TITLE
switch order of search for speech-to-text (fixed formatting)

### DIFF
--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -35,10 +35,11 @@ public class VoiceRecognitionTrigger {
     }
 
     private Trigger getTrigger() {
-        if (ImeTrigger.isInstalled(mInputMethodService)) {
-            return getImeTrigger();
-        } else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
+        if (IntentApiTrigger.isInstalled(mInputMethodService)) {
             return getIntentTrigger();
+        } else if (ImeTrigger.isInstalled(mInputMethodService)) {
+            //use Google stt as fallback
+            return getImeTrigger();
         } else {
             return null;
         }


### PR DESCRIPTION
Sigh... redo of the prior PR that @menny had commented on (my newb self rebased and messed up the repo history; this should hopefully be a stable fix that passes the formatting tests).

This feature edit switches the order of searches for available stt services to prioritize non-google based applications (e.g. vosk android service). This fix directly addresses ASK issue #3230 (see also vosk-android-service https://github.com/alphacep/vosk-android-service/issues/33) and indirectly addresses #3004. Can consider adding user-based preferences on whether to prioritize a given service in the future.

Changes not tested for stability given minimal change to codebase.

To address @menny's question on the original PR - unfortunately, vosk-android-service is not available on the play store yet.