### PR TITLE
[LLM] Migrate hardcoded dependencies to version catalog

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,19 +13,18 @@ repositories {
 }
 
 dependencies {
-    // Versions kept in sync with main project's libs.versions.toml
-    implementation 'org.jsoup:jsoup:1.22.2'
+    implementation libs.jsoup
     implementation gradleApi()
     implementation localGroovy()
 
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    implementation 'com.google.code.gson:gson:2.14.0'
-    implementation "org.jetbrains.kotlin:kotlin-reflect:2.3.21"
+    implementation libs.httpclient
+    implementation libs.gson
+    implementation libs.kotlin.reflect
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'com.nhaarman:mockito-kotlin:1.6.0'
+    testImplementation libs.junit
+    testImplementation libs.system.rules
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.kotlin
 }
 
 gradlePlugin {

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/ime/chewbacca/build.gradle
+++ b/ime/chewbacca/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'com.android.library'
 apply from: "${rootDir}/gradle/android_general.gradle"
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.10.0'
-    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.fragment:fragment:1.8.9'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.annotation
+    implementation libs.androidx.legacy.support.v13
+    implementation libs.androidx.fragment
+    implementation libs.androidx.appcompat
     implementation project(':ime:base')
     implementation project(':ime:base-rx')
     implementation project(':ime:pixel')

--- a/ime/dictionaries/build.gradle
+++ b/ime/dictionaries/build.gradle
@@ -5,7 +5,7 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 dependencies {
     implementation project(':ime:base')
     implementation project(':ime:base-rx')
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.appcompat
 
     testImplementation project(':ime:base-test')
 }

--- a/ime/dictionaries/jnidictionaryv1/build.gradle
+++ b/ime/dictionaries/jnidictionaryv1/build.gradle
@@ -15,5 +15,5 @@ android {
 dependencies {
     implementation project(':ime:dictionaries')
     implementation project(':ime:base')
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.androidx.annotation
 }

--- a/ime/dictionaries/jnidictionaryv2/build.gradle
+++ b/ime/dictionaries/jnidictionaryv2/build.gradle
@@ -15,5 +15,5 @@ android {
 dependencies {
     implementation project(':ime:dictionaries')
     implementation project(':ime:base')
-    implementation 'androidx.annotation:annotation:1.10.0'
+    implementation libs.androidx.annotation
 }

--- a/ime/fileprovider/build.gradle
+++ b/ime/fileprovider/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(':ime:base')
     implementation project(':ime:base-rx')
 
-    implementation 'androidx.core:core:1.18.0'
+    implementation libs.androidx.core
 
     testImplementation project(':ime:base-test')
 }

--- a/ime/notification/build.gradle
+++ b/ime/notification/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     implementation project(path: ':ime:base')
     implementation project(path: ':ime:permissions')
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.appcompat
 
     testImplementation project(path: ':ime:base-test')
 }

--- a/ime/pixel/build.gradle
+++ b/ime/pixel/build.gradle
@@ -5,7 +5,7 @@ apply from: "${rootDir}/gradle/android_general.gradle"
 dependencies {
     implementation project(':ime:base')
     implementation project(':ime:base-rx')
-    implementation 'androidx.preference:preference:1.2.1'
+    implementation libs.androidx.preference
 
     testImplementation project(':ime:base-test')
 }

--- a/ime/releaseinfo/build.gradle
+++ b/ime/releaseinfo/build.gradle
@@ -8,12 +8,12 @@ dependencies {
     implementation project(path: ':ime:notification')
     implementation project(path: ':ime:prefs')
     implementation project(path: ':ime:pixel')
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'androidx.recyclerview:recyclerview:1.4.0'
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.recyclerview
 
     testImplementation project(path: ':ime:base-test')
-    testImplementation 'androidx.test.ext:junit:1.3.0'
-    testImplementation 'androidx.fragment:fragment-testing:1.8.9'
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.androidx.fragment.testing
 }
 
 android {

--- a/ime/remote/build.gradle
+++ b/ime/remote/build.gradle
@@ -8,9 +8,9 @@ dependencies {
     implementation project(':ime:base-rx')
     implementation project(':ime:pixel')
     implementation project(':ime:fileprovider')
-    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
-    implementation 'androidx.fragment:fragment:1.8.9'
-    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation libs.androidx.legacy.support.v13
+    implementation libs.androidx.fragment
+    implementation libs.androidx.appcompat
 
     testImplementation project(':ime:base-test')
 }


### PR DESCRIPTION
Migrated hardcoded dependency strings in multiple build.gradle files and buildSrc/build.gradle to use the project's version catalog (libs.versions.toml). This ensures centralized dependency management and easier version updates.

### Changes
- Updated dependency declarations in 9 modules under /ime to use the `libs` catalog.
- Created `buildSrc/settings.gradle` to make the version catalog available to the `buildSrc` project.
- Migrated `buildSrc/build.gradle` dependencies to the catalog.
- Verified that all migrated versions matched the previous hardcoded versions.
- Ran `spotlessApply` and `bazel run //:format` to ensure code standards.