### PR TITLE
feat: Change word splitting default and update title to beta

### DIFF
--- a/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
@@ -134,7 +134,7 @@
 
     <bool name="settings_default_workaround_disable_rtl_fix">true</bool>
 
-    <bool name="settings_default_try_splitting_words_for_correction">true</bool>
+    <bool name="settings_default_try_splitting_words_for_correction">false</bool>
 
     <dimen name="key_hysteresis_distance">10dp</dimen>
 

--- a/ime/app/src/main/res/values/strings.xml
+++ b/ime/app/src/main/res/values/strings.xml
@@ -462,7 +462,7 @@
                   checked in override default dictionary</string>
 
 
-    <string name="try_split_words_for_correction">Correct by splitting typed word</string>
+    <string name="try_split_words_for_correction">[beta] Correct by splitting typed word</string>
     <string name="try_split_words_for_correction_summary_on">Split typed word by guessing missing SPACE.</string>
     <string name="try_split_words_for_correction_summary_off"/>
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardDictionaryEnablingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardDictionaryEnablingTest.java
@@ -295,7 +295,8 @@ public class AnySoftKeyboardDictionaryEnablingTest extends AnySoftKeyboardBaseTe
   public void testSettingCorrectModeFromPrefs() {
     SharedPrefsHelper.setPrefsValue(
         "settings_key_auto_pick_suggestion_aggressiveness", "minimal_aggressiveness");
-    Mockito.verify(mAnySoftKeyboardUnderTest.getSuggest()).setCorrectionMode(true, 1, 1, true);
+    Mockito.verify(mAnySoftKeyboardUnderTest.getSuggest())
+        .setCorrectionMode(true, 1, 1, false /*the default*/);
   }
 
   @Test


### PR DESCRIPTION
- Set 'Try splitting words for correction' to be off by default.
- Add '[beta]' prefix to the title of the 'Try splitting words for correction' setting to indicate its experimental status.