### PR TITLE
Fix nav-bar colorization setting for API 36

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -275,12 +275,12 @@ jobs:
         continue-on-error: true
         with:
           name: fdroid-metadata-dry-run-${{ matrix.shard_type }}
-          path: outputs/apk
+          path: outputs/fdroid
       - uses: actions/upload-artifact@v4.6.2
         continue-on-error: true
         with:
           name: binaries-dry-run-${{ matrix.shard_type }}
-          path: outputs/fdroid
+          path: outputs/apk
   all-green-requirement:
     needs: [static-checks, linters, tests, deploy-dry-run, bazel]
     if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -275,6 +275,11 @@ jobs:
         continue-on-error: true
         with:
           name: fdroid-metadata-dry-run-${{ matrix.shard_type }}
+          path: outputs/apk
+      - uses: actions/upload-artifact@v4.6.2
+        continue-on-error: true
+        with:
+          name: binaries-dry-run-${{ matrix.shard_type }}
           path: outputs/fdroid
   all-green-requirement:
     needs: [static-checks, linters, tests, deploy-dry-run, bazel]

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardColorizeNavBar.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardColorizeNavBar.java
@@ -43,14 +43,19 @@ public abstract class AnySoftKeyboardColorizeNavBar extends AnySoftKeyboardIncog
         mNavigationBarHeightId,
         mNavigationBarShownId);
 
-    addDisposable(
-        prefs()
-            .getBoolean(
-                R.string.settings_key_colorize_nav_bar, R.bool.settings_default_colorize_nav_bar)
-            .asObservable()
-            .subscribe(
-                val -> mPrefsToShow = val,
-                GenericOnError.onError("settings_key_colorize_nav_bar")));
+    if (Build.VERSION.SDK_INT >= 36) {
+      mPrefsToShow = true;
+    } else {
+      addDisposable(
+          prefs()
+              .getBoolean(
+                  R.string.settings_key_colorize_nav_bar,
+                  R.bool.settings_default_colorize_nav_bar)
+              .asObservable()
+              .subscribe(
+                  val -> mPrefsToShow = val,
+                  GenericOnError.onError("settings_key_colorize_nav_bar")));
+    }
 
     addDisposable(
         prefs()

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardColorizeNavBar.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardColorizeNavBar.java
@@ -49,8 +49,7 @@ public abstract class AnySoftKeyboardColorizeNavBar extends AnySoftKeyboardIncog
       addDisposable(
           prefs()
               .getBoolean(
-                  R.string.settings_key_colorize_nav_bar,
-                  R.bool.settings_default_colorize_nav_bar)
+                  R.string.settings_key_colorize_nav_bar, R.bool.settings_default_colorize_nav_bar)
               .asObservable()
               .subscribe(
                   val -> mPrefsToShow = val,

--- a/ime/app/src/main/java/com/anysoftkeyboard/ui/settings/EffectsSettingsFragment.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ui/settings/EffectsSettingsFragment.java
@@ -62,6 +62,12 @@ public class EffectsSettingsFragment extends PreferenceFragmentCompat {
       svPref.setVisible(false);
       svPref.setSelectable(false);
     }
+
+    if (Build.VERSION.SDK_INT >= 36) {
+      Preference navBarPref = findPreference(getText(R.string.settings_key_colorize_nav_bar));
+      navBarPref.setVisible(false);
+      navBarPref.setSelectable(false);
+    }
   }
 
   @Override

--- a/ime/app/src/main/res/values-v36/settings_defaults_dont_translate.xml
+++ b/ime/app/src/main/res/values-v36/settings_defaults_dont_translate.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,TypographyDashes">
+    <!-- DO NOT TRANSLATE -->
+    <!-- Default settings values -->
+    <bool name="settings_default_colorize_nav_bar">true</bool>
+</resources>

--- a/ime/prefs/src/main/java/com/anysoftkeyboard/prefs/RxSharedPrefs.java
+++ b/ime/prefs/src/main/java/com/anysoftkeyboard/prefs/RxSharedPrefs.java
@@ -82,11 +82,11 @@ public class RxSharedPrefs {
     final int configurationVersion = sp.getInt(CONFIGURATION_VERSION, CONFIGURATION_LEVEL_VALUE);
 
     if (configurationVersion < 14) {
-        if (android.os.Build.VERSION.SDK_INT >= 36) {
-            final Editor editor = sp.edit();
-            editor.putBoolean("settings_key_colorize_nav_bar", true);
-            editor.apply();
-        }
+      if (android.os.Build.VERSION.SDK_INT >= 36) {
+        final Editor editor = sp.edit();
+        editor.putBoolean("settings_key_colorize_nav_bar", true);
+        editor.apply();
+      }
     }
     if (configurationVersion < 13) {
       final Map<String, ?> allValues = sp.getAll();

--- a/ime/prefs/src/main/java/com/anysoftkeyboard/prefs/RxSharedPrefs.java
+++ b/ime/prefs/src/main/java/com/anysoftkeyboard/prefs/RxSharedPrefs.java
@@ -46,7 +46,7 @@ import java.util.Set;
 
 public class RxSharedPrefs {
   static final String CONFIGURATION_VERSION = "configurationVersion";
-  static final int CONFIGURATION_LEVEL_VALUE = 13;
+  static final int CONFIGURATION_LEVEL_VALUE = 14;
   private static final String TAG = "ASK_Cfg";
 
   @VisibleForTesting static final String AUTO_APPLY_PREFS_FILENAME = "STARTUP_PREFS_APPLY.xml";
@@ -81,6 +81,13 @@ public class RxSharedPrefs {
     // upgrading should only be done when actually need to be done.
     final int configurationVersion = sp.getInt(CONFIGURATION_VERSION, CONFIGURATION_LEVEL_VALUE);
 
+    if (configurationVersion < 14) {
+        if (android.os.Build.VERSION.SDK_INT >= 36) {
+            final Editor editor = sp.edit();
+            editor.putBoolean("settings_key_colorize_nav_bar", true);
+            editor.apply();
+        }
+    }
     if (configurationVersion < 13) {
       final Map<String, ?> allValues = sp.getAll();
       if (allValues.containsKey("zoom_factor_keys_in_portrait")) {

--- a/ime/prefs/src/test/java/com/anysoftkeyboard/prefs/RxSharedPrefsTest.java
+++ b/ime/prefs/src/test/java/com/anysoftkeyboard/prefs/RxSharedPrefsTest.java
@@ -122,7 +122,7 @@ public class RxSharedPrefsTest {
     new RxSharedPrefs(getApplicationContext(), this::testRestoreFunction);
 
     Assert.assertFalse(preferences.contains("settings_key_vibrate_on_key_press_duration_int"));
-    Assert.assertEquals(13, preferences.getInt(RxSharedPrefs.CONFIGURATION_VERSION, 0));
+    Assert.assertEquals(14, preferences.getInt(RxSharedPrefs.CONFIGURATION_VERSION, 0));
   }
 
   @Test


### PR DESCRIPTION
fixes #4266

For API level 36 and above, the navigation bar colorization should always be enabled. This commit introduces a resource override to enforce this behavior.

Also, a preference upgrade step was added to ensure that existing installations are also updated.

The UI setting is hidden for API 36+ since it can no longer be changed.

Finally, the `AnySoftKeyboardColorizeNavBar` class is updated to ensure the feature is always on for API 36+.