### PR TITLE
Update NDK to r29 for 16 KB page size support

### DIFF
--- a/gradle/root_all_projects_ext.gradle
+++ b/gradle/root_all_projects_ext.gradle
@@ -3,7 +3,7 @@ allprojects {
         androidBuildTools = '36.0.0'
         robolectricVersion = '4.14.1'
 
-        sideBySideNdkVersion = '27.2.12479018'
+        sideBySideNdkVersion = '29.0.14206865'
 
         sdkTargetVersion = 35
         sdkCompileVersion = 36


### PR DESCRIPTION
Upgrades NDK from r27 to r29 to enable native library alignment for 16 KB memory page sizes. NDK r28+ compiles with 16 KB alignment by default, ensuring compatibility with Android 15 devices and meeting Google Play Console requirements (mandatory after November 1st, 2025).

Fixes #4381