### PR TITLE
Urdu pack: fix symbol label "Farsi Yeh" to Urdu-neutral naming

### DIFF
--- a/addons/languages/urdu/pack/src/main/res/xml/urdu_with_symbols.xml
+++ b/addons/languages/urdu/pack/src/main/res/xml/urdu_with_symbols.xml
@@ -337,7 +337,7 @@
     064A ي Yeh
     0678 ٸ High Hamza Yeh
     0626 ئ Yeh With Hamza Above
-    06CC ی Farsi Yeh
+    06CC ی Yeh (Urdu)
     06CD ۍ Yeh With Tail
     06D2 ے Yeh Barree
     06D3 ۓ Yeh Barree With Hamza Above


### PR DESCRIPTION
This PR updates a symbol label in the Urdu symbols layout, replacing the
Persian-specific name “Farsi Yeh” with an Urdu-appropriate, neutral label.

No functional or behavioral changes.