### PR TITLE
feat: Run code-review only on labeled PRs

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -16,6 +16,7 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
       - name: AI Code Review
+        if: contains(github.event.pull_request.labels.*.name, 'ai-code-review')
         run: |
           bazel run //js/ai -- codeReview \
             --gemini-api-key "${{ secrets.GEMINI_2_5_FLASH_API_KEY }}" \


### PR DESCRIPTION
This change modifies the `auto_approve.yml` workflow to make the `AI Code Review` step conditional. It will now only run if the pull request has the `ai-code-review` label applied.