### PR TITLE
[LLM] Fix StringIndexOutOfBoundsException in onPress

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1054,10 +1054,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
 
     // https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/2481
     // the host app may report -1 as indexes (when nothing is selected)
-    if (et.text == null
-        || selectionStart == selectionEnd
-        || selectionEnd == -1
-        || selectionStart == -1) return;
+    if (et.text == null || selectionStart == selectionEnd || selectionEnd < 0 || selectionStart < 0)
+      return;
     final CharSequence selectedText = et.text.subSequence(selectionStart, selectionEnd);
 
     if (selectedText.length() > 0) {
@@ -1111,10 +1109,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
 
     // https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/2481
     // the host app may report -1 as indexes (when nothing is selected)
-    if (et.text == null
-        || selectionStart == selectionEnd
-        || selectionEnd == -1
-        || selectionStart == -1) return;
+    if (et.text == null || selectionStart == selectionEnd || selectionEnd < 0 || selectionStart < 0)
+      return;
     final CharSequence selectedText = et.text.subSequence(selectionStart, selectionEnd);
 
     if (selectedText.length() > 0) {


### PR DESCRIPTION
This fixes issue #4401 

This commit fixes a `StringIndexOutOfBoundsException` that could occur in the `onPress` method when handling text selection. The crash was caused by the `getExtractedText` method returning negative values for `selectionStart` and `selectionEnd` in some edge cases.

The fix adds a check to ensure that `selectionStart` and `selectionEnd` are not negative before using them to create a substring. This prevents the crash from happening.

I have also applied the same fix to the `wrapSelectionWithCharacters` method to be safe.

Signed-off-by: Gemini-Code-Assistant