### PR TITLE
Better gesture typing accept words whose starting char is close to first gesture path corner

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -346,6 +346,9 @@ public class GestureTypingDetector {
       for (int i = 0; i < words.length; i++) {
         // Check if current word starts with a key close to the gesture start point
         final Keyboard.Key wordStartKey = mKeysByCharacter.get(Dictionary.toLowerCase(words[i][0]));
+        if (wordStartKey == null) {
+          continue; // Character not found on keyboard
+        }
 
         // Calculate squared distance from gesture start to word's starting key
         final int distanceSquared = wordStartKey.squaredDistanceFrom(corners[0], corners[1]);

--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -27,8 +27,8 @@ public class GestureTypingDetector {
   private static final double MINIMUM_DISTANCE_FILTER = 1000000;
 
   /**
-   * Penalty factor for words that start near but not on the exact starting key.
-   * Lower value = less penalty, higher value = more penalty.
+   * Penalty factor for words that start near but not on the exact starting key. Lower value = less
+   * penalty, higher value = more penalty.
    */
   private static final double PROXIMITY_PENALTY_FACTOR = 0.1;
 
@@ -36,9 +36,9 @@ public class GestureTypingDetector {
   private final int mMinPointDistanceSquared;
 
   /**
-   * Maximum squared distance from gesture start point to accept a word's starting key.
-   * This allows for imprecise gesture starts while filtering obviously wrong candidates.
-   * Value is approximately 1.5 key widths squared (assuming ~100 pixel keys).
+   * Maximum squared distance from gesture start point to accept a word's starting key. This allows
+   * for imprecise gesture starts while filtering obviously wrong candidates. Value is approximately
+   * 1.5 key widths squared (assuming ~100 pixel keys).
    */
   private final int mStartKeyProximityThresholdSquared;
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -345,12 +345,20 @@ public class GestureTypingDetector {
           continue; // Character not found on keyboard
         }
 
-        // Calculate squared distance from gesture start to word's starting key
-        final int distanceSquared = wordStartKey.squaredDistanceFrom(corners[0], corners[1]);
+        // Add a small penalty if the word doesn't start on the exact starting key
+        // This biases towards words that start on the gesture starting key
+        double proximityPenalty = 0;
+        if (wordStartKey != startKey) {
+          // Calculate squared distance from gesture start to word's starting key
+          final int distanceSquared = wordStartKey.squaredDistanceFrom(corners[0], corners[1]);
 
-        // Filter out words whose starting key is too far from gesture start
-        if (distanceSquared > mStartKeyProximityThresholdSquared) {
-          continue;
+          // Filter out words whose starting key is too far from gesture start
+          if (distanceSquared > mStartKeyProximityThresholdSquared) {
+            continue;
+          }
+
+          // Small penalty proportional to distance from start point
+          proximityPenalty = Math.sqrt(distanceSquared) * PROXIMITY_PENALTY_FACTOR;
         }
 
         final double distanceFromCurve =
@@ -363,14 +371,6 @@ public class GestureTypingDetector {
         // TODO: convert wordFrequencies to a double[] in the loading phase.
         final double revisedDistanceFromCurve =
             distanceFromCurve - (mFrequencyFactor * ((double) wordFrequencies[i]));
-
-        // Add a small penalty if the word doesn't start on the exact starting key
-        // This biases towards words that start on the gesture starting key
-        double proximityPenalty = 0;
-        if (wordStartKey != startKey) {
-          // Small penalty proportional to distance from start point
-          proximityPenalty = Math.sqrt(distanceSquared) * PROXIMITY_PENALTY_FACTOR;
-        }
 
         final double finalWeight = revisedDistanceFromCurve + proximityPenalty;
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -333,11 +333,6 @@ public class GestureTypingDetector {
       }
     }
 
-    if (startKey == null) {
-      Logger.w(TAG, "Could not find a key that is inside %d,%d", corners[0], corners[1]);
-      return mCandidates;
-    }
-
     mCandidateWeights.clear();
     int dictionaryWordsCornersOffset = 0;
     for (int dictIndex = 0; dictIndex < mWords.size(); dictIndex++) {

--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -27,13 +27,6 @@ public class GestureTypingDetector {
   private static final double MINIMUM_DISTANCE_FILTER = 1000000;
 
   /**
-   * Maximum squared distance from gesture start point to accept a word's starting key.
-   * This allows for imprecise gesture starts while filtering obviously wrong candidates.
-   * Value is approximately 1.5 key widths squared (assuming ~100 pixel keys).
-   */
-  private static final int START_KEY_PROXIMITY_THRESHOLD_SQUARED = 22500;
-
-  /**
    * Penalty factor for words that start near but not on the exact starting key.
    * Lower value = less penalty, higher value = more penalty.
    */
@@ -41,6 +34,13 @@ public class GestureTypingDetector {
 
   // How far away do two points of the gesture have to be (distance squared)?
   private final int mMinPointDistanceSquared;
+
+  /**
+   * Maximum squared distance from gesture start point to accept a word's starting key.
+   * This allows for imprecise gesture starts while filtering obviously wrong candidates.
+   * Value is approximately 1.5 key widths squared (assuming ~100 pixel keys).
+   */
+  private final int mStartKeyProximityThresholdSquared;
 
   private final ArrayList<String> mCandidates;
   private final double mFrequencyFactor;
@@ -72,12 +72,14 @@ public class GestureTypingDetector {
       double frequencyFactor,
       int maxSuggestions,
       int minPointDistance,
+      int startKeyProximityThreshold,
       @NonNull Iterable<Keyboard.Key> keys) {
     mFrequencyFactor = frequencyFactor;
     mMaxSuggestions = maxSuggestions;
     mCandidates = new ArrayList<>(mMaxSuggestions * 3);
     mCandidateWeights = new ArrayList<>(mMaxSuggestions * 3);
     mMinPointDistanceSquared = minPointDistance * minPointDistance;
+    mStartKeyProximityThresholdSquared = startKeyProximityThreshold * startKeyProximityThreshold;
     mKeys = keys;
 
     mGenerateStateSubject.onNext(LoadingState.NOT_LOADED);
@@ -349,7 +351,7 @@ public class GestureTypingDetector {
         final int distanceSquared = wordStartKey.squaredDistanceFrom(corners[0], corners[1]);
 
         // Filter out words whose starting key is too far from gesture start
-        if (distanceSquared > START_KEY_PROXIMITY_THRESHOLD_SQUARED) {
+        if (distanceSquared > mStartKeyProximityThresholdSquared) {
           continue;
         }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetector.java
@@ -344,9 +344,6 @@ public class GestureTypingDetector {
       for (int i = 0; i < words.length; i++) {
         // Check if current word starts with a key close to the gesture start point
         final Keyboard.Key wordStartKey = mKeysByCharacter.get(Dictionary.toLowerCase(words[i][0]));
-        if (wordStartKey == null) {
-          continue; // Character not found on keyboard
-        }
 
         // Calculate squared distance from gesture start to word's starting key
         final int distanceSquared = wordStartKey.squaredDistanceFrom(corners[0], corners[1]);

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithGestureTyping.java
@@ -165,6 +165,7 @@ public abstract class AnySoftKeyboardWithGestureTyping extends AnySoftKeyboardWi
                 getResources().getDimension(R.dimen.gesture_typing_frequency_factor),
                 15 /*max suggestions. For now it is static*/,
                 getResources().getDimensionPixelSize(R.dimen.gesture_typing_min_point_distance),
+                getResources().getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold),
                 keyboard.getKeys());
         mGestureTypingDetectors.put(key, mCurrentGestureDetector);
       }

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
@@ -612,9 +612,9 @@ public abstract class Keyboard {
       final boolean topEdge = (edgeFlags & EDGE_TOP) != 0;
       final boolean bottomEdge = (edgeFlags & EDGE_BOTTOM) != 0;
       return (x >= this.x || (leftEdge && x <= this.x + this.width))
-          && (x < this.x + this.width || (rightEdge && x >= this.x))
+          && (x <= this.x + this.width || (rightEdge && x >= this.x))
           && (y >= this.y || (topEdge && y <= this.y + this.height))
-          && (y < this.y + this.height || (bottomEdge && y >= this.y));
+          && (y <= this.y + this.height || (bottomEdge && y >= this.y));
     }
 
     /**

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/Keyboard.java
@@ -612,9 +612,9 @@ public abstract class Keyboard {
       final boolean topEdge = (edgeFlags & EDGE_TOP) != 0;
       final boolean bottomEdge = (edgeFlags & EDGE_BOTTOM) != 0;
       return (x >= this.x || (leftEdge && x <= this.x + this.width))
-          && (x <= this.x + this.width || (rightEdge && x >= this.x))
+          && (x < this.x + this.width || (rightEdge && x >= this.x))
           && (y >= this.y || (topEdge && y <= this.y + this.height))
-          && (y <= this.y + this.height || (bottomEdge && y >= this.y));
+          && (y < this.y + this.height || (bottomEdge && y >= this.y));
     }
 
     /**

--- a/ime/app/src/main/res/values/dimens.xml
+++ b/ime/app/src/main/res/values/dimens.xml
@@ -90,7 +90,7 @@
 
     <dimen name="gesture_typing_min_point_distance">5sp</dimen>
     <dimen name="gesture_typing_frequency_factor">2.5dp</dimen>
-    <dimen name="gesture_typing_proximity_threshold">20dp</dimen>
+    <dimen name="gesture_typing_proximity_threshold">150dp</dimen>
     <dimen name="extension_keyboard_reveal_point">-10dp</dimen>
     <dimen name="dismiss_keyboard_point">5dp</dimen>
     <dimen name="navigation_bar_min_height">40dp</dimen>

--- a/ime/app/src/main/res/values/dimens.xml
+++ b/ime/app/src/main/res/values/dimens.xml
@@ -90,6 +90,7 @@
 
     <dimen name="gesture_typing_min_point_distance">5sp</dimen>
     <dimen name="gesture_typing_frequency_factor">2.5dp</dimen>
+    <dimen name="gesture_typing_proximity_threshold">20dp</dimen>
     <dimen name="extension_keyboard_reveal_point">-10dp</dimen>
     <dimen name="dismiss_keyboard_point">5dp</dimen>
     <dimen name="navigation_bar_min_height">40dp</dimen>

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -837,4 +837,126 @@ public class GestureTypingDetectorTest {
     Assert.assertTrue(
         "Expected to find words starting with 'g' in candidates: " + candidates, hasGWords);
   }
+
+  @Test
+  public void testStartKeyProximityThreshold() {
+    // Test: Start key proximity threshold filters out words that are too far
+    // Gesture starts on 'h' key, but we try to get candidates starting with distant keys
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get positions for keys that are far apart
+    final Point hKeyCenter = getPointForCharacter('h');
+    final Point gKeyCenter = getPointForCharacter('g');
+
+    // Calculate distance between 'h' and 'g' keys
+    final int distanceSquared =
+        (hKeyCenter.x - gKeyCenter.x) * (hKeyCenter.x - gKeyCenter.x)
+            + (hKeyCenter.y - gKeyCenter.y) * (hKeyCenter.y - gKeyCenter.y);
+
+    // Start gesture on 'h' key
+    mDetectorUnderTest.addPoint(hKeyCenter.x, hKeyCenter.y);
+
+    // Continue with rest of "hello" gesture
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Words starting with 'h' should be in candidates (within threshold)
+    boolean hasHWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("h"));
+    Assert.assertTrue("Expected words starting with 'h' in candidates: " + candidates, hasHWords);
+
+    // Words starting with 'g' should be filtered out if distance exceeds threshold
+    // This depends on the actual proximity threshold value and key layout
+    // If 'g' is far enough from 'h', 'g' words should not appear
+    final int proximityThreshold =
+        ApplicationProvider.getApplicationContext()
+            .getResources()
+            .getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold);
+    final int proximityThresholdSquared = proximityThreshold * proximityThreshold;
+
+    if (distanceSquared > proximityThresholdSquared) {
+      // 'g' key is outside proximity threshold, so 'g' words should be filtered out
+      boolean hasGWords =
+          candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
+      Assert.assertFalse(
+          "Expected words starting with 'g' to be filtered out (distance squared: "
+              + distanceSquared
+              + " > threshold squared: "
+              + proximityThresholdSquared
+              + "), but got: "
+              + candidates,
+          hasGWords);
+    }
+  }
+
+  @Test
+  public void testNearbyKeyWordsHaveLowerPriority() {
+    // Test: Words from nearby keys have lower priority than words from the exact starting key
+    // When gesture starts between 'h' and 'g', words starting with the closer key should rank
+    // higher
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get positions for 'h' and 'g' keys
+    final Point hKeyCenter = getPointForCharacter('h');
+    final Point gKeyCenter = getPointForCharacter('g');
+
+    // Start gesture exactly on 'h' key center
+    mDetectorUnderTest.addPoint(hKeyCenter.x, hKeyCenter.y);
+
+    // Continue with a gesture path that could match both 'h' and 'g' words
+    // Use 'ello' continuation which makes "hello" a good match
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Both 'h' and 'g' words might be in candidates if 'g' is within proximity threshold
+    boolean hasHWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("h"));
+    boolean hasGWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
+
+    if (hasHWords && hasGWords) {
+      // If both types of words are present, verify 'h' words rank higher
+      // Find the highest ranking (lowest index) 'h' word
+      int bestHWordIndex = -1;
+      for (int i = 0; i < candidates.size(); i++) {
+        if (candidates.get(i).toLowerCase().startsWith("h")) {
+          bestHWordIndex = i;
+          break;
+        }
+      }
+
+      // Find the highest ranking (lowest index) 'g' word
+      int bestGWordIndex = -1;
+      for (int i = 0; i < candidates.size(); i++) {
+        if (candidates.get(i).toLowerCase().startsWith("g")) {
+          bestGWordIndex = i;
+          break;
+        }
+      }
+
+      Assert.assertTrue(
+          "Expected words starting with 'h' to rank higher than words starting with 'g' "
+              + "when gesture starts on 'h' key. Best 'h' word at index "
+              + bestHWordIndex
+              + ", best 'g' word at index "
+              + bestGWordIndex
+              + ". Candidates: "
+              + candidates,
+          bestHWordIndex < bestGWordIndex);
+    } else if (hasHWords) {
+      // If only 'h' words are present, that's also correct (g words filtered by proximity)
+      Assert.assertTrue("Expected 'h' words when starting on 'h' key", true);
+    } else {
+      Assert.fail(
+          "Expected at least words starting with 'h' when gesture starts on 'h' key, but got: "
+              + candidates);
+    }
+  }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -177,10 +177,11 @@ public class GestureTypingDetectorTest {
         .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
     candidates.addAll(mDetectorUnderTest.getCandidates());
 
-    Assert.assertEquals(3, candidates.size());
+    // With proximity filtering, we may get words from nearby keys too (e.g., 'h' is near 'g')
+    // But we should still have all the 'g' words
+    Assert.assertTrue("Should have at least 3 candidates", candidates.size() >= 3);
     Arrays.asList("good", "God", "gods")
-        .forEach(word -> Assert.assertTrue("Missing the word " + word, candidates.remove(word)));
-    Assert.assertTrue("Still has " + candidates.toString(), candidates.isEmpty());
+        .forEach(word -> Assert.assertTrue("Missing the word " + word, candidates.contains(word)));
   }
 
   @Test
@@ -470,7 +471,7 @@ public class GestureTypingDetectorTest {
     generatePointsStreamOfKeysString("god")
         .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
     final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
-    Assert.assertEquals(3, candidates.size());
+    Assert.assertTrue(candidates.size() >= 3);
   }
 
   @Test
@@ -514,7 +515,7 @@ public class GestureTypingDetectorTest {
     generatePointsStreamOfKeysString("good")
         .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
     final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
-    Assert.assertEquals(3, candidates.size());
+    Assert.assertTrue(candidates.size() >= 3);
     Assert.assertEquals("good", candidates.get(0));
   }
 
@@ -595,5 +596,244 @@ public class GestureTypingDetectorTest {
         .skip(1 /*the first one is just wrong*/)
         .map(pair -> generateTraceBetweenPoints(pair.first, pair.second))
         .flatMap(pointStream -> pointStream);
+  }
+
+  // Tests for proximity-based filtering
+
+  @Test
+  public void testExactMatchStillWorks() {
+    // Test: Exact match still works
+    // Gesture starts exactly on 'h' key
+    // Verify "hello" is in candidates
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Generate a gesture that starts exactly on the 'h' key
+    generatePointsStreamOfKeysString("hello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Verify "hello" is in the candidates
+    Assert.assertTrue(
+        "Expected 'hello' to be in candidates but got: " + candidates,
+        candidates.contains("hello"));
+  }
+
+  @Test
+  public void testNearbyKeyIsAccepted() {
+    // Test: Nearby key is accepted
+    // Gesture starts near 'h' key (but not exactly on it)
+    // Verify "hello" is still in candidates
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get the 'h' key position
+    final Point hKeyCenter = getPointForCharacter('h');
+
+    // Start slightly offset from the 'h' key center (within proximity threshold)
+    // Offset by ~30 pixels (well within the 150 pixel threshold = sqrt(22500))
+    final int offsetX = 30;
+    final int offsetY = 30;
+    mDetectorUnderTest.addPoint(hKeyCenter.x + offsetX, hKeyCenter.y + offsetY);
+
+    // Continue with the rest of the gesture for "hello"
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Verify "hello" is still in candidates despite imprecise start
+    Assert.assertTrue(
+        "Expected 'hello' to be in candidates with nearby start but got: " + candidates,
+        candidates.contains("hello"));
+  }
+
+  @Test
+  public void testFarKeyIsRejected() {
+    // Test: Far key is rejected
+    // Gesture starts on 'a' key (far from 'h')
+    // Verify "hello" is NOT in candidates (first char is 'h')
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get the 'a' key position (far from 'h')
+    final Point aKeyCenter = getPointForCharacter('a');
+
+    // Start gesture on 'a' key
+    mDetectorUnderTest.addPoint(aKeyCenter.x, aKeyCenter.y);
+
+    // Continue with gesture points for "ello"
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Verify "hello" is NOT in candidates because 'a' is far from 'h'
+    Assert.assertFalse(
+        "Did not expect 'hello' to be in candidates when starting far from 'h', but got: "
+            + candidates,
+        candidates.contains("hello"));
+  }
+
+  @Test
+  public void testNullHandlingForUnknownCharacter() {
+    // Test: Null handling
+    // Word with character not on keyboard
+    // Verify no crash, word is skipped
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    // Add a word with a special character that won't be on the keyboard
+    mDetectorUnderTest.setWords(
+        Collections.singletonList(
+            new char[][] {
+              "hello".toCharArray(),
+              "h\u00E9llo".toCharArray(), // Contains é which might not be on English keyboard
+              "test".toCharArray()
+            }),
+        Collections.singletonList(new int[] {100, 100, 100}));
+
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Generate a gesture for "hello"
+    generatePointsStreamOfKeysString("hello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Should complete without crashing
+    // "hello" should be in candidates, words with unknown characters should be skipped
+    Assert.assertTrue(
+        "Expected 'hello' to be in candidates", candidates.contains("hello"));
+  }
+
+  @Test
+  public void testProximityPenaltyPrefersExactMatch() {
+    // Test: Proximity penalty
+    // Two words could match: one starts on exact key, one starts on nearby key
+    // Verify exact match ranks higher
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get positions for 'h' and 'g' keys (they should be adjacent)
+    final Point hKeyCenter = getPointForCharacter('h');
+    final Point gKeyCenter = getPointForCharacter('g');
+
+    // Start gesture between 'h' and 'g', but closer to 'h'
+    // This means both 'h' words and 'g' words might be considered
+    int startX = (hKeyCenter.x + gKeyCenter.x) / 2;
+    int startY = (hKeyCenter.y + gKeyCenter.y) / 2;
+
+    // Adjust to be slightly closer to 'h'
+    startX = (startX + hKeyCenter.x) / 2;
+    startY = (startY + hKeyCenter.y) / 2;
+
+    mDetectorUnderTest.addPoint(startX, startY);
+
+    // Continue with gesture that could match both "hello" and "good"
+    // Let's use a gesture that goes through 'e', 'l', 'o' area for "hello"
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Words starting with 'h' should be preferred over words starting with 'g'
+    // because the start point is closer to 'h'
+    if (candidates.contains("hello") && candidates.contains("good")) {
+      int helloIndex = candidates.indexOf("hello");
+      int goodIndex = candidates.indexOf("good");
+
+      // "hello" should rank higher (lower index) than "good"
+      Assert.assertTrue(
+          "Expected 'hello' to rank higher than 'good' due to proximity penalty, "
+              + "but got: "
+              + candidates,
+          helloIndex < goodIndex);
+    }
+  }
+
+  @Test
+  public void testEdgeProximity() {
+    // Test: Edge proximity
+    // Gesture starts just outside a key but within threshold
+    // Verify words starting with that key are still considered
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get the 'h' key to find its edges
+    Keyboard.Key hKey =
+        mKeys.stream()
+            .filter(key -> key.getPrimaryCode() == 'h')
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("Could not find 'h' key"));
+
+    // Start just outside the right edge of the 'h' key, but within proximity threshold
+    // The key boundary is at (hKey.x + hKey.width)
+    int edgeX = hKey.x + hKey.width + 20; // 20 pixels outside the right edge
+    int edgeY = Keyboard.Key.getCenterY(hKey);
+
+    mDetectorUnderTest.addPoint(edgeX, edgeY);
+
+    // Continue with the rest of the gesture for "hello"
+    generatePointsStreamOfKeysString("ello")
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Verify "hello" is in candidates even though we started outside the key
+    Assert.assertTrue(
+        "Expected 'hello' to be in candidates when starting near edge but got: " + candidates,
+        candidates.contains("hello"));
+  }
+
+  @Test
+  public void testProximityFilteringWithMultipleNearbyWords() {
+    // Test that proximity filtering includes multiple words starting with nearby keys
+    TestRxSchedulers.drainAllTasks();
+    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
+
+    mDetectorUnderTest.clearGesture();
+
+    // Get positions for 'h' and 'g' keys
+    final Point hKeyCenter = getPointForCharacter('h');
+    final Point gKeyCenter = getPointForCharacter('g');
+
+    // Calculate a point between 'h' and 'g' that's within proximity threshold of both
+    int midX = (hKeyCenter.x + gKeyCenter.x) / 2;
+    int midY = (hKeyCenter.y + gKeyCenter.y) / 2;
+
+    mDetectorUnderTest.addPoint(midX, midY);
+
+    // Add points that could lead to either 'h' words or 'g' words
+    // Use 'o' as next point which is common to paths for both sets
+    final Point oKeyCenter = getPointForCharacter('o');
+    generateTraceBetweenPoints(new Point(midX, midY), oKeyCenter)
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    // Continue to 'd' which completes "god" or "good"
+    final Point dKeyCenter = getPointForCharacter('d');
+    generateTraceBetweenPoints(oKeyCenter, dKeyCenter)
+        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
+
+    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
+
+    // Should contain words starting with 'g' since we're close enough
+    boolean hasGWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
+    Assert.assertTrue(
+        "Expected to find words starting with 'g' in candidates: " + candidates, hasGWords);
   }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -80,6 +80,7 @@ public class GestureTypingDetectorTest {
             context.getResources().getDimension(R.dimen.gesture_typing_frequency_factor),
             MAX_SUGGESTIONS,
             context.getResources().getDimensionPixelSize(R.dimen.gesture_typing_min_point_distance),
+            context.getResources().getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold),
             mKeys);
 
     mCurrentState = new AtomicReference<>();

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -80,7 +80,9 @@ public class GestureTypingDetectorTest {
             context.getResources().getDimension(R.dimen.gesture_typing_frequency_factor),
             MAX_SUGGESTIONS,
             context.getResources().getDimensionPixelSize(R.dimen.gesture_typing_min_point_distance),
-            context.getResources().getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold),
+            context
+                .getResources()
+                .getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold),
             mKeys);
 
     mCurrentState = new AtomicReference<>();
@@ -714,8 +716,7 @@ public class GestureTypingDetectorTest {
 
     // Should complete without crashing
     // "hello" should be in candidates, words with unknown characters should be skipped
-    Assert.assertTrue(
-        "Expected 'hello' to be in candidates", candidates.contains("hello"));
+    Assert.assertTrue("Expected 'hello' to be in candidates", candidates.contains("hello"));
   }
 
   @Test

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
 public class GestureTypingDetectorTest {
-  private static final int MAX_SUGGESTIONS = 4;
+  private static final int MAX_SUGGESTIONS = 6;
   private List<Keyboard.Key> mKeys;
   private GestureTypingDetector mDetectorUnderTest;
   private AtomicReference<GestureTypingDetector.LoadingState> mCurrentState;
@@ -132,7 +132,7 @@ public class GestureTypingDetectorTest {
 
     Assert.assertEquals(MAX_SUGGESTIONS, candidates.size());
     // "harp" is removed due to MAX_SUGGESTIONS limit
-    Arrays.asList("hero", "hello", "hell", "Hall")
+    Arrays.asList("hero", "hello", "hell", "Hall", "help", "good")
         .forEach(
             word ->
                 Assert.assertTrue(
@@ -624,7 +624,7 @@ public class GestureTypingDetectorTest {
   }
 
   @Test
-  public void testNearbyKeyIsAccepted() {
+  public void testNearbyWordStartKeyIsAccepted() {
     // Test: Nearby key is accepted
     // Gesture starts near 'h' key (but not exactly on it)
     // Verify "hello" is still in candidates
@@ -655,7 +655,7 @@ public class GestureTypingDetectorTest {
   }
 
   @Test
-  public void testFarKeyIsRejected() {
+  public void testFarWordStartKeyIsRejected() {
     // Test: Far key is rejected
     // Gesture starts on 'a' key (far from 'h')
     // Verify "hello" is NOT in candidates (first char is 'h')
@@ -752,17 +752,15 @@ public class GestureTypingDetectorTest {
 
     // Words starting with 'h' should be preferred over words starting with 'g'
     // because the start point is closer to 'h'
-    if (candidates.contains("hello") && candidates.contains("good")) {
-      int helloIndex = candidates.indexOf("hello");
-      int goodIndex = candidates.indexOf("good");
+    int helloIndex = candidates.indexOf("hello");
+    int goodIndex = candidates.indexOf("good");
 
-      // "hello" should rank higher (lower index) than "good"
-      Assert.assertTrue(
-          "Expected 'hello' to rank higher than 'good' due to proximity penalty, "
-              + "but got: "
-              + candidates,
-          helloIndex < goodIndex);
-    }
+    // "hello" should rank higher (lower index) than "good"
+    Assert.assertTrue(
+        "Expected 'hello' to rank higher than 'good' due to proximity penalty, "
+            + "but got: "
+            + candidates,
+        helloIndex < goodIndex);
   }
 
   @Test
@@ -836,127 +834,5 @@ public class GestureTypingDetectorTest {
     boolean hasGWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
     Assert.assertTrue(
         "Expected to find words starting with 'g' in candidates: " + candidates, hasGWords);
-  }
-
-  @Test
-  public void testStartKeyProximityThreshold() {
-    // Test: Start key proximity threshold filters out words that are too far
-    // Gesture starts on 'h' key, but we try to get candidates starting with distant keys
-    TestRxSchedulers.drainAllTasks();
-    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
-
-    mDetectorUnderTest.clearGesture();
-
-    // Get positions for keys that are far apart
-    final Point hKeyCenter = getPointForCharacter('h');
-    final Point gKeyCenter = getPointForCharacter('g');
-
-    // Calculate distance between 'h' and 'g' keys
-    final int distanceSquared =
-        (hKeyCenter.x - gKeyCenter.x) * (hKeyCenter.x - gKeyCenter.x)
-            + (hKeyCenter.y - gKeyCenter.y) * (hKeyCenter.y - gKeyCenter.y);
-
-    // Start gesture on 'h' key
-    mDetectorUnderTest.addPoint(hKeyCenter.x, hKeyCenter.y);
-
-    // Continue with rest of "hello" gesture
-    generatePointsStreamOfKeysString("ello")
-        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
-
-    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
-
-    // Words starting with 'h' should be in candidates (within threshold)
-    boolean hasHWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("h"));
-    Assert.assertTrue("Expected words starting with 'h' in candidates: " + candidates, hasHWords);
-
-    // Words starting with 'g' should be filtered out if distance exceeds threshold
-    // This depends on the actual proximity threshold value and key layout
-    // If 'g' is far enough from 'h', 'g' words should not appear
-    final int proximityThreshold =
-        ApplicationProvider.getApplicationContext()
-            .getResources()
-            .getDimensionPixelSize(R.dimen.gesture_typing_proximity_threshold);
-    final int proximityThresholdSquared = proximityThreshold * proximityThreshold;
-
-    if (distanceSquared > proximityThresholdSquared) {
-      // 'g' key is outside proximity threshold, so 'g' words should be filtered out
-      boolean hasGWords =
-          candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
-      Assert.assertFalse(
-          "Expected words starting with 'g' to be filtered out (distance squared: "
-              + distanceSquared
-              + " > threshold squared: "
-              + proximityThresholdSquared
-              + "), but got: "
-              + candidates,
-          hasGWords);
-    }
-  }
-
-  @Test
-  public void testNearbyKeyWordsHaveLowerPriority() {
-    // Test: Words from nearby keys have lower priority than words from the exact starting key
-    // When gesture starts between 'h' and 'g', words starting with the closer key should rank
-    // higher
-    TestRxSchedulers.drainAllTasks();
-    Assert.assertEquals(GestureTypingDetector.LoadingState.LOADED, mCurrentState.get());
-
-    mDetectorUnderTest.clearGesture();
-
-    // Get positions for 'h' and 'g' keys
-    final Point hKeyCenter = getPointForCharacter('h');
-    final Point gKeyCenter = getPointForCharacter('g');
-
-    // Start gesture exactly on 'h' key center
-    mDetectorUnderTest.addPoint(hKeyCenter.x, hKeyCenter.y);
-
-    // Continue with a gesture path that could match both 'h' and 'g' words
-    // Use 'ello' continuation which makes "hello" a good match
-    generatePointsStreamOfKeysString("ello")
-        .forEach(point -> mDetectorUnderTest.addPoint(point.x, point.y));
-
-    final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
-
-    // Both 'h' and 'g' words might be in candidates if 'g' is within proximity threshold
-    boolean hasHWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("h"));
-    boolean hasGWords = candidates.stream().anyMatch(word -> word.toLowerCase().startsWith("g"));
-
-    if (hasHWords && hasGWords) {
-      // If both types of words are present, verify 'h' words rank higher
-      // Find the highest ranking (lowest index) 'h' word
-      int bestHWordIndex = -1;
-      for (int i = 0; i < candidates.size(); i++) {
-        if (candidates.get(i).toLowerCase().startsWith("h")) {
-          bestHWordIndex = i;
-          break;
-        }
-      }
-
-      // Find the highest ranking (lowest index) 'g' word
-      int bestGWordIndex = -1;
-      for (int i = 0; i < candidates.size(); i++) {
-        if (candidates.get(i).toLowerCase().startsWith("g")) {
-          bestGWordIndex = i;
-          break;
-        }
-      }
-
-      Assert.assertTrue(
-          "Expected words starting with 'h' to rank higher than words starting with 'g' "
-              + "when gesture starts on 'h' key. Best 'h' word at index "
-              + bestHWordIndex
-              + ", best 'g' word at index "
-              + bestGWordIndex
-              + ". Candidates: "
-              + candidates,
-          bestHWordIndex < bestGWordIndex);
-    } else if (hasHWords) {
-      // If only 'h' words are present, that's also correct (g words filtered by proximity)
-      Assert.assertTrue("Expected 'h' words when starting on 'h' key", true);
-    } else {
-      Assert.fail(
-          "Expected at least words starting with 'h' when gesture starts on 'h' key, but got: "
-              + candidates);
-    }
   }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/gesturetyping/GestureTypingDetectorTest.java
@@ -127,7 +127,7 @@ public class GestureTypingDetectorTest {
     AtomicInteger distance = new AtomicInteger();
     generatePointsStreamOfKeysString("helo")
         .forEach(point -> distance.addAndGet(mDetectorUnderTest.addPoint(point.x, point.y)));
-    Assert.assertEquals(8016, distance.get());
+    Assert.assertEquals(8076, distance.get());
     final ArrayList<String> candidates = mDetectorUnderTest.getCandidates();
 
     Assert.assertEquals(MAX_SUGGESTIONS, candidates.size());

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboardTest.java
@@ -28,12 +28,12 @@ public class ExternalAnyKeyboardTest {
 
         @Override
         public float getKeyHorizontalGap() {
-          return 1;
+          return 10;
         }
 
         @Override
         public float getRowVerticalGap() {
-          return 2;
+          return 10;
         }
 
         @Override


### PR DESCRIPTION
I tried improving the gesture typing mechanics by not requiring the user to start their swiped word with the correct first character.

Example:
- Before this change: you want to swipe the word Juggernaut, but you start the gesture on the key next to it. Result: you will never get the word you wanted, because AnySoftKeyboard dismisses all words not starting with the first letter of the gesture path.
- After this change: AnySoftKeyboard now also suggests words whose path aligns with the gesture path without requiring the first letter to be correct, so when you swipe the gesture path for Juggernaut but you start on the letter K, now you still get the suggestion for the word Juggernaut, since the gesture path in total aligns best with that word.