### PR TITLE
chore: make cyrillic keyboard reflect slavic etymology and common typing standards

### DIFF
--- a/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
@@ -6,10 +6,10 @@
     <Row android:keyWidth="8.33%p">
         <!-- йцукенгшщзхъ    -->
         <Key android:codes="1081" android:keyLabel="й" android:popupCharacters="1їӣӥ" android:keyEdgeFlags="left"/>
-        <Key android:codes="1094" android:keyLabel="ц" android:popupCharacters="2ћџҵ"/>
-        <Key android:codes="1091" android:keyLabel="у" android:popupCharacters="3ўүұӯӱӳѹ"/>
+        <Key android:codes="1094" android:keyLabel="ц" android:popupCharacters="2ћҵ"/>
+        <Key android:codes="1091" android:keyLabel="у" android:popupCharacters="3ўүұӯӱӳѹѫѭ"/>
         <Key android:codes="1082" android:keyLabel="к" android:popupCharacters="4ќқҝҟҡӄ"/>
-        <Key android:codes="1077" android:keyLabel="е" android:popupCharacters="5ёјҽҿӗәӛ"/>
+        <Key android:codes="1077" android:keyLabel="е" android:popupCharacters="5ёјҽҿӗәӛѧѩ"/>
         <Key android:codes="1085" android:keyLabel="н" android:popupCharacters="6њңҥӈ"/>
         <Key android:codes="1075" android:keyLabel="г" android:popupCharacters="7ґѓғҕ"/>
         <Key android:codes="1096" android:keyLabel="ш" android:popupCharacters="8һѡѽѿ"/>
@@ -29,24 +29,24 @@
         <Key android:codes="1087" android:keyLabel="п" android:popupCharacters="ҧ"/>
         <Key android:codes="1088" android:keyLabel="р"/>
         <Key android:codes="1086" android:keyLabel="о" android:popupCharacters="ӧөӫѳѻ"/>
-        <Key android:codes="1083" android:keyLabel="л" android:popupCharacters="љѧѩ"/>
+        <Key android:codes="1083" android:keyLabel="л" android:popupCharacters="љ"/>
         <Key android:codes="1076" android:keyLabel="д" android:popupCharacters="ј"/>
-        <Key android:codes="1078" android:keyLabel="ж" android:popupCharacters="ђҗӂӝѫѭ"/>
-        <Key android:codes="1101" android:keyLabel="э" android:popupCharacters="є" android:keyEdgeFlags="right"/>
+        <Key android:codes="1078" android:keyLabel="ж" android:popupCharacters="ђҗӂӝ"/>
+        <Key android:codes="1101" android:keyLabel="э" android:popupCharacters="єѥ" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row android:keyWidth="9.09%p">
         <!-- ячсмитьбю -->
         <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
-        <Key android:codes="1103" android:keyLabel="я"/>
-        <Key android:codes="1095" android:keyLabel="ч" android:popupCharacters="ҷҹӌӵ"/>
+        <Key android:codes="1103" android:keyLabel="я" android:popupCharacters="ѕ"/>
+        <Key android:codes="1095" android:keyLabel="ч" android:popupCharacters="џҷҹӌӵ"/>
         <Key android:codes="1089" android:keyLabel="с" android:popupCharacters="ҫҁ"/>
         <Key android:codes="1084" android:keyLabel="м"/>
         <Key android:codes="1080" android:keyLabel="и"/>
         <Key android:codes="1090" android:keyLabel="т" android:popupCharacters="ҭ"/>
         <Key android:codes="1100" android:keyLabel="ь"/>
         <Key android:codes="1073" android:keyLabel="б"/>
-        <Key android:codes="1102" android:keyLabel="ю" android:popupCharacters="ѥ"/>
+        <Key android:codes="1102" android:keyLabel="ю"/>
         <Key android:codes="-5" android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>
 </Keyboard>


### PR DESCRIPTION
This keyboard layout is primarily used to type etymological interslavic: https://en.wikipedia.org/wiki/Interslavic

Some of the pop-up character assignments wouldn't really make sense to interslavic users, as well as those studying Slavic languages or typing Old Church Slavonic, because the pop-up characters don't have anything to do with the main characters assigned to those keys. This PR fixes this issue.

<h3>Summary of the changes</h3>
- "џ" is not a variant of "ц", but it's a voiced equivalent of the unvoiced "ч" in Interslavic and Serbo-Croatian
- "ѫ" (and it's iotated ligature ѭ) are not used in modern languages because the sounds they used to make changed to "y" sounds
- same thing with ѧ, ѩ. They have nothing to do with л, but in the majority of languages the sounds they used to make migrated to "e" sounds.
- ѥ is an iotated ligature derivative of є
- ѕ is assigned sort-of correctly, but it would be more convenient for Serbo-Croatian speakers to have it also at я position because that's where it is in their [keyboard layout](https://en.wikipedia.org/wiki/Serbian_Cyrillic_alphabet), so I duplicated it.

<h3>Future Considerations</h3>
- Remove j assignment from д, because in Slavic languages it makes the English "y" sound as in "Yes"

I'm working on a dedicated interslavic language add-on which will be based on Russian2 with these assignments, but this is a good temp fix imo