### PR TITLE
Add ǐ and ǎ to qwerty, to complete pinyin

### DIFF
--- a/addons/languages/english/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty.xml
@@ -26,13 +26,13 @@
         <Key android:codes="116" android:popupCharacters="5țť\u0163τ"/>
         <Key android:codes="121" android:popupCharacters="6ýÿψ"/>
         <Key android:codes="117" android:popupKeyboard="@xml/popup_qwerty_u"/>
-        <Key android:codes="105" android:popupCharacters="8ìíîïłīι*"/>
+        <Key android:codes="105" android:popupCharacters="8ìíîǐïłīι*"/>
         <Key android:codes="111" android:popupCharacters="9òóôǒōõöőøœoº"/>
         <Key android:codes="112" android:popupCharacters="0þπ" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row>
-        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãāäåæąăαª"
+        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâǎãāäåæąăαª"
              android:keyEdgeFlags="left"/>
         <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσ"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>


### PR DESCRIPTION
Added ǎ and ǐ, which more or less completes the ability to type [pinyin](https://en.wikipedia.org/wiki/Pinyin) in the QWERTY keyboard (not counting ü-tones). The vowels+tones used in pinyin are:

```
āáǎàa
ēéěèe
īíǐìi
ōóǒòo
ūúǔùu
ǖǘǚǜü
```

(However, the `ü` can also be written as a `u` (with no umlaut) or v or even yu depending on context and style.)

Before this pull request, the ability to type in pinyin is nearly complete on AnySoft keyboard in QWERTY except for just two tones that are missing.  It seems like an important and low-hanging fruit to round off the ability to write in pinyin. Chinese is the second most widely spoken language in the world, after all.