### PR TITLE
Please delete this PR, the correct PR is #4749.

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -619,9 +619,12 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
       case KeyCodes.ENTER:
         if (mShiftKeyState.isPressed() && ic != null) {
           // power-users feature ahead: Shift+Enter
-          // getting away from firing the default editor action, by forcing newline
+          // Send a real KeyEvent with META_SHIFT_ON so that apps (e.g. SSH clients,
+          // terminals, chat apps) can distinguish Shift+Enter from plain Enter,
+          // consistent with how Hacker's Keyboard behaves.
           abortCorrectionAndResetPredictionState(false);
-          ic.commitText("\n", 1);
+          sendKeyEvent(ic, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER, KeyEvent.META_SHIFT_ON);
+          sendKeyEvent(ic, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER, KeyEvent.META_SHIFT_ON);
           break;
         }
         final EditorInfo editorInfo = getCurrentInputEditorInfo();


### PR DESCRIPTION
## Problem
When Shift is held and Enter is pressed, the keyboard sends a plain
newline character via `commitText("\n")`. This loses the shift modifier
information, so apps cannot distinguish Shift+Enter from plain Enter.

## Solution
Send a proper KeyEvent with META_SHIFT_ON for both ACTION_DOWN and
ACTION_UP, consistent with how Hacker's Keyboard and physical keyboards
behave.

## Testing
Tested in SSH/terminal apps where Shift+Enter has a different meaning
than Enter alone.