### PR TITLE
Fix: Update 'checks' workflow badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Discussions can be found on&nbsp;[💬&nbsp;GitHub](https://github.com/AnySoftKeyboard/AnySoftKeyboard/discussions)<br/>
 Follow us on <a rel="me" href="https://hachyderm.io/@anysoftkeyboard">Mastodon</a>
 <br/>
-`main` latest build&nbsp;![](https://github.com/AnySoftKeyboard/AnySoftKeyboard/workflows/checks/badge.svg?event=push&branch=main)<br/>
+`main` latest build&nbsp;[![checks](https://github.com/AnySoftKeyboard/AnySoftKeyboard/actions/workflows/checks.yml/badge.svg)](https://github.com/AnySoftKeyboard/AnySoftKeyboard/actions/workflows/checks.yml)<br/>
 `main` coverage&nbsp;[![codecov](https://codecov.io/gh/AnySoftKeyboard/AnySoftKeyboard/branch/main/graph/badge.svg)](https://codecov.io/gh/AnySoftKeyboard/AnySoftKeyboard)<br/>
 <br/>
 Android (f/w 4.0.3+, API level 15+) on screen keyboard for multiple languages.


### PR DESCRIPTION
The previous badge URL for the 'checks' workflow on the main branch was showing 'no status'.

This change updates the badge URL to the format:
`[![checks](.../actions/workflows/checks.yml/badge.svg)](.../actions/workflows/checks.yml)`

This new URL, by omitting specific event and branch parameters and using the full `.yml` extension, correctly reflects the workflow's status (e.g., 'passing') by likely considering a broader range of successful runs on the default branch. The badge is now also a clickable link to the workflow's page on GitHub Actions.