### PR TITLE
Fix build folder search heuristic for duplicate word finding

### DIFF
--- a/buildSrc/src/main/java/MergeWordsListTask.java
+++ b/buildSrc/src/main/java/MergeWordsListTask.java
@@ -72,7 +72,9 @@ public class MergeWordsListTask extends DefaultTask {
                 parser.parse(inputSource, new MySaxHandler(allWords, duplicateWords));
                 System.out.printf(Locale.ENGLISH, "Loaded %d words in total...%n", allWords.size());
             }
-            if (duplicateWords.size() > 0 && !inputFile.getAbsolutePath().contains("/build/")) {
+            if (duplicateWords.size() > 0
+                    && !inputFile.getAbsolutePath().contains("/build/")
+                    && !inputFile.getAbsolutePath().contains("\\build\\")) {
                 inputFilesWithDuplicates.add(inputFile.getAbsolutePath());
                 filterWordsFromInputFile(inputFile, duplicateWords);
             }

--- a/buildSrc/src/main/java/MergeWordsListTask.java
+++ b/buildSrc/src/main/java/MergeWordsListTask.java
@@ -72,9 +72,12 @@ public class MergeWordsListTask extends DefaultTask {
                 parser.parse(inputSource, new MySaxHandler(allWords, duplicateWords));
                 System.out.printf(Locale.ENGLISH, "Loaded %d words in total...%n", allWords.size());
             }
-            if (duplicateWords.size() > 0
-                    && !inputFile.getAbsolutePath().contains("/build/")
-                    && !inputFile.getAbsolutePath().contains("\\build\\")) {
+
+            boolean isBuildDir =
+                    inputFile
+                            .getAbsolutePath()
+                            .contains((File.separator).concat("build").concat(File.separator));
+            if (duplicateWords.size() > 0 && !isBuildDir) {
                 inputFilesWithDuplicates.add(inputFile.getAbsolutePath());
                 filterWordsFromInputFile(inputFile, duplicateWords);
             }


### PR DESCRIPTION
This fix addresses a build-time error for the recent build [https://github.com/AnySoftKeyboard/AnySoftKeyboard/commit/498dab3a1cba1b197b7b48aea40e7e595c50d299] in which generating an english word list fails on Windows due to inappropriate heuristic matching for the word list build directory (relies on searching for '/build/' in the folder path to avoid checking itself against duplicate words; added another condition for the alternate filesep).

(sorry... here's try 3.)