### PR TITLE
Fix english duplicates

### DIFF
--- a/buildSrc/src/main/java/MergeWordsListTask.java
+++ b/buildSrc/src/main/java/MergeWordsListTask.java
@@ -72,7 +72,9 @@ public class MergeWordsListTask extends DefaultTask {
                 parser.parse(inputSource, new MySaxHandler(allWords, duplicateWords));
                 System.out.printf(Locale.ENGLISH, "Loaded %d words in total...%n", allWords.size());
             }
-            if (duplicateWords.size() > 0 && !inputFile.getAbsolutePath().contains("/build/")) {
+            if (duplicateWords.size() > 0
+                    && !inputFile.getAbsolutePath().contains("/build/")
+                    && !inputFile.getAbsolutePath().contains("\\build\\")) {
                 inputFilesWithDuplicates.add(inputFile.getAbsolutePath());
                 filterWordsFromInputFile(inputFile, duplicateWords);
             }

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -37,7 +37,8 @@ public class VoiceRecognitionTrigger {
     private Trigger getTrigger() {
         if (IntentApiTrigger.isInstalled(mInputMethodService)) {
             return getIntentTrigger();
-        } else if (ImeTrigger.isInstalled(mInputMethodService)) { //use Google stt as fallback
+        } else if (ImeTrigger.isInstalled(mInputMethodService)) {
+            //use Google stt as fallback
             return getImeTrigger();
         } else {
             return null;

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -35,10 +35,10 @@ public class VoiceRecognitionTrigger {
     }
 
     private Trigger getTrigger() {
-        if (ImeTrigger.isInstalled(mInputMethodService)) {
-            return getImeTrigger();
-        } else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
+        if (IntentApiTrigger.isInstalled(mInputMethodService)) {
             return getIntentTrigger();
+        } else if (ImeTrigger.isInstalled(mInputMethodService)) { //use Google stt as fallback
+            return getImeTrigger();
         } else {
             return null;
         }


### PR DESCRIPTION
This fix addresses a build-time error for the recent build [498dab3] in which generating an english word list fails on Windows due to inappropriate heuristic matching for the word list build directory (relies on searching for '/build/' in the folder path to avoid checking itself against duplicate words; added another condition for the alternate filesep). 