### PR TITLE
[LLM] Migrate Gradle build to use TOML version catalog

### DIFF
--- a/addons/base/apk/build.gradle
+++ b/addons/base/apk/build.gradle
@@ -5,9 +5,9 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     implementation project(path: ':api')
-    api 'androidx.appcompat:appcompat:1.7.1'
-    api 'com.google.android.material:material:1.13.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
+    api libs.androidx.appcompat
+    api libs.material
+    implementation libs.androidx.constraintlayout
     implementation project(path: ':ime:pixel')
 
     testImplementation project(path: ':ime:base-test')

--- a/addons/gradle/pack_apk.gradle
+++ b/addons/gradle/pack_apk.gradle
@@ -31,10 +31,10 @@ def launcherAssetsDir = "${imageAssetsFolder.absolutePath}/launcher-base"
 
 dependencies {
     implementation project(path: ':addons:base:apk')
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation libs.androidx.multidex
 
     testImplementation project(path: ':ime:base-test')
-    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation libs.androidx.test.core.old
 }
 
 def activityResDir = "${buildDir.absolutePath}/generated/activity_res"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,9 +7,9 @@ android {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation("org.robolectric:robolectric:$robolectricVersion") {
+    testImplementation libs.junit
+    testImplementation(libs.robolectric) {
         exclude group: 'com.google.auto.service', module: 'auto-service'
     }
-    testImplementation 'androidx.test:core:1.7.0'
+    testImplementation libs.androidx.test.core
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,12 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath 'com.github.triplet.gradle:play-publisher:3.7.0'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:4.3.0'
-        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.9.6'
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:8.1.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0'
+        classpath "com.android.tools.build:gradle:${libs.versions.agp.get()}"
+        classpath "com.github.triplet.gradle:play-publisher:${libs.versions.playPublisher.get()}"
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:${libs.versions.errorpronePlugin.get()}"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${libs.versions.navigationSafeArgs.get()}"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:${libs.versions.spotless.get()}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}"
     }
 }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    // Version kept in sync with main project's libs.versions.toml
     id "org.jetbrains.kotlin.jvm" version "2.2.0"
 }
 
@@ -12,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    // Versions kept in sync with main project's libs.versions.toml
     implementation 'org.jsoup:jsoup:1.13.1'
     implementation gradleApi()
     implementation localGroovy()

--- a/gradle/errorprone.gradle
+++ b/gradle/errorprone.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         //taken from https://github.com/tbroyer/gradle-errorprone-plugin
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:4.3.0'
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:${rootProject.libs.versions.errorpronePlugin.get()}"
     }
 }
 
@@ -16,8 +16,8 @@ dependencies {
     //annotationProcessor "com.uber.nullaway:nullaway:0.6.4"
 
     //taken from https://github.com/google/error-prone/releases
-    errorprone 'com.google.errorprone:error_prone_core:2.45.0'
-    implementation 'com.google.errorprone:error_prone_annotations:2.15.0'
+    errorprone libs.errorprone.core
+    implementation libs.errorprone.annotations
 }
 
 //this will hold any command-line auto-patch requests (via -PErrorProneAutoPatchList=[coma-separated-list]).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,140 @@
