### PR TITLE
[LLM] fix: add ImageMagick to deploy action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -41,6 +41,9 @@ runs:
     - name: Install NDK
       shell: bash
       run: echo "y" | sdkmanager "ndk;29.0.14206865"
+    - name: Install ImageMagick
+      shell: bash
+      run: sudo apt-get install -y imagemagick
     - shell: bash
       env:
         TERM: dumb


### PR DESCRIPTION
Fixes the deployment workflow failure caused by missing ImageMagick.

## Issue
The deploy action was failing during launcher icon generation with:
```
/home/runner/work/AnySoftKeyboard/AnySoftKeyboard/addons/StoreStuff/assets/launcher-base/generate.sh: line 22: convert: command not found
```

## Root Cause
PR #4568 successfully migrated from the Docker container to standard GitHub Actions for the checks workflow, but the deploy composite action (`.github/actions/deploy/action.yml`) also needs ImageMagick for generating launcher icons.

## Solution
Added ImageMagick installation step to the deploy composite action, matching the setup in the checks workflow.

## Related
- Fixes deployment failures seen in https://github.com/AnySoftKeyboard/AnySoftKeyboard/actions/runs/20411048159
- Follow-up to PR #4568 which migrated checks workflow from Docker to GitHub Actions

Generated by Claude (Anthropic)