### PR TITLE
Simplify paste action in clipboard dialog

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
@@ -281,11 +281,7 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
       final CharSequence[] entries = nonEmpties.toArray(new CharSequence[0]);
       DialogInterface.OnClickListener onClickListener =
           (dialog, which) -> {
-            if (which == 0 && !mClipboard.isOsClipboardEmpty()) {
-              performPaste();
-            } else {
-              onText(key, entries[which]);
-            }
+             onText(key, entries[which]);            
           };
       showOptionsDialogWithData(
           R.string.clipboard_paste_entries_title,


### PR DESCRIPTION
Removed check for clipboard emptiness before pasting.

Fixes #3531