### PR TITLE
Add Gershayim to Hebrew

### DIFF
--- a/addons/languages/hebrew/pack/src/main/res/xml/heb_qwerty_niqquds.xml
+++ b/addons/languages/hebrew/pack/src/main/res/xml/heb_qwerty_niqquds.xml
@@ -9,6 +9,8 @@
         05B3    Reduced Kamatz
         05B4    Hiriq   Hebrew Hiriq.svg [1]
         05B5    Zeire   Hebrew Zeire.svg [1]
+        05F3    Geresh
+        05F4    Gershayim
         -->
         <Key android:codes="1456" android:keyLabel="" android:keyEdgeFlags="left"/>
         <Key android:codes="1457" android:keyLabel=""/>
@@ -16,7 +18,8 @@
         <Key android:codes="1459" android:keyLabel=""/>
         <Key android:codes="1460" android:keyLabel=""/>
         <Key android:codes="1461" android:keyLabel=""/>
-        <Key android:codes="1523" android:keyLabel="" android:keyEdgeFlags="right"/>
+        <Key android:codes="1523" android:keyLabel=""/>
+        <Key android:codes="1524" android:keyLabel="" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row android:rowEdgeFlags="bottom">
@@ -27,6 +30,7 @@
         05B9    Holam   Hebrew Holam.svg [1]
         05BC    Dagesh or Mappiq    Hebrew Equal Dagesh.svg [1] / 05BC  Shuruk  Hebrew Equal Shuruk.svg [4]
         05BB    Kubutz  Hebrew Backslash Qubuz.svg [1]
+        05BE    Maqaf
         -->
         <Key android:codes="1462" android:keyLabel="" android:keyEdgeFlags="left"/>
         <Key android:codes="1463" android:keyLabel=""/>


### PR DESCRIPTION
This symbol is used extremely often in many abbreviations (e.g. words for kilogram, doctor etc.) and typing Geresh twice is not a proper substitute.
The change wasn't tested as I have no dev environment set up.