### PR TITLE
added Polytonic Greek Keyboard

### DIFF
--- a/addons/languages/greek/pack/src/main/res/values/greek_strings.xml
+++ b/addons/languages/greek/pack/src/main/res/values/greek_strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="greek_keyboard_name">Ελληνικό</string>
+    <string name="koine_greek_keyboard_name">Ἑληνική Κοινή</string>
     <string name="greek_dictionary_name">Ελληνικό</string>
 </resources>

--- a/addons/languages/greek/pack/src/main/res/values/greek_strings.xml
+++ b/addons/languages/greek/pack/src/main/res/values/greek_strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="greek_keyboard_name">Ελληνικό</string>
-    <string name="koine_greek_keyboard_name">Ἑληνική Κοινή</string>
+    <string name="koine_greek_keyboard_name">Ἑλληνική Κοινή</string>
     <string name="greek_dictionary_name">Ελληνικό</string>
 </resources>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_keyboards.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_keyboards.xml
@@ -15,4 +15,12 @@
         index="1"
         layoutResId="@xml/greek_qwerty"
         nameResId="@string/greek_keyboard_name" />
+    <Keyboard
+        defaultDictionaryLocale="el"
+        description="For Ancient Greek"
+        iconResId="@drawable/ic_status_greek"
+        id="48decb20-63ac-11ef-8664-0800200c9a66"
+        index="2"
+        layoutResId="@xml/greek_qwerty_polytonic"
+        nameResId="@string/koine_greek_keyboard_name" />
 </Keyboards>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
@@ -3,15 +3,15 @@
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     android:keyWidth="10%p"><!-- "android:keyWidth" specify the default width of a key. In this example, 10% of parent (the whole keyboard) -->
 
-    <!-- Key attributes:
-     "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
-     "android:popupCharacters" : characters to show on long-press popup keyboard
-     "android:keyLabel" : the text to show on the key. If this attribute is missing, the first code in "android:codes" will be used.
-     "android:horizontalGap" : gap to add to the left of this key.
-     "android:isModifier" : true/false (default is false) whether this key is a modifier key. Means it will be rendered with a differnt background (shift, delete are example of modifier key)
-     "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
-     "android:keyWidth" : specify the width of this key
-     -->
+        <!-- Key attributes:
+         "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
+         "android:popupCharacters" : characters to show on long-press popup keyboard
+         "android:keyLabel" : the text to show on the key. If this attribute is missing, the first code in "android:codes" will be used.
+         "android:horizontalGap" : gap to add to the left of this key.
+         "android:isModifier" : true/false (default is false) whether this key is a modifier key. Means it will be rendered with a differnt background (shift, delete are example of modifier key)
+         "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
+         "android:keyWidth" : specify the width of this key
+         -->
     <Row>
         <Key android:codes="59" android:keyEdgeFlags="left"/>
         <Key android:codes="962"/>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
@@ -3,15 +3,15 @@
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     android:keyWidth="10%p"><!-- "android:keyWidth" specify the default width of a key. In this example, 10% of parent (the whole keyboard) -->
 
-        <!-- Key attributes:
-         "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
-         "android:popupCharacters" : characters to show on long-press popup keyboard
-         "android:keyLabel" : the text to show on the key. If this attribute is missing, the first code in "android:codes" will be used.
-         "android:horizontalGap" : gap to add to the left of this key.
-         "android:isModifier" : true/false (default is false) whether this key is a modifier key. Means it will be rendered with a differnt background (shift, delete are example of modifier key)
-         "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
-         "android:keyWidth" : specify the width of this key
-         -->
+    <!-- Key attributes:
+     "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
+     "android:popupCharacters" : characters to show on long-press popup keyboard
+     "android:keyLabel" : the text to show on the key. If this attribute is missing, the first code in "android:codes" will be used.
+     "android:horizontalGap" : gap to add to the left of this key.
+     "android:isModifier" : true/false (default is false) whether this key is a modifier key. Means it will be rendered with a differnt background (shift, delete are example of modifier key)
+     "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
+     "android:keyWidth" : specify the width of this key
+     -->
     <Row>
         <Key android:codes="59" android:keyEdgeFlags="left"/>
         <Key android:codes="962"/>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
@@ -14,13 +14,13 @@
          -->
     <Row>
         <Key android:codes="903" android:keyEdgeFlags="left"/>
+        <Key android:codes="772"/>
         <Key android:codes="768"/>
         <Key android:codes="769"/>
-        <Key android:codes="772"/>
         <Key android:codes="776"/>
+        <Key android:codes="834"/>
         <Key android:codes="787"/>
         <Key android:codes="788"/>
-        <Key android:codes="834"/>
         <Key android:codes="837"/>
         <Key android:codes="989" android:popupCharacters="Ϟϡ" android:keyEdgeFlags="right"/>
     </Row>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyWidth="10%p"><!-- "android:keyWidth" specify the default width of a key. In this example, 10% of parent (the whole keyboard) -->
+
+        <!-- Key attributes:
+         "android:codes" : a comma separated unicode values of the keys. If you specify more than one code, then the other codes are accessible via multi-tap.
+         "android:popupCharacters" : characters to show on long-press popup keyboard
+         "android:keyLabel" : the text to show on the key. If this attribute is missing, the first code in "android:codes" will be used.
+         "android:horizontalGap" : gap to add to the left of this key.
+         "android:isModifier" : true/false (default is false) whether this key is a modifier key. Means it will be rendered with a different background (shift, delete are example of modifier key)
+         "android:isRepeatable" : true/false (default is false) whether this key repeats printing on long press (like the backspace). Setting this to true will disable the long-press (android:popupCharacters) functionality
+         "android:keyWidth" : specify the width of this key
+         -->
+    <Row>
+        <Key android:codes="903" android:keyEdgeFlags="left"/>
+        <Key android:codes="768"/>
+        <Key android:codes="769"/>
+        <Key android:codes="772"/>
+        <Key android:codes="776"/>
+        <Key android:codes="787"/>
+        <Key android:codes="788"/>
+        <Key android:codes="834"/>
+        <Key android:codes="837"/>
+        <Key android:codes="989" android:popupCharacters="Ϟϡ" android:keyEdgeFlags="right"/>
+    </Row>
+    <Row>
+        <Key android:codes="59" android:keyEdgeFlags="left"/>
+        <Key android:codes="962"/>
+        <Key android:codes="949"/>
+        <Key android:codes="961"/>
+        <Key android:codes="964"/>
+        <Key android:codes="965"/>
+        <Key android:codes="952"/>
+        <Key android:codes="953"/>
+        <Key android:codes="959"/>
+        <Key android:codes="960"/>
+    </Row>
+
+    <Row>
+        <Key android:horizontalGap="5%p" android:codes="945" android:keyEdgeFlags="left"/>
+        <Key android:codes="963" />
+        <Key android:codes="948"/>
+        <Key android:codes="966"/>
+        <Key android:codes="947"/>
+        <Key android:codes="951"/>
+        <Key android:codes="958"/>
+        <Key android:codes="954"/>
+        <Key android:codes="955" android:keyEdgeFlags="right"/>
+    </Row>
+
+    <Row>
+        <Key android:keyWidth="15%p" android:codes="-1"
+            android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
+        <Key android:codes="950"/>
+        <Key android:codes="967"/>
+        <Key android:codes="968"/>
+        <Key android:codes="969"/>
+        <Key android:codes="946"/>
+        <Key android:codes="957"/>
+        <Key android:codes="956"/>
+        <Key android:keyWidth="15%p" android:codes="-5" android:keyEdgeFlags="right" android:isRepeatable="true"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
I wanted a better way to type in Polytonic Greek. [Apptide](https://ancient-languages-pack-for-anysoftkeyboard.en.aptoide.com/app) has an ancient languages pack that supports Polytonic Greek, but it is hard to use because of the large popup menus. So I have created one that uses combining diacritics. and lists them in a row for easy access. now there is some difficulty because a lot of systems including mine(android 15) do fine if one types: Vowel, Breathing Mark, Tonos(ἔ); but have trouble if one types: Vowel, Tonos Breathing Mark, (έ̓). but I know not how to solve this problem in AnySoftKeyboard. I don't think I did anything "Copyright-able" so do with this keyboard as you please. I do not know whether it really belongs in the Greek package or in a new package for itself.