### PR TITLE
Don't show voice result dialog when only 1 result

### DIFF
--- a/ime/voiceime/src/main/java/com/google/android/voiceime/ActivityHelper.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/ActivityHelper.java
@@ -64,9 +64,9 @@ public class ActivityHelper extends Activity {
         && data.hasExtra(RecognizerIntent.EXTRA_RESULTS)) {
       ArrayList<String> results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
 
-      if(results.size() > 1) {
+      if (results.size() > 1) {
         createResultDialog(results.toArray(new String[results.size()])).show();
-      } else if(results.size() > 0) {
+      } else if (results.size() == 1) {
         notifyResult(results.get(0));
       } else {
         notifyResult(null);

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/ActivityHelper.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/ActivityHelper.java
@@ -63,7 +63,14 @@ public class ActivityHelper extends Activity {
         && data != null
         && data.hasExtra(RecognizerIntent.EXTRA_RESULTS)) {
       ArrayList<String> results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
-      createResultDialog(results.toArray(new String[results.size()])).show();
+
+      if(results.size() > 1) {
+        createResultDialog(results.toArray(new String[results.size()])).show();
+      } else if(results.size() > 0) {
+        notifyResult(results.get(0));
+      } else {
+        notifyResult(null);
+      }
     } else {
       notifyResult(null);
     }


### PR DESCRIPTION
Currently, AnySoftKeyboard shows a voice recognition result dialog even if there's only one result. I assume this dialog is intended to allow picking between multiple results, but when there's only one result, it just adds an unnecessary step. This change shows the dialog only when there's two or more results, and skips to typing the text instantly if there's only one.

Example of the dialog with only one result:
![image](https://github.com/AnySoftKeyboard/AnySoftKeyboard/assets/65567823/116cba75-5870-47f9-8937-53347580e5f4)
