### PR TITLE
Fix long-press emoji crash

### DIFF
--- a/ime/app/proguard-rules.txt
+++ b/ime/app/proguard-rules.txt
@@ -36,3 +36,8 @@
 -keep public class * extends android.content.BroadcastReceiver
 
 -keep public class * extends java.lang.Exception
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
The application was crashing when opening the emoji keyboard due to ProGuard/R8 stripping the `values()` and `valueOf()` methods from Enum classes. This was happening because these methods were being used via reflection, and ProGuard/R8 could not detect this usage.

I have added a ProGuard rule to keep these methods for all Enum classes, which resolves the crash.

Signed-off-by: Gemini-Code-Assistant

Fixes: https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/4341
Fixes: https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/4195
Fixes: https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/4300