### PR TITLE
en dvorak: add ð & þ

### DIFF
--- a/addons/languages/kachin/pack/src/main/res/xml/dvorak.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/dvorak.xml
@@ -22,9 +22,9 @@
         <Key android:codes="101" android:keyLabel="e" android:popupCharacters="èéêëęē€"/>
         <Key android:codes="117" android:keyLabel="u" android:popupCharacters="ùúûüŭűū"/>
         <Key android:codes="105" android:keyLabel="i" android:popupCharacters="ìíîïīι*"/>
-        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
+        <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδð"/>
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥθ"/>
-        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="țť\u0163τ"/>
+        <Key android:codes="116" android:keyLabel="t" android:popupCharacters="țť\u0163τþ"/>
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñńν"/>
         <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝšșσ" android:keyEdgeFlags="right"/>
     </Row>


### PR DESCRIPTION
Eth & thorn, ð & þ, were historic letters to English & still common in Icelandic words. There seems to be recurring movements online to use them in English today too to supplant the most common digraph, “th”, for [θ] [ð] sounds.

Placement was at the beginning of the list as these characters have higher codepoint values than the others (altho the order doesn’t have an order I personally understand—and ideally users could reorder them).