### PR TITLE
[LLM] Add F-Droid version file generation for automated updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,11 @@ jobs:
         with:
           name: proguard-mapping
           path: proguard-mapping
+      - uses: actions/download-artifact@v5.0.0
+        if: endsWith(needs.deploy.outputs.deployment_environment, '_010')
+        with:
+          name: fdroid-metadata
+          path: fdroid-metadata
       - name: "Delete prior release and tag"
         if: endsWith(needs.deploy.outputs.deployment_environment, '_010')
         run: gh release delete "${{ env.TAG_NAME }}" --cleanup-tag --yes || true
@@ -145,6 +150,7 @@ jobs:
             apks/*.apk
             bundles/*.aab
             proguard-mapping/**/*.txt
+            fdroid-metadata/version.txt
       - name: Update GitHub Release to Stable
         if: endsWith(needs.deploy.outputs.deployment_environment, '_100')
         run: gh release edit "${{ env.TAG_NAME }}" --prerelease=false

--- a/buildSrc/src/main/kotlin/net/evendanan/versiongenerator/SimpleVersionGeneratorPlugin.kt
+++ b/buildSrc/src/main/kotlin/net/evendanan/versiongenerator/SimpleVersionGeneratorPlugin.kt
@@ -49,10 +49,31 @@ class SimpleVersionGeneratorPlugin : Plugin<Project> {
 
                     project.version = verData.versionName
                     project.allprojects.forEach { it.version = verData.versionName }
+
+                    if (versionConf.generateVersionFile) {
+                      generateVersionFile(project, versionConf, verData)
+                    }
                   }
         }
       }
     }
+  }
+
+  private fun generateVersionFile(
+      project: Project,
+      config: SimpleConfiguration,
+      versionData: VersionData
+  ) {
+    val outputFile = project.rootProject.file(config.versionFileOutputPath)
+    outputFile.parentFile.mkdirs()
+
+    // Write version file in Wire Android format
+    val content =
+        """VersionCode: ${versionData.versionCode}
+VersionName: ${versionData.versionName}
+"""
+
+    outputFile.writeText(content)
   }
 
   // This class has to be `open` so Gradle will be able to create a Proxy to it.
@@ -65,6 +86,8 @@ class SimpleVersionGeneratorPlugin : Plugin<Project> {
     var patchOffset = 0
     var defaultBuildCount = 1
     var versionData: VersionData? = null
+    var generateVersionFile = false
+    var versionFileOutputPath = "outputs/fdroid/version.txt"
   }
 
   companion object {

--- a/ime/build.gradle
+++ b/ime/build.gradle
@@ -9,4 +9,6 @@ autoVersioning {
     buildCounterOffset = 6305
     /*decrementing due to minor, every minor/major bump, this should be decremented*/
     patchOffset = -5170-1790-668-1084
+    /*F-Droid version file generation*/
+    generateVersionFile = true
 }


### PR DESCRIPTION
Feature Request: F-Droid maintainers requested a version file to automate AnySoftKeyboard updates in the F-Droid repository.

Solution:
- Integrated version file generation directly into SimpleVersionGeneratorPlugin
- Added generateVersionFile configuration option (default: false)
- Automatically generates outputs/fdroid/version.txt with VersionCode and VersionName
- Updated GitHub workflow to upload version.txt as a release asset
- Enabled version file generation in ime/build.gradle

The version file is now automatically generated during builds with auto-versioning enabled and uploaded to GitHub releases for F-Droid automation.