### PR TITLE
Temporary fix for Yochees Light theme having unreadable icons

### DIFF
--- a/ime/app/src/main/res/values/styles_yochees_keyboard_theme.xml
+++ b/ime/app/src/main/res/values/styles_yochees_keyboard_theme.xml
@@ -183,7 +183,8 @@
 
     <!-- light theme -->
     <style name="YocheesLightKeyIconTheme"
-           parent="YocheesDarkKeyIconTheme">
+           parent="LeanLightKeyIconTheme">
+        <!-- TODO: create light-theme versions of Yochees icons instead of using ones from Lean Light -->
     </style>
 
     <style name="YocheesLightTheme"


### PR DESCRIPTION
This isn't the "correct" way to fix this, which would be creating a separate set of icons for the yochees light theme, but it fixes #2439 and since no-one touched that bug in 3 years, I think this is good enough.

![image](https://github.com/AnySoftKeyboard/AnySoftKeyboard/assets/24840010/ed374608-af35-4eb2-aac5-78cf41009722)
