### PR TITLE
Reset alpha release notes for 1.13

### DIFF
--- a/ime/app/src/main/play/release-notes/en-US/alpha.txt
+++ b/ime/app/src/main/play/release-notes/en-US/alpha.txt
@@ -1,12 +1,3 @@
-* Support for Android 15.
-* Clipboard support improvements.
-* A few Settings app navigation fixes.
-* Vibration fixes.
-* Suggestions pick and order fixes.
-* Improved pop-up keys order.
-* Gesture-typing improvements.
-* Support for Direct-Boot devices.
-* Reduced installation size (for supporting devices).
-* Updated translations from the community (at crowdin.net).
+Work in progress for version 1.13.
 
-More here: https://github.com/AnySoftKeyboard/AnySoftKeyboard/milestone/94
+More here: https://github.com/AnySoftKeyboard/AnySoftKeyboard/milestone/95

--- a/ime/releaseinfo/src/main/java/com/anysoftkeyboard/releaseinfo/VersionChangeLogs.java
+++ b/ime/releaseinfo/src/main/java/com/anysoftkeyboard/releaseinfo/VersionChangeLogs.java
@@ -13,6 +13,13 @@ public class VersionChangeLogs {
     log.add(
         new VersionChangeLog(
             1,
+            13,
+            "",
+            Uri.parse("https://github.com/AnySoftKeyboard/AnySoftKeyboard/milestone/95"),
+            "Work in progress for 1.13."));
+    log.add(
+        new VersionChangeLog(
+            1,
             12,
             "",
             Uri.parse("https://github.com/AnySoftKeyboard/AnySoftKeyboard/milestone/94"),


### PR DESCRIPTION
This commit resets the content of the alpha release notes file (ime/app/src/main/play/release-notes/en-US/alpha.txt) with a placeholder message for the upcoming version 1.13. It also includes the link to the new milestone.