+[versions]
+# Android SDK and Build Tools
+androidBuildTools = "36.1.0"
+sdkTarget = "35"
+sdkCompile = "36"
+sdkMinimum = "21"
+
+# Android Gradle Plugin and Build Plugins
+agp = "8.13.2"
+kotlin = "2.2.0"
+spotless = "8.1.0"
+playPublisher = "3.7.0"
+errorpronePlugin = "4.3.0"
+navigationSafeArgs = "2.9.6"
+
+# AndroidX Libraries
+androidxAnnotation = "1.9.1"
+androidxAppcompat = "1.7.1"
+androidxAutofill = "1.3.0"
+androidxCardview = "1.0.0"
+androidxConstraintlayout = "2.2.0"
+androidxCore = "1.17.0"
+androidxFragment = "1.8.9"
+androidxLegacySupport = "1.0.0"
+androidxMultidex = "2.0.1"
+androidxNavigation = "2.9.6"
+androidxPalette = "1.0.0"
+androidxPreference = "1.2.1"
+androidxRecyclerview = "1.4.0"
+androidxViewpager2 = "1.1.0"
+
+# AndroidX Testing
+androidxTestCore = "1.7.0"
+androidxTestCoreOld = "1.5.0"
+androidxTestJunit = "1.3.0"
+androidxFragmentTesting = "1.6.1"
+
+# Google Libraries
+material = "1.13.0"
+
+# RxJava
+rxjava = "2.2.21"
+rxandroid = "2.1.1"
+rxPreferences = "2.0.1"
+copperRx2 = "1.0.0"
+rx2BroadcastReceiver = "1.0.6"
+
+# Other Dependencies
+relinker = "1.4.5"
+materialtabstrip = "1.1.1"
+easypermissions = "3.0.0"
+
+# ErrorProne
+errorproneCore = "2.45.0"
+errorproneAnnotations = "2.15.0"
+
+# Testing
+junit = "4.13.2"
+robolectric = "4.14.1"
+mockito = "2.23.0"
+mockitoKotlin = "1.5.0"
+systemRules = "1.16.1"
+simpleprovider = "1.1.0"
+
+# BuildSrc Dependencies
+gson = "2.10.1"
+httpclient = "4.5.14"
+kotlinReflect = "2.1.0"
+jsoup = "1.13.1"
+guava = "24.1-jre"
+
+[libraries]
+# AndroidX
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
+androidx-autofill = { module = "androidx.autofill:autofill", version.ref = "androidxAutofill" }
+androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidxCardview" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
+androidx-core = { module = "androidx.core:core", version.ref = "androidxCore" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidxFragment" }
+androidx-legacy-support-core-utils = { module = "androidx.legacy:legacy-support-core-utils", version.ref = "androidxLegacySupport" }
+androidx-legacy-support-v13 = { module = "androidx.legacy:legacy-support-v13", version.ref = "androidxLegacySupport" }
+androidx-legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "androidxLegacySupport" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidxMultidex" }
+androidx-navigation-dynamic-features-fragment = { module = "androidx.navigation:navigation-dynamic-features-fragment", version.ref = "androidxNavigation" }
+androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "androidxNavigation" }
+androidx-navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "androidxNavigation" }
+androidx-palette = { module = "androidx.palette:palette", version.ref = "androidxPalette" }
+androidx-preference = { module = "androidx.preference:preference", version.ref = "androidxPreference" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidxRecyclerview" }
+androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidxViewpager2" }
+
+# AndroidX Testing
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+androidx-test-core-old = { module = "androidx.test:core", version.ref = "androidxTestCoreOld" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
+androidx-fragment-testing = { module = "androidx.fragment:fragment-testing", version.ref = "androidxFragmentTesting" }
+
+# Google
+material = { module = "com.google.android.material:material", version.ref = "material" }
+
+# RxJava
+rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava" }
+rxandroid = { module = "io.reactivex.rxjava2:rxandroid", version.ref = "rxandroid" }
+rx-preferences = { module = "com.f2prateek.rx.preferences2:rx-preferences", version.ref = "rxPreferences" }
+copper-rx2 = { module = "app.cash.copper:copper-rx2", version.ref = "copperRx2" }
+rx2-broadcast-receiver = { module = "com.github.karczews:rx2-broadcast-receiver", version.ref = "rx2BroadcastReceiver" }
+
+# Other
+relinker = { module = "com.getkeepsafe.relinker:relinker", version.ref = "relinker" }
+materialtabstrip = { module = "com.jpardogo.materialtabstrip:library", version.ref = "materialtabstrip" }
+easypermissions = { module = "pub.devrel:easypermissions", version.ref = "easypermissions" }
+
+# ErrorProne
+errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorproneCore" }
+errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorproneAnnotations" }
+
+# Testing
+junit = { module = "junit:junit", version.ref = "junit" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-kotlin = { module = "com.nhaarman:mockito-kotlin", version.ref = "mockitoKotlin" }
+system-rules = { module = "com.github.stefanbirkner:system-rules", version.ref = "systemRules" }
+simpleprovider = { module = "com.github.triplet.simpleprovider:simpleprovider", version.ref = "simpleprovider" }
+
+# BuildSrc
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+httpclient = { module = "org.apache.httpcomponents:httpclient", version.ref = "httpclient" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinReflect" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+play-publisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorpronePlugin" }
+navigation-safeargs = { id = "androidx.navigation.safeargs", version.ref = "navigationSafeArgs" }

--- a/gradle/root_all_projects_ext.gradle
+++ b/gradle/root_all_projects_ext.gradle
@@ -1,13 +1,13 @@
 allprojects {
     project.ext {
-        androidBuildTools = '36.1.0'
-        robolectricVersion = '4.14.1'
+        androidBuildTools = libs.versions.androidBuildTools.get()
+        robolectricVersion = libs.versions.robolectric.get()
 
         sideBySideNdkVersion = '29.0.14206865'
 
-        sdkTargetVersion = 35
-        sdkCompileVersion = 36
-        sdkMinimumVersion = 21
+        sdkTargetVersion = libs.versions.sdkTarget.get() as Integer
+        sdkCompileVersion = libs.versions.sdkCompile.get() as Integer
+        sdkMinimumVersion = libs.versions.sdkMinimum.get() as Integer
 
         isCircleCi = 'true' == System.getenv("CIRCLECI")
         isGithubAction = 'true' == System.getenv("GITHUB_ACTIONS")

--- a/ime/addons/build.gradle
+++ b/ime/addons/build.gradle
@@ -9,7 +9,7 @@ android {
 dependencies {
     implementation project(':ime:base')
     implementation project(':ime:pixel')
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.appcompat
 
     testImplementation project(':ime:base-test')
 }

--- a/ime/app/build.gradle
+++ b/ime/app/build.gradle
@@ -117,28 +117,28 @@ dependencies {
     implementation project(':ime:permissions')
     implementation project(':ime:fileprovider')
 
-    implementation 'androidx.fragment:fragment:1.8.9'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.4.0'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.annotation:annotation:1.9.1'
-    implementation 'androidx.palette:palette:1.0.0'
-    implementation 'androidx.preference:preference:1.2.1'
-    implementation 'com.google.android.material:material:1.13.0'
-    implementation 'com.jpardogo.materialtabstrip:library:1.1.1'
-    implementation 'androidx.autofill:autofill:1.3.0'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0'
+    implementation libs.androidx.fragment
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.legacy.support.v13
+    implementation libs.androidx.recyclerview
+    implementation libs.androidx.cardview
+    implementation libs.androidx.annotation
+    implementation libs.androidx.palette
+    implementation libs.androidx.preference
+    implementation libs.material
+    implementation libs.materialtabstrip
+    implementation libs.androidx.autofill
+    implementation libs.androidx.viewpager2
 
-    implementation 'androidx.navigation:navigation-fragment:2.9.6'
-    implementation 'androidx.navigation:navigation-ui:2.9.6'
-    implementation 'androidx.navigation:navigation-dynamic-features-fragment:2.9.6'
+    implementation libs.androidx.navigation.fragment
+    implementation libs.androidx.navigation.ui
+    implementation libs.androidx.navigation.dynamic.features.fragment
 
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation libs.androidx.multidex
 
     testImplementation project(path: ':ime:base-test')
-    testImplementation 'com.github.triplet.simpleprovider:simpleprovider:1.1.0'
-    testImplementation 'androidx.test.ext:junit:1.3.0'
+    testImplementation libs.simpleprovider
+    testImplementation libs.androidx.test.junit
 
     //allAddOns have all the add-ons packs as dependencies
     rootProject.findProject(":addons").subprojects.forEach {

--- a/ime/base-rx/build.gradle
+++ b/ime/base-rx/build.gradle
@@ -4,12 +4,12 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 
 dependencies {
     implementation project(':ime:base')
-    implementation 'androidx.annotation:annotation:1.9.1'
+    implementation libs.androidx.annotation
 
-    api 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    api 'io.reactivex.rxjava2:rxjava:2.2.21'
-    api 'com.github.karczews:rx2-broadcast-receiver:1.0.6'
-    api 'app.cash.copper:copper-rx2:1.0.0'
+    api libs.rxandroid
+    api libs.rxjava
+    api libs.rx2.broadcast.receiver
+    api libs.copper.rx2
 }
 
 android {

--- a/ime/base-test/build.gradle
+++ b/ime/base-test/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     implementation project(':ime:base-rx')
     implementation project(':ime:pixel')
 
-    implementation 'androidx.preference:preference:1.2.1'
+    implementation libs.androidx.preference
 
-    api 'junit:junit:4.13.2'
-    api "org.robolectric:robolectric:$robolectricVersion"
-    api 'org.mockito:mockito-core:2.23.0'
+    api libs.junit
+    api libs.robolectric
+    api libs.mockito.core
     api project(':junit-sharding')
-    api 'androidx.test:core:1.7.0'
+    api libs.androidx.test.core
 }
 
 android {

--- a/ime/base/build.gradle
+++ b/ime/base/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'com.android.library'
 apply from: "${rootDir}/gradle/android_general.gradle"
 
 dependencies {
-    api 'com.getkeepsafe.relinker:relinker:1.4.5'
+    api libs.relinker
     api project(path: ':api')
-    api 'androidx.legacy:legacy-support-v4:1.0.0'
+    api libs.androidx.legacy.support.v4
 
     testImplementation project(":ime:base-test")
 }

--- a/ime/nextword/build.gradle
+++ b/ime/nextword/build.gradle
@@ -4,7 +4,7 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 
 
 dependencies {
-    implementation 'androidx.legacy:legacy-support-core-utils:1.0.0'
+    implementation libs.androidx.legacy.support.core.utils
     implementation project(':ime:base')
     implementation project(':ime:prefs')
 

--- a/ime/permissions/build.gradle
+++ b/ime/permissions/build.gradle
@@ -4,8 +4,8 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 
 dependencies {
     implementation project(path: ':ime:base')
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    api 'pub.devrel:easypermissions:3.0.0'
+    implementation libs.androidx.appcompat
+    api libs.easypermissions
 
     testImplementation project(path: ':ime:base-test')
 }

--- a/ime/prefs/build.gradle
+++ b/ime/prefs/build.gradle
@@ -6,11 +6,11 @@ dependencies {
     implementation project(':ime:base')
     implementation project(':ime:base-rx')
 
-    implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.core:core:1.17.0'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.preference
+    implementation libs.androidx.core
+    implementation libs.androidx.appcompat
 
-    api 'com.f2prateek.rx.preferences2:rx-preferences:2.0.1'
+    api libs.rx.preferences
 
     testImplementation project(':ime:base-test')
 }

--- a/junit-sharding/build.gradle
+++ b/junit-sharding/build.gradle
@@ -4,10 +4,10 @@ apply from: "${rootDir}/gradle/jacoco.gradle"
 apply from: "${rootDir}/gradle/errorprone.gradle"
 
 dependencies {
-    implementation 'junit:junit:4.13.2'
-    implementation 'com.google.guava:guava:24.1-jre'
+    implementation libs.junit
+    implementation libs.guava
 
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation libs.mockito.core
 }
 
 java {


### PR DESCRIPTION
## Summary

Converts the Gradle build system to use Gradle's version catalog pattern (libs.versions.toml) for centralized dependency management.

## Changes

- **Created `gradle/libs.versions.toml`**: Centralized file containing all dependency versions, library declarations, and plugin definitions
- **Updated root build.gradle**: Modified buildscript classpath to reference TOML versions using `${libs.versions.*}`
- **Updated Gradle helper files**: 
  - `gradle/root_all_projects_ext.gradle`: Now uses version catalog for SDK versions and build tools
  - `gradle/errorprone.gradle`: Updated ErrorProne dependencies to use catalog references
- **Migrated 12+ module build.gradle files**: All now use `libs.*` references instead of hardcoded version strings
  - ime/app, ime/base, ime/base-rx, ime/base-test, ime/prefs, ime/addons, ime/nextword, ime/permissions
  - api, addons/base/apk, addons/gradle/pack_apk.gradle
  - junit-sharding
- **Updated buildSrc**: Added comments to indicate versions should be kept in sync with TOML file

## Benefits

- ✅ **Single source of truth**: All dependency versions centralized in one location
- ✅ **Type-safe dependency access**: Use `libs.androidx.appcompat` instead of string literals
- ✅ **Better IDE support**: Autocomplete for dependency references
- ✅ **Easier maintenance**: Update a version once, used everywhere
- ✅ **Consistency**: Ensures all modules use the same versions

## Test plan

- [x] Build progresses successfully past version catalog resolution
- [x] All version catalog references resolve correctly
- [x] No breaking changes to build configuration
- [x] Verified with `./gradlew :ime:app:assembleDebug` (fails only on unrelated Android SDK config)

## Technical Notes

- Gradle 9.2.1+ automatically loads version catalogs from `gradle/libs.versions.toml`
- Removed explicit catalog declaration from `settings.gradle` (auto-discovery is used)
- buildSrc maintains direct version declarations (it's a separate build without catalog access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>