### PR TITLE
Fix: Update locale generation and System locale handling

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
@@ -41,6 +41,7 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardDialogProvid
 
     mSharedPrefsNotToUse.registerOnSharedPreferenceChangeListener(mGeneralShardPrefChangedListener);
 
+    final var defaultSystemLocaleValue = getString(R.string.settings_default_force_locale_setting);
     addDisposable(
         mRxPrefs
             .getString(
@@ -48,9 +49,9 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardDialogProvid
             .asObservable()
             .subscribe(
                 forceLocaleValue -> {
-                    String systemLocaleValue = getString(R.string.settings_default_force_locale_setting);
-                    String valueToApply = systemLocaleValue.equals(forceLocaleValue) ? null : forceLocaleValue;
-                    LocaleTools.applyLocaleToContext(getApplicationContext(), valueToApply);
+                  String valueToApply =
+                      defaultSystemLocaleValue.equals(forceLocaleValue) ? null : forceLocaleValue;
+                  LocaleTools.applyLocaleToContext(getApplicationContext(), valueToApply);
                 },
                 GenericOnError.onError("settings_key_force_locale")));
     addDisposable(

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
@@ -47,8 +47,11 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardDialogProvid
                 R.string.settings_key_force_locale, R.string.settings_default_force_locale_setting)
             .asObservable()
             .subscribe(
-                forceLocaleValue ->
-                    LocaleTools.applyLocaleToContext(getApplicationContext(), forceLocaleValue),
+                forceLocaleValue -> {
+                    String systemLocaleValue = getString(R.string.settings_default_force_locale_setting);
+                    String valueToApply = systemLocaleValue.equals(forceLocaleValue) ? null : forceLocaleValue;
+                    LocaleTools.applyLocaleToContext(getApplicationContext(), valueToApply);
+                },
                 GenericOnError.onError("settings_key_force_locale")));
     addDisposable(
         mRxPrefs

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardForceLocaleTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardForceLocaleTest.java
@@ -47,7 +47,7 @@ public class AnySoftKeyboardForceLocaleTest extends AnySoftKeyboardBaseTest {
         "Russian",
         mAnySoftKeyboardUnderTest.getResources().getConfiguration().locale.getDisplayName());
 
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, "System");
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, getApplicationContext().getString(R.string.settings_default_force_locale_setting));
 
     Assert.assertEquals(
         Locale.getDefault().getLanguage(),
@@ -99,7 +99,7 @@ public class AnySoftKeyboardForceLocaleTest extends AnySoftKeyboardBaseTest {
             .get(0)
             .getDisplayName());
 
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, "System");
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, getApplicationContext().getString(R.string.settings_default_force_locale_setting));
 
     Assert.assertEquals(
         Locale.getDefault().getLanguage(),

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardForceLocaleTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardForceLocaleTest.java
@@ -47,7 +47,9 @@ public class AnySoftKeyboardForceLocaleTest extends AnySoftKeyboardBaseTest {
         "Russian",
         mAnySoftKeyboardUnderTest.getResources().getConfiguration().locale.getDisplayName());
 
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, getApplicationContext().getString(R.string.settings_default_force_locale_setting));
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_force_locale,
+        getApplicationContext().getString(R.string.settings_default_force_locale_setting));
 
     Assert.assertEquals(
         Locale.getDefault().getLanguage(),
@@ -99,7 +101,9 @@ public class AnySoftKeyboardForceLocaleTest extends AnySoftKeyboardBaseTest {
             .get(0)
             .getDisplayName());
 
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_force_locale, getApplicationContext().getString(R.string.settings_default_force_locale_setting));
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_force_locale,
+        getApplicationContext().getString(R.string.settings_default_force_locale_setting));
 
     Assert.assertEquals(
         Locale.getDefault().getLanguage(),

--- a/js/contributors/contributors.ts
+++ b/js/contributors/contributors.ts
@@ -42,6 +42,7 @@ function isBot(login: string): boolean {
   switch (login.toLocaleLowerCase()) {
     case 'anysoftkeyboard-bot':
     case '[dependabot[bot]]':
+    case 'google-labs-jules':
       return true;
     default:
       return false;

--- a/js/localization_tools/locales_generator.test.ts
+++ b/js/localization_tools/locales_generator.test.ts
@@ -34,7 +34,7 @@ test.describe('locales generation tests', () => {
     generateLocaleArrayXml(tmp, outputFile);
 
     const xml = fs.readFileSync(outputFile, 'utf8');
-    
+
     // Extract all items into an array
     const items = [];
     const itemRegex = /<item>(.*?)<\/item>/g;
@@ -44,14 +44,14 @@ test.describe('locales generation tests', () => {
     }
 
     // Define the expected order and content of locales
-    const expectedLocales = ["System", "en", "en-US", "es", "fr", "pt", "pt-BR", "ru"];
-    
+    const expectedLocales = ['System', 'en', 'en-US', 'es', 'fr', 'pt', 'pt-BR', 'ru'];
+
     // Assert that the extracted items match the expected locales
-    assert.deepStrictEqual(items, expectedLocales, "Locales are not in the expected order or content");
+    assert.deepStrictEqual(items, expectedLocales, 'Locales are not in the expected order or content');
 
     // These checks are implicitly covered by deepStrictEqual, but it's good to be explicit about what should NOT be there.
-    assert.doesNotMatch(xml, /v21/, "Should not contain v21");
-    assert.doesNotMatch(xml, /not-a-locale/, "Should not contain not-a-locale");
+    assert.doesNotMatch(xml, /v21/, 'Should not contain v21');
+    assert.doesNotMatch(xml, /not-a-locale/, 'Should not contain not-a-locale');
     assert.doesNotMatch(xml, /<item>values<\/item>/, "Should not contain 'values' as an item");
   });
 

--- a/js/localization_tools/locales_generator.test.ts
+++ b/js/localization_tools/locales_generator.test.ts
@@ -34,17 +34,25 @@ test.describe('locales generation tests', () => {
     generateLocaleArrayXml(tmp, outputFile);
 
     const xml = fs.readFileSync(outputFile, 'utf8');
-    // Check that the XML contains the expected locales
-    assert.match(xml, /<item>en<\/item>/);
-    assert.match(xml, /<item>fr<\/item>/);
-    assert.match(xml, /<item>es<\/item>/);
-    assert.match(xml, /<item>ru<\/item>/);
-    assert.match(xml, /<item>en-US<\/item>/);
-    assert.match(xml, /<item>pt-BR<\/item>/);
-    // Should not contain v21, values, or not-a-locale
-    assert.doesNotMatch(xml, /v21/);
-    assert.doesNotMatch(xml, /not-a-locale/);
-    assert.doesNotMatch(xml, /<item>values<\/item>/);
+    
+    // Extract all items into an array
+    const items = [];
+    const itemRegex = /<item>(.*?)<\/item>/g;
+    let match;
+    while ((match = itemRegex.exec(xml)) !== null) {
+      items.push(match[1]);
+    }
+
+    // Define the expected order and content of locales
+    const expectedLocales = ["System", "en", "en-US", "es", "fr", "pt", "pt-BR", "ru"];
+    
+    // Assert that the extracted items match the expected locales
+    assert.deepStrictEqual(items, expectedLocales, "Locales are not in the expected order or content");
+
+    // These checks are implicitly covered by deepStrictEqual, but it's good to be explicit about what should NOT be there.
+    assert.doesNotMatch(xml, /v21/, "Should not contain v21");
+    assert.doesNotMatch(xml, /not-a-locale/, "Should not contain not-a-locale");
+    assert.doesNotMatch(xml, /<item>values<\/item>/, "Should not contain 'values' as an item");
   });
 
   test.after(() => {

--- a/js/localization_tools/locales_generator.ts
+++ b/js/localization_tools/locales_generator.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 export const generateLocaleArrayXml = (resPath: string, outputFile: string): void => {
   console.log(`Will read locals from ${resPath}...`);
-  const localeEntries = locateStringResourcesFoldersInRes(resPath)
+  let localeEntries = locateStringResourcesFoldersInRes(resPath)
     .map(path.dirname)
     .map((f) => {
       console.log(f);
@@ -16,6 +16,26 @@ export const generateLocaleArrayXml = (resPath: string, outputFile: string): voi
     .filter((locale) => locale !== '') // Remove any empty strings just in case
     .sort();
 
+  // Create a Set to store unique locales, initialized with current entries.
+  const localeSet = new Set(localeEntries);
+
+  // Iterate over a copy of the original localeEntries to find specific locales
+  // (those containing a hyphen) and add their generic counterparts to the Set.
+  // Use [...localeEntries] to iterate over a copy, as localeEntries itself might be modified if not careful
+  for (const locale of [...localeEntries]) { 
+    if (locale.includes('-')) {
+      const genericLocale = locale.split('-')[0];
+      localeSet.add(genericLocale); 
+    }
+  }
+
+  // Convert the Set back to an array, sort it, and update localeEntries.
+  // First, clear localeEntries by reassigning.
+  localeEntries = Array.from(localeSet).sort();
+
+  // Add "System" as the first item.
+  localeEntries.unshift("System");
+
   const xmlContent = `<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- DO NOT TRANSLATE - this is auto generated -->
@@ -24,7 +44,8 @@ export const generateLocaleArrayXml = (resPath: string, outputFile: string): voi
     <!-- this should hold the locales the app is translated to, and any addon-->
     <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/res/res/values/locale_config.xml -->
     <string-array name="settings_key_force_locale_values">
-${localeEntries.map((entry) => `        <item>${entry}</item>`).join('\n')}
+${localeEntries.map((entry) => `        <item>${entry}</item>`).join('
+')}
     </string-array>
 </resources>
 `;

--- a/js/localization_tools/locales_generator.ts
+++ b/js/localization_tools/locales_generator.ts
@@ -22,19 +22,16 @@ export const generateLocaleArrayXml = (resPath: string, outputFile: string): voi
   // Iterate over a copy of the original localeEntries to find specific locales
   // (those containing a hyphen) and add their generic counterparts to the Set.
   // Use [...localeEntries] to iterate over a copy, as localeEntries itself might be modified if not careful
-  for (const locale of [...localeEntries]) { 
+  for (const locale of [...localeEntries]) {
     if (locale.includes('-')) {
       const genericLocale = locale.split('-')[0];
-      localeSet.add(genericLocale); 
+      localeSet.add(genericLocale);
     }
   }
 
   // Convert the Set back to an array, sort it, and update localeEntries.
   // First, clear localeEntries by reassigning.
   localeEntries = Array.from(localeSet).sort();
-
-  // Add "System" as the first item.
-  localeEntries.unshift("System");
 
   const xmlContent = `<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
@@ -44,8 +41,8 @@ export const generateLocaleArrayXml = (resPath: string, outputFile: string): voi
     <!-- this should hold the locales the app is translated to, and any addon-->
     <!-- https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/res/res/values/locale_config.xml -->
     <string-array name="settings_key_force_locale_values">
-${localeEntries.map((entry) => `        <item>${entry}</item>`).join('
-')}
+        <item>System</item>
+${localeEntries.map((entry) => `        <item>${entry}</item>`).join('\n')}
     </string-array>
 </resources>
 `;


### PR DESCRIPTION
This commit addresses several issues related to locale handling:

1.  **Locale Generation (`js/localization_tools/locales_generator.ts`):**
    *   Adds "System" as the first entry in the generated `settings_key_force_locale_values` string-array.
    *   Includes generic locales (e.g., "en" for "en-US") in the array. If a direct generic translation (e.g., `values-en`) exists, it's used; otherwise, the generic version is derived from specific locales (e.g., "en" from `values-en-rUS`).
    *   Ensures the final list is unique and sorted alphabetically after "System".
    *   Unit tests for `locales_generator.ts` have been updated to reflect these changes, verifying the "System" entry, generic locale inclusion, and correct sorting.

2.  **Android System Locale Handling (`AnySoftKeyboardRxPrefs.java`):**
    *   When the "Force Locale" preference is set to the value representing "System" (defined by `R.string.settings_default_force_locale_setting`), the application context's locale is now correctly reset by passing `null` to `LocaleTools.applyLocaleToContext`.
    *   Unit tests in `AnySoftKeyboardForceLocaleTest.java` have been updated to use `getApplicationContext().getString(R.string.settings_default_force_locale_setting)` when simulating this preference change, ensuring the tests accurately cover the updated logic.