### PR TITLE
Fix hardcoded google voice input check

### DIFF
--- a/ime/voiceime/build.gradle
+++ b/ime/voiceime/build.gradle
@@ -5,6 +5,8 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 dependencies {
 
     implementation project(path: ':ime:base')
+
+    testImplementation project(path: ':ime:base-test')
 }
 
 android {

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/ImeTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/ImeTrigger.java
@@ -29,8 +29,6 @@ class ImeTrigger implements Trigger {
 
   private static final String VOICE_IME_SUBTYPE_MODE = "voice";
 
-  private static final String VOICE_IME_PACKAGE_PREFIX = "com.google.android";
-
   private final InputMethodService mInputMethodService;
 
   public ImeTrigger(InputMethodService inputMethodService) {
@@ -76,11 +74,7 @@ class ImeTrigger implements Trigger {
     for (InputMethodInfo inputMethodInfo : inputMethodManager.getEnabledInputMethodList()) {
       for (int i = 0; i < inputMethodInfo.getSubtypeCount(); i++) {
         InputMethodSubtype subtype = inputMethodInfo.getSubtypeAt(i);
-        if (VOICE_IME_SUBTYPE_MODE.equals(subtype.getMode())
-            && inputMethodInfo
-                .getComponent()
-                .getPackageName()
-                .startsWith(VOICE_IME_PACKAGE_PREFIX)) {
+        if (VOICE_IME_SUBTYPE_MODE.equals(subtype.getMode())) {
           return inputMethodInfo;
         }
       }

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -67,6 +67,19 @@ public class VoiceRecognitionTrigger {
     return true;
   }
 
+  // For testing
+  public String getKind() {
+    if (mImeTrigger != null && mIntentApiTrigger != null) {
+      return "both";
+    } else if (mImeTrigger != null) {
+      return "ime";
+    } else if (mIntentApiTrigger != null) {
+      return "intent";
+    } else {
+      return "none";
+    }
+  }
+
   /**
    * Starts a voice recognition
    *

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -38,7 +38,7 @@ public class VoiceRecognitionTrigger {
     if (ImeTrigger.isInstalled(mInputMethodService)) {
       // Prioritize IME as it's usually a better experience
       return getImeTrigger();
-    }else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
+    } else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
       return getIntentTrigger();
     } else {
       return null;

--- a/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
+++ b/ime/voiceime/src/main/java/com/google/android/voiceime/VoiceRecognitionTrigger.java
@@ -35,11 +35,11 @@ public class VoiceRecognitionTrigger {
   }
 
   private Trigger getTrigger() {
-    if (IntentApiTrigger.isInstalled(mInputMethodService)) {
-      return getIntentTrigger();
-    } else if (ImeTrigger.isInstalled(mInputMethodService)) {
-      // use Google stt as fallback
+    if (ImeTrigger.isInstalled(mInputMethodService)) {
+      // Prioritize IME as it's usually a better experience
       return getImeTrigger();
+    }else if (IntentApiTrigger.isInstalled(mInputMethodService)) {
+      return getIntentTrigger();
     } else {
       return null;
     }

--- a/ime/voiceime/src/test/java/com/google/android/voiceime/VoiceRecognitionTriggerTest.java
+++ b/ime/voiceime/src/test/java/com/google/android/voiceime/VoiceRecognitionTriggerTest.java
@@ -1,0 +1,129 @@
+package com.google.android.voiceime;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.inputmethodservice.InputMethodService;
+import android.view.inputmethod.InputMethodInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.view.inputmethod.InputMethodSubtype;
+import com.anysoftkeyboard.AnySoftKeyboardPlainTestRunner;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+@RunWith(AnySoftKeyboardPlainTestRunner.class)
+public class VoiceRecognitionTriggerTest {
+
+  InputMethodManager mMockInputMethodManager;
+  InputMethodService mMockInputMethodService;
+  PackageManager mMockPackageManager;
+
+  List<InputMethodInfo> inputMethods;
+  List<ResolveInfo> voiceActivities;
+
+  @Before
+  public void setUp() {
+    inputMethods = new ArrayList<>();
+    voiceActivities = new ArrayList<>();
+
+    mMockInputMethodManager = Mockito.mock(InputMethodManager.class);
+    Mockito.when(mMockInputMethodManager.getEnabledInputMethodList()).thenReturn(inputMethods);
+
+    mMockInputMethodService = Mockito.mock(InputMethodService.class);
+    Mockito.when(mMockInputMethodService.getSystemService(Context.INPUT_METHOD_SERVICE))
+        .thenReturn(mMockInputMethodManager);
+
+    mMockPackageManager = Mockito.mock(PackageManager.class);
+    Mockito.when(mMockInputMethodService.getPackageManager()).thenReturn(mMockPackageManager);
+
+    Mockito.when(mMockPackageManager.queryIntentActivities(Mockito.any(), Mockito.eq(0)))
+        .thenReturn(voiceActivities);
+  }
+
+  private void addInputMethodInfo(List<String> modes) {
+    InputMethodInfo inputMethod = Mockito.mock(InputMethodInfo.class);
+
+    Mockito.when(inputMethod.getSubtypeCount()).thenReturn(modes.size());
+
+    for (int i = 0; i < modes.size(); i++) {
+      InputMethodSubtype subtype = Mockito.mock(InputMethodSubtype.class);
+      Mockito.when(subtype.getMode()).thenReturn(modes.get(i));
+      Mockito.when(inputMethod.getSubtypeAt(i)).thenReturn(subtype);
+    }
+
+    inputMethods.add(inputMethod);
+  }
+
+  @Test
+  public void testImeNotInstalledWhenNoVoice() {
+    addInputMethodInfo(List.of("keyboard", "keyboard", "handwriting"));
+    addInputMethodInfo(List.of("handwriting"));
+    addInputMethodInfo(List.of("handwriting", "keyboard", "keyboard", "keyboard"));
+
+    Assert.assertFalse(ImeTrigger.isInstalled(mMockInputMethodService));
+  }
+
+  @Test
+  public void testImeInstalledWhenOnlyVoice() {
+    addInputMethodInfo(List.of("voice"));
+
+    Assert.assertTrue(ImeTrigger.isInstalled(mMockInputMethodService));
+  }
+
+  @Test
+  public void testImeInstalledWhenMixedVoice() {
+    addInputMethodInfo(List.of("keyboard", "keyboard", "handwriting"));
+    addInputMethodInfo(List.of("handwriting"));
+    addInputMethodInfo(List.of("handwriting", "keyboard", "voice", "keyboard", "keyboard"));
+
+    Assert.assertTrue(ImeTrigger.isInstalled(mMockInputMethodService));
+  }
+
+  @Test
+  public void testIntentNotInstalledWhenNoActivities() {
+    Assert.assertFalse(IntentApiTrigger.isInstalled(mMockInputMethodService));
+  }
+
+  @Test
+  public void testIntentInstalledWhenSomeActivity() {
+    voiceActivities.add(new ResolveInfo());
+    Assert.assertTrue(IntentApiTrigger.isInstalled(mMockInputMethodService));
+  }
+
+  @Test
+  public void testVoiceRecognitionTriggerNoneWhenNothing() {
+    VoiceRecognitionTrigger trigger = new VoiceRecognitionTrigger(mMockInputMethodService);
+    Assert.assertEquals("none", trigger.getKind());
+  }
+
+  @Test
+  public void testVoiceRecognitionTriggerPrioritizesIme() {
+    addInputMethodInfo(List.of("voice"));
+    voiceActivities.add(new ResolveInfo());
+
+    VoiceRecognitionTrigger trigger = new VoiceRecognitionTrigger(mMockInputMethodService);
+    Assert.assertEquals("ime", trigger.getKind());
+  }
+
+  @Test
+  public void testVoiceRecognitionTriggerFallsBackToIntent() {
+    addInputMethodInfo(List.of("keyboard"));
+    voiceActivities.add(new ResolveInfo());
+
+    VoiceRecognitionTrigger trigger = new VoiceRecognitionTrigger(mMockInputMethodService);
+    Assert.assertEquals("intent", trigger.getKind());
+  }
+
+  @Test
+  public void testVoiceRecognitionTriggerAcceptsIme() {
+    addInputMethodInfo(List.of("voice"));
+
+    VoiceRecognitionTrigger trigger = new VoiceRecognitionTrigger(mMockInputMethodService);
+    Assert.assertEquals("ime", trigger.getKind());
+  }
+}


### PR DESCRIPTION
Currently, ImeTrigger is hardcoded to only look for voice IME subtypes whose package names are prefixed with `com.google.android`. This means that only Google Voice Input is allowed to be picked by ImeTrigger.

From my understanding, it's adequate to check that the subtype equals `"voice"`. Any input method subtype advertising its mode as `"voice"` is probably capable of doing voice input. So I'm not certain why this check was there in the first place, other than to prioritize Google's Voice Input on the belief that Google's probably works better than whatever else is installed by the user or vendor.

This PR removes this check to allow non-Google voice inputs to be picked by ImeTrigger. Previously it was still possible for third party voice inputs to be picked by IntentApiTrigger instead, but the intent API isn't as well-integrated as an input method and it's a better experience to use an IME instead, so this PR also prioritizes ImeTrigger over IntentApiTrigger.