### PR TITLE
[LLM] Fix suggestion lifecycle and prevent auto-correction on delete (Fixes #4550, Fixes #4426)

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: AI Code Review
-        uses: menny/cassandra@v0.3.0
+        uses: menny/cassandra@v0.6.0
         with:
           reviewer_github_token: ${{ secrets.AI_CODE_REVIEW_GH_TOKEN }}
           provider_api_key: ${{ secrets.GEMINI_2_5_FLASH_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ alwaysApply: true
 
 # Lint and Format
 
+- Before making any code change, provide a concise (1-2 sentences) explanation to the user of what is being changed and why.
 - don't try to fix linting or formatting issues, we have auto-fixers for that. This is applicable for _all_ code in the codebase.
 - You can run the auto-fixers with `bazel run //:format`. This is applicable for _all_ code in the codebase.
 - for Android code, you should also run `./gradle spotlessApply`, which had additional formating and linting.
@@ -22,6 +23,7 @@ alwaysApply: true
 # Git Commit Guidelines
 
 Before creating a commit, always:
+
 1. Run formatters and linters: `bazel run //:format`. If the changed code is related to Android, also run `./gradlew spotlessApply`.
 2. Run and verify that all relevant unit tests pass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,9 @@ alwaysApply: true
 
 # Git Commit Guidelines
 
-Before creating a commit always run `bazel run //:format`.
-If the changed code is related to Android, also run `./gradle spotlessApply`.
+Before creating a commit, always:
+1. Run formatters and linters: `bazel run //:format`. If the changed code is related to Android, also run `./gradlew spotlessApply`.
+2. Run and verify that all relevant unit tests pass.
 
 ## Commit Message
 

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -1,5 +1,5 @@
 provider = "google"
-model = "gemini-3-flash-preview"
+model = "gemini-3.6-flash"
 
 supplemental-guidelines = [
     ".cassandra/code-reuse.md",

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
@@ -3,23 +3,27 @@
 This document outlines the high-level architecture, flows, and state evolution of word suggestion in AnySoftKeyboard.
 
 ## High-Level Description
+
 Suggestions in AnySoftKeyboard are provided by a combination of dictionary sources configured dynamically by the user and the keyboard environment. The `SuggestImpl` orchestrates querying these dictionaries for matching strings given the user's typed `WordComposer` (a sequence of key codes, possibly fuzzy). `SuggestionsProvider` acts as the manager of various `Dictionary` instances (like Main, User, Contacts, AutoText, and Abbreviations) and aggregates their results.
 
 ## Key Classes and Interfaces
-* [`Suggest.java`](./Suggest.java) - The core interface for components providing keyboard suggestions.
-* [`SuggestImpl.java`](./SuggestImpl.java) - The concrete implementation of `Suggest`. Handles string buffering, basic capitalizations, auto-text, abbreviations, fuzzy matching (edit distance), and splitting logic via various `Dictionary.WordCallback`s.
-* [`SuggestionsProvider.java`](./SuggestionsProvider.java) - Manages the lifecycle of multiple dictionaries (Main, User, Contacts, AutoText, etc.) and routes queries from `SuggestImpl` to the loaded dictionaries.
-* [`Dictionary.java`](../../../../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/Dictionary.java) - Abstract base class representing a searchable list of words. Defines `WordCallback`.
-* `WordComposer.java` - (Found elsewhere) Collects typed characters, key coordinates, and potential fuzzy matches to query dictionaries.
+
+- [`Suggest.java`](./Suggest.java) - The core interface for components providing keyboard suggestions.
+- [`SuggestImpl.java`](./SuggestImpl.java) - The concrete implementation of `Suggest`. Handles string buffering, basic capitalizations, auto-text, abbreviations, fuzzy matching (edit distance), and splitting logic via various `Dictionary.WordCallback`s.
+- [`SuggestionsProvider.java`](./SuggestionsProvider.java) - Manages the lifecycle of multiple dictionaries (Main, User, Contacts, AutoText, etc.) and routes queries from `SuggestImpl` to the loaded dictionaries.
+- [`Dictionary.java`](../../../../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/Dictionary.java) - Abstract base class representing a searchable list of words. Defines `WordCallback`.
+- `WordComposer.java` - (Found elsewhere) Collects typed characters, key coordinates, and potential fuzzy matches to query dictionaries.
 
 ## Flows
 
 ### 1. Dictionary Initialization Flow
+
 1. The keyboard/service initializes `SuggestionsProvider`.
 2. `SuggestionsProvider` sets up dictionaries using `setupSuggestionsForKeyboard(...)`, receiving a list of `DictionaryAddOnAndBuilder` instances based on user settings (e.g., active languages).
 3. Main dictionaries, User dictionaries (based on locale), Contacts dictionary (if permitted), and AutoText/Abbreviations are instantiated and loaded asynchronously using `DictionaryBackgroundLoader`.
 
 ### 2. Suggestion Generation Flow (`getSuggestions`)
+
 1. User types characters -> Keyboard updates `WordComposer`.
 2. Keyboard calls `Suggest.getSuggestions(WordComposer)`.
 3. `SuggestImpl` prepares the internal `mSuggestions` list and calls `SuggestionsProvider.getSuggestions(...)`, `SuggestionsProvider.getAbbreviations(...)`, and `SuggestionsProvider.getAutoText(...)`.
@@ -30,6 +34,7 @@ Suggestions in AnySoftKeyboard are provided by a combination of dictionary sourc
 8. The sorted `mSuggestions` is returned to the keyboard to render in the suggestion strip.
 
 ### 3. Next Word Prediction Flow (`getNextSuggestions`)
+
 1. Keyboard identifies a typed word has finished.
 2. Keyboard calls `Suggest.getNextSuggestions(previousWord, inAllUpperCaseState)`.
 3. `SuggestImpl` delegates to `SuggestionsProvider.getNextWords(...)`.
@@ -39,17 +44,36 @@ Suggestions in AnySoftKeyboard are provided by a combination of dictionary sourc
 ## State Definition and Evolution
 
 ### `SuggestImpl` State
-* **mSuggestions / mNextSuggestions**: The output lists representing the current UI state to display. They are reset/cleared each time `getSuggestions` is called.
-* **mStringPool**: Used to minimize allocations when generating strings for suggestions.
-* **Capitalization State (`mIsFirstCharCapitalized`, `mIsAllUpperCase`)**: Set during `getSuggestions` based on `WordComposer.isFirstCharCapitalized()` and `WordComposer.isAllUpperCase()`. This state is used in the `WordCallback` to format dictionary words appropriately before insertion into the suggestion list.
-* **mCorrectSuggestionIndex**: Tracks which suggestion in `mSuggestions` is considered the primary correction/fix for the typed word.
+
+- **mSuggestions / mNextSuggestions**: The output lists representing the current UI state to display. They are reset/cleared each time `getSuggestions` is called.
+- **mStringPool**: Used to minimize allocations when generating strings for suggestions.
+- **Capitalization State (`mIsFirstCharCapitalized`, `mIsAllUpperCase`)**: Set during `getSuggestions` based on `WordComposer.isFirstCharCapitalized()` and `WordComposer.isAllUpperCase()`. This state is used in the `WordCallback` to format dictionary words appropriately before insertion into the suggestion list.
+- **mCorrectSuggestionIndex**: Tracks which suggestion in `mSuggestions` is considered the primary correction/fix for the typed word.
 
 ### Configuration and Environment Flags
+
 The suggestions flow is highly impacted by user configurations (`SharedPreferences`):
-* `mPrefMaxSuggestions`: Maximum number of suggestions to generate (configurable).
-* `mEnabledSuggestions`: Toggles dictionary corrections globally.
-* `mIncognitoMode`: If true, stops adding words to User Dictionary and stops tracking Next-Word patterns.
-* `mCommonalityMaxLengthDiff` & `mCommonalityMaxDistance`: Toggles strictness of fuzzy matching.
-* `mContactsDictionaryEnabled`: Flag allowing/denying access to Android Contacts for suggestions.
-* `mNextWordEnabled`: Enables/disables predicting the next word based on context.
-* `mQuickFixesEnabled`: Toggles auto-text replacements and abbreviations.
+
+- `mPrefMaxSuggestions`: Maximum number of suggestions to generate (configurable).
+- `mEnabledSuggestions`: Toggles dictionary corrections globally.
+- `mIncognitoMode`: If true, stops adding words to User Dictionary and stops tracking Next-Word patterns.
+- `mCommonalityMaxLengthDiff` & `mCommonalityMaxDistance`: Toggles strictness of fuzzy matching.
+- `mContactsDictionaryEnabled`: Flag allowing/denying access to Android Contacts for suggestions.
+- `mNextWordEnabled`: Enables/disables predicting the next word based on context.
+- `mQuickFixesEnabled`: Toggles auto-text replacements and abbreviations.
+
+### Environment, IME Callbacks, and EditorInfo Flags
+
+The suggestion flows are deeply integrated with Android's `InputMethodService` lifecycle callbacks (managed in `AnySoftKeyboardSuggestions.java`).
+
+- **`onStartInputView`**: This is the primary entry point for determining if suggestions should be active for a given input field. It inspects the `EditorInfo` passed by the OS.
+  - It initializes the default state (`mPredictionOn = true`).
+  - If `EditorInfo.inputType` dictates a non-text field (e.g., `TYPE_CLASS_DATETIME`, `TYPE_CLASS_NUMBER`, `TYPE_CLASS_PHONE`), `mPredictionOn` is forcibly set to `false`.
+  - For text fields (`TYPE_CLASS_TEXT`), it checks specific variations:
+    - `TYPE_TEXT_VARIATION_PASSWORD`, `TYPE_TEXT_VARIATION_VISIBLE_PASSWORD`, and `TYPE_TEXT_VARIATION_WEB_PASSWORD` will disable prediction.
+    - `TYPE_TEXT_VARIATION_EMAIL_ADDRESS` and `TYPE_TEXT_VARIATION_URI` disable auto-picking and auto-spacing but may keep predictions on depending on other flags.
+  - Explicit developer overrides like `IMEUtil.shouldHonorNoSuggestionsFlag(textFlag)` (which checks for `NO_SUGGESTIONS` or `TYPE_TEXT_FLAG_NO_SUGGESTIONS`) will also set `mPredictionOn = false`.
+- **`onUpdateSelection`**: This callback tracks the user's cursor position.
+  - If the user manually moves the cursor inside a currently predicted word, the `WordComposer`'s internal cursor position is updated without destroying the state.
+  - If the cursor is moved outside the currently predicted word ("no man's land"), the correction state is aborted (`abortCorrectionAndResetPredictionState`) and suggestions are restarted for the new context.
+- **Global Overrides**: Finally, `mPredictionOn` is AND'ed with the user preference `mShowSuggestions`. Even if the field supports suggestions, they won't show if the user disabled them globally.

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
@@ -86,3 +86,10 @@ Configuration changes dynamically impact the suggestion engine via RxJava observ
   - `mShowSuggestions` is bound to the `settings_key_show_suggestions` preference, but it can be immediately disabled if the system enters `PowerSaving` mode. If this value toggles, dictionaries are either initialized (`setDictionariesForCurrentKeyboard()`) or shut down (`closeDictionaries()`).
   - `auto_pick_suggestion_aggressiveness`: This user preference calculates `mAutoComplete` and explicitly updates the fuzzy matching tolerance by calculating and passing `commonalityMaxLengthDiff` and `commonalityMaxDistance` directly to `mSuggest.setCorrectionMode(...)`.
   - `settings_key_try_splitting_words_for_correction`: Also passed down to `setCorrectionMode`, enabling or disabling sub-word splitting logic on the fly.
+
+### PowerSaving Mode and Gesture Typing Impacts
+
+Additional system-level states like `PowerSaving` also intersect with word predictions, particularly through gesture typing mechanisms in `AnySoftKeyboardWithGestureTyping.java`.
+
+- **PowerSaving mode**: When the `settings_key_power_save_mode_gesture_control` is active, another `Observable.combineLatest` reactive stream will intercept the `settings_key_gesture_typing` preference and forcibly set `mGestureTypingEnabled = false`.
+- **Gesture Dictionary Bypassing**: When gesture typing is disabled, the system bypasses `WordListDictionaryListener` (which acts as a `DictionaryBackgroundLoader.Listener`). This prevents the `GestureTypingDetector` from parsing the dictionary arrays (`char[][]` paths) to correlate screen swipes with specific dictionary words.

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
@@ -77,3 +77,12 @@ The suggestion flows are deeply integrated with Android's `InputMethodService` l
   - If the user manually moves the cursor inside a currently predicted word, the `WordComposer`'s internal cursor position is updated without destroying the state.
   - If the cursor is moved outside the currently predicted word ("no man's land"), the correction state is aborted (`abortCorrectionAndResetPredictionState`) and suggestions are restarted for the new context.
 - **Global Overrides**: Finally, `mPredictionOn` is AND'ed with the user preference `mShowSuggestions`. Even if the field supports suggestions, they won't show if the user disabled them globally.
+
+### Reactive Preferences and Dynamic State Evolution
+
+Configuration changes dynamically impact the suggestion engine via RxJava observers.
+
+- **`Observable.combineLatest`**: In `AnySoftKeyboardSuggestions`, multiple reactive streams (shared preferences) are combined to evaluate global conditions:
+  - `mShowSuggestions` is bound to the `settings_key_show_suggestions` preference, but it can be immediately disabled if the system enters `PowerSaving` mode. If this value toggles, dictionaries are either initialized (`setDictionariesForCurrentKeyboard()`) or shut down (`closeDictionaries()`).
+  - `auto_pick_suggestion_aggressiveness`: This user preference calculates `mAutoComplete` and explicitly updates the fuzzy matching tolerance by calculating and passing `commonalityMaxLengthDiff` and `commonalityMaxDistance` directly to `mSuggest.setCorrectionMode(...)`.
+  - `settings_key_try_splitting_words_for_correction`: Also passed down to `setCorrectionMode`, enabling or disabling sub-word splitting logic on the fly.

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGEATIONS.md
@@ -1,0 +1,55 @@
+# AnySoftKeyboard Suggestions Flow
+
+This document outlines the high-level architecture, flows, and state evolution of word suggestion in AnySoftKeyboard.
+
+## High-Level Description
+Suggestions in AnySoftKeyboard are provided by a combination of dictionary sources configured dynamically by the user and the keyboard environment. The `SuggestImpl` orchestrates querying these dictionaries for matching strings given the user's typed `WordComposer` (a sequence of key codes, possibly fuzzy). `SuggestionsProvider` acts as the manager of various `Dictionary` instances (like Main, User, Contacts, AutoText, and Abbreviations) and aggregates their results.
+
+## Key Classes and Interfaces
+* [`Suggest.java`](./Suggest.java) - The core interface for components providing keyboard suggestions.
+* [`SuggestImpl.java`](./SuggestImpl.java) - The concrete implementation of `Suggest`. Handles string buffering, basic capitalizations, auto-text, abbreviations, fuzzy matching (edit distance), and splitting logic via various `Dictionary.WordCallback`s.
+* [`SuggestionsProvider.java`](./SuggestionsProvider.java) - Manages the lifecycle of multiple dictionaries (Main, User, Contacts, AutoText, etc.) and routes queries from `SuggestImpl` to the loaded dictionaries.
+* [`Dictionary.java`](../../../../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/Dictionary.java) - Abstract base class representing a searchable list of words. Defines `WordCallback`.
+* `WordComposer.java` - (Found elsewhere) Collects typed characters, key coordinates, and potential fuzzy matches to query dictionaries.
+
+## Flows
+
+### 1. Dictionary Initialization Flow
+1. The keyboard/service initializes `SuggestionsProvider`.
+2. `SuggestionsProvider` sets up dictionaries using `setupSuggestionsForKeyboard(...)`, receiving a list of `DictionaryAddOnAndBuilder` instances based on user settings (e.g., active languages).
+3. Main dictionaries, User dictionaries (based on locale), Contacts dictionary (if permitted), and AutoText/Abbreviations are instantiated and loaded asynchronously using `DictionaryBackgroundLoader`.
+
+### 2. Suggestion Generation Flow (`getSuggestions`)
+1. User types characters -> Keyboard updates `WordComposer`.
+2. Keyboard calls `Suggest.getSuggestions(WordComposer)`.
+3. `SuggestImpl` prepares the internal `mSuggestions` list and calls `SuggestionsProvider.getSuggestions(...)`, `SuggestionsProvider.getAbbreviations(...)`, and `SuggestionsProvider.getAutoText(...)`.
+4. `SuggestionsProvider` routes the `WordComposer` to each active `Dictionary` (Contacts, User, Main, etc.).
+5. Each `Dictionary` compares `WordComposer` combinations with its tree/words.
+6. For each matched word, the `Dictionary` invokes a specific `Dictionary.WordCallback` (implemented internally by `SuggestImpl` like `SuggestionCallback`, `DictionarySuggestionCallback`, `AutoTextSuggestionCallback`, etc.).
+7. `SuggestImpl`'s callback evaluates the frequency, applies bonuses for capitalizations or exact matches, checks `IMEUtil.editDistance`, and decides whether to insert it into `mSuggestions` (limited to `mPrefMaxSuggestions`).
+8. The sorted `mSuggestions` is returned to the keyboard to render in the suggestion strip.
+
+### 3. Next Word Prediction Flow (`getNextSuggestions`)
+1. Keyboard identifies a typed word has finished.
+2. Keyboard calls `Suggest.getNextSuggestions(previousWord, inAllUpperCaseState)`.
+3. `SuggestImpl` delegates to `SuggestionsProvider.getNextWords(...)`.
+4. `SuggestionsProvider` queries `NextWordSuggestions` dictionaries (User, Contacts).
+5. Output is bounded by `mMaxNextWordSuggestionsCount` and sorted by word usage (`mMinWordUsage`).
+
+## State Definition and Evolution
+
+### `SuggestImpl` State
+* **mSuggestions / mNextSuggestions**: The output lists representing the current UI state to display. They are reset/cleared each time `getSuggestions` is called.
+* **mStringPool**: Used to minimize allocations when generating strings for suggestions.
+* **Capitalization State (`mIsFirstCharCapitalized`, `mIsAllUpperCase`)**: Set during `getSuggestions` based on `WordComposer.isFirstCharCapitalized()` and `WordComposer.isAllUpperCase()`. This state is used in the `WordCallback` to format dictionary words appropriately before insertion into the suggestion list.
+* **mCorrectSuggestionIndex**: Tracks which suggestion in `mSuggestions` is considered the primary correction/fix for the typed word.
+
+### Configuration and Environment Flags
+The suggestions flow is highly impacted by user configurations (`SharedPreferences`):
+* `mPrefMaxSuggestions`: Maximum number of suggestions to generate (configurable).
+* `mEnabledSuggestions`: Toggles dictionary corrections globally.
+* `mIncognitoMode`: If true, stops adding words to User Dictionary and stops tracking Next-Word patterns.
+* `mCommonalityMaxLengthDiff` & `mCommonalityMaxDistance`: Toggles strictness of fuzzy matching.
+* `mContactsDictionaryEnabled`: Flag allowing/denying access to Android Contacts for suggestions.
+* `mNextWordEnabled`: Enables/disables predicting the next word based on context.
+* `mQuickFixesEnabled`: Toggles auto-text replacements and abbreviations.

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGESTIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGESTIONS.md
@@ -11,8 +11,8 @@ Suggestions in AnySoftKeyboard are provided by a combination of dictionary sourc
 - [`Suggest.java`](./Suggest.java) - The core interface for components providing keyboard suggestions.
 - [`SuggestImpl.java`](./SuggestImpl.java) - The concrete implementation of `Suggest`. Handles string buffering, basic capitalizations, auto-text, abbreviations, fuzzy matching (edit distance), and splitting logic via various `Dictionary.WordCallback`s.
 - [`SuggestionsProvider.java`](./SuggestionsProvider.java) - Manages the lifecycle of multiple dictionaries (Main, User, Contacts, AutoText, etc.) and routes queries from `SuggestImpl` to the loaded dictionaries.
-- [`Dictionary.java`](../../../../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/Dictionary.java) - Abstract base class representing a searchable list of words. Defines `WordCallback`.
-- `WordComposer.java` - (Found elsewhere) Collects typed characters, key coordinates, and potential fuzzy matches to query dictionaries.
+- [`Dictionary.java`](../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/Dictionary.java) - Abstract base class representing a searchable list of words. Defines `WordCallback`.
+- [`WordComposer.java`](../../../../../../dictionaries/src/main/java/com/anysoftkeyboard/dictionaries/WordComposer.java) - Collects typed characters, key coordinates, and potential fuzzy matches to query dictionaries.
 
 ## Flows
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGESTIONS.md
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/SUGGESTIONS.md
@@ -21,6 +21,7 @@ Suggestions in AnySoftKeyboard are provided by a combination of dictionary sourc
 1. The keyboard/service initializes `SuggestionsProvider`.
 2. `SuggestionsProvider` sets up dictionaries using `setupSuggestionsForKeyboard(...)`, receiving a list of `DictionaryAddOnAndBuilder` instances based on user settings (e.g., active languages).
 3. Main dictionaries, User dictionaries (based on locale), Contacts dictionary (if permitted), and AutoText/Abbreviations are instantiated and loaded asynchronously using `DictionaryBackgroundLoader`.
+4. `DictionaryBackgroundLoader.Listener` receives lifecycle callbacks (`onDictionaryLoadingStarted`, `onDictionaryLoadingDone`, `onDictionaryLoadingFailed`). If loading fails (e.g., Contacts permission revoked), the provider falls back to `NullDictionary`.
 
 ### 2. Suggestion Generation Flow (`getSuggestions`)
 
@@ -64,7 +65,7 @@ The suggestions flow is highly impacted by user configurations (`SharedPreferenc
 
 ### Environment, IME Callbacks, and EditorInfo Flags
 
-The suggestion flows are deeply integrated with Android's `InputMethodService` lifecycle callbacks (managed in `AnySoftKeyboardSuggestions.java`).
+The suggestion flows are deeply integrated with Android's `InputMethodService` lifecycle callbacks (managed in `AnySoftKeyboardSuggestions.java` and `AnySoftKeyboardIncognito.java`).
 
 - **`onStartInputView`**: This is the primary entry point for determining if suggestions should be active for a given input field. It inspects the `EditorInfo` passed by the OS.
   - It initializes the default state (`mPredictionOn = true`).
@@ -73,19 +74,33 @@ The suggestion flows are deeply integrated with Android's `InputMethodService` l
     - `TYPE_TEXT_VARIATION_PASSWORD`, `TYPE_TEXT_VARIATION_VISIBLE_PASSWORD`, and `TYPE_TEXT_VARIATION_WEB_PASSWORD` will disable prediction.
     - `TYPE_TEXT_VARIATION_EMAIL_ADDRESS` and `TYPE_TEXT_VARIATION_URI` disable auto-picking and auto-spacing but may keep predictions on depending on other flags.
   - Explicit developer overrides like `IMEUtil.shouldHonorNoSuggestionsFlag(textFlag)` (which checks for `NO_SUGGESTIONS` or `TYPE_TEXT_FLAG_NO_SUGGESTIONS`) will also set `mPredictionOn = false`.
+  - **Incognito OS Triggers**: In `AnySoftKeyboardIncognito.java`, `onStartInputView` evaluates `EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING` or password field types and automatically engages incognito mode (`setIncognitoMode(true)`), halting dictionary learning and next-word tracking.
 - **`onUpdateSelection`**: This callback tracks the user's cursor position.
   - If the user manually moves the cursor inside a currently predicted word, the `WordComposer`'s internal cursor position is updated without destroying the state.
-  - If the cursor is moved outside the currently predicted word ("no man's land"), the correction state is aborted (`abortCorrectionAndResetPredictionState`) and suggestions are restarted for the new context.
+  - If the cursor is moved outside the currently predicted word ("no man's land"), the correction state is aborted (`abortCorrectionAndResetPredictionState`) and suggestions are restarted for the new context (governed by the `settings_key_allow_suggestions_restart` preference).
 - **Global Overrides**: Finally, `mPredictionOn` is AND'ed with the user preference `mShowSuggestions`. Even if the field supports suggestions, they won't show if the user disabled them globally.
 
 ### Reactive Preferences and Dynamic State Evolution
 
 Configuration changes dynamically impact the suggestion engine via RxJava observers.
 
-- **`Observable.combineLatest`**: In `AnySoftKeyboardSuggestions`, multiple reactive streams (shared preferences) are combined to evaluate global conditions:
-  - `mShowSuggestions` is bound to the `settings_key_show_suggestions` preference, but it can be immediately disabled if the system enters `PowerSaving` mode. If this value toggles, dictionaries are either initialized (`setDictionariesForCurrentKeyboard()`) or shut down (`closeDictionaries()`).
-  - `auto_pick_suggestion_aggressiveness`: This user preference calculates `mAutoComplete` and explicitly updates the fuzzy matching tolerance by calculating and passing `commonalityMaxLengthDiff` and `commonalityMaxDistance` directly to `mSuggest.setCorrectionMode(...)`.
-  - `settings_key_try_splitting_words_for_correction`: Also passed down to `setCorrectionMode`, enabling or disabling sub-word splitting logic on the fly.
+#### `AnySoftKeyboardSuggestions` Rx Streams
+
+- **`Observable.combineLatest`**: Combines multiple reactive preference streams to evaluate global conditions on the fly:
+  - `mShowSuggestions`: Bound to `settings_key_show_suggestions`, but forcibly disabled if `PowerSaving.observePowerSavingState` indicates low-power mode. Toggling this value initializes (`setDictionariesForCurrentKeyboard()`) or closes (`closeDictionaries()`) dictionaries.
+  - `settings_key_auto_pick_suggestion_aggressiveness`: Calculates `mAutoComplete` and dynamically updates fuzzy matching parameters (`commonalityMaxLengthDiff`, `commonalityMaxDistance`) passed to `mSuggest.setCorrectionMode(...)`.
+  - `settings_key_try_splitting_words_for_correction`: Enables/disables sub-word splitting logic dynamically via `setCorrectionMode`.
+  - `settings_key_allow_suggestions_restart`: Updates `mAllowSuggestionsRestart` controlling whether suggestions auto-restart when moving the cursor.
+
+#### `SuggestionsProvider` Rx Streams (`mPrefsDisposables`)
+
+`SuggestionsProvider` manages its own internal Rx preference subscriptions to dynamically adjust dictionary state:
+
+- **`settings_key_quick_fix` & `settings_key_quick_fix_second_disabled`**: Reactively update `mQuickFixesEnabled` and `mQuickFixesSecondDisabled` while invalidating dictionary setup hash (`mCurrentSetupHashCode = 0`).
+- **`settings_key_use_contacts_dictionary`**: Reactively updates `mContactsDictionaryEnabled`. Disabling closes `mContactsDictionary` immediately and replaces it with `NullDictionary`.
+- **`settings_key_use_user_dictionary`**: Reactively updates `mUserDictionaryEnabled`.
+- **`settings_key_next_word_suggestion_aggressiveness`**: Reactively recalculates `mMaxNextWordSuggestionsCount` (3, 5, or 8) and `mMinWordUsage` (5, 3, or 1).
+- **`settings_key_next_word_dictionary_type`**: Reactively updates `mNextWordEnabled` and `mAlsoSuggestNextPunctuations` ("off", "words_punctuations", "word").
 
 ### PowerSaving Mode and Gesture Typing Impacts
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSwitchedListener.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardSwitchedListener.java
@@ -186,6 +186,8 @@ public abstract class AnySoftKeyboardKeyboardSwitchedListener extends AnySoftKey
 
   @Override
   protected void onSharedPreferenceChange(String key) {
+    // null/empty key is received when SharedPreferences is cleared
+    if (TextUtils.isEmpty(key)) return;
     if (key.startsWith(Keyboard.PREF_KEY_ROW_MODE_ENABLED_PREFIX)) {
       mKeyboardSwitcher.flushKeyboardsCache();
     } else {

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardTagsSearcher.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardTagsSearcher.java
@@ -55,6 +55,8 @@ public abstract class AnySoftKeyboardKeyboardTagsSearcher extends AnySoftKeyboar
   private SharedPreferences mSharedPrefsNotToUse;
   private final SharedPreferences.OnSharedPreferenceChangeListener mUpdatedPrefKeysListener =
       (sharedPreferences, key) -> {
+        // null/empty key is received when SharedPreferences is cleared
+        if (TextUtils.isEmpty(key)) return;
         if (key.startsWith(QuickTextKeyFactory.PREF_ID_PREFIX) && mTagsExtractor.isEnabled()) {
           // forcing reload
           setupTagsSearcher();

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardTagsSearcher.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardKeyboardTagsSearcher.java
@@ -19,6 +19,7 @@ package com.anysoftkeyboard.ime;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.XmlResourceParser;
+import android.text.TextUtils;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardRxPrefs.java
@@ -1,6 +1,7 @@
 package com.anysoftkeyboard.ime;
 
 import android.content.SharedPreferences;
+import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import com.anysoftkeyboard.keyboardextensions.KeyboardExtensionFactory;
 import com.anysoftkeyboard.keyboards.KeyboardFactory;
@@ -142,6 +143,8 @@ public abstract class AnySoftKeyboardRxPrefs extends AnySoftKeyboardDialogProvid
   }
 
   protected void onSharedPreferenceChange(String key) {
+    // null/empty key is received when SharedPreferences is cleared
+    if (TextUtils.isEmpty(key)) return;
     if (key.equals(getString(R.string.settings_key_zoom_percent_in_portrait))
         || key.equals(getString(R.string.settings_key_zoom_percent_in_landscape))
         || key.equals(getString(R.string.settings_key_smiley_icon_on_smileys_key))

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -224,8 +224,11 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                       setDictionariesForCurrentKeyboard();
                     } else {
                       closeDictionaries();
-                      clearSuggestions();
-                      abortCorrectionAndResetPredictionState(false);
+                      // Only abort correction if the user is currently typing/predicting
+                      // to avoid clearing suggestions mock state/interactions prematurely.
+                      if (isCurrentlyPredicting()) {
+                        abortCorrectionAndResetPredictionState(false);
+                      }
                     }
                   }
                 },
@@ -691,7 +694,9 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
       }
       // Picked the suggestion by a space/punctuation character: we will treat it
       // as "added an auto space".
-      mWordRevertLength = wordToOutput.length() + 1;
+      if (mAutoComplete) {
+        mWordRevertLength = wordToOutput.length() + 1;
+      }
     } else if (separatorInsideWord) {
       // when putting a separator in the middle of a word, there is no
       // need to do correction, or keep knowledge

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -224,6 +224,8 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
                       setDictionariesForCurrentKeyboard();
                     } else {
                       closeDictionaries();
+                      clearSuggestions();
+                      abortCorrectionAndResetPredictionState(false);
                     }
                   }
                 },
@@ -963,11 +965,13 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
     final InputViewBinder inputView = getInputView();
     if (!isPredictionOn()
         || !mAllowSuggestionsRestart
+        || !mAutoComplete
         || inputView == null
         || !inputView.isShown()) {
       // Conditions checked:
       // - isPredictionOn(): Global prediction must be enabled for the current input field
       // - mAllowSuggestionsRestart: User setting to enable/disable suggestion restart
+      // - mAutoComplete: Auto-correct / word correction must be enabled
       // - inputView visibility: Input view must be shown
       //
       // Note: We don't check isCurrentlyPredicting() here because this method is called
@@ -976,9 +980,10 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
       Logger.d(
           TAG,
           "performRestartWordSuggestion: no need to restart: isPredictionOn=%s,"
-              + " mAllowSuggestionsRestart=%s",
+              + " mAllowSuggestionsRestart=%s, mAutoComplete=%s",
           isPredictionOn(),
-          mAllowSuggestionsRestart);
+          mAllowSuggestionsRestart,
+          mAutoComplete);
       return false;
     } else if (!isCursorTouchingWord()) {
       Logger.d(TAG, "User moved cursor to no-man land. Bye bye.");
@@ -995,6 +1000,10 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
   protected void setSuggestions(
       @NonNull List<? extends CharSequence> suggestions, int highlightedSuggestionIndex) {
+    if (!mShowSuggestions || !isPredictionOn()) {
+      suggestions = Collections.emptyList();
+      highlightedSuggestionIndex = -1;
+    }
     mCancelSuggestionsAction.setCancelIconVisible(!suggestions.isEmpty());
     if (mCandidateView != null) {
       mCandidateView.setSuggestions(suggestions, highlightedSuggestionIndex);

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -538,8 +538,10 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
   private void postRestartWordSuggestion() {
     mKeyboardHandler.removeMessages(KeyboardUIStateHandler.MSG_UPDATE_SUGGESTIONS);
     mKeyboardHandler.removeMessages(KeyboardUIStateHandler.MSG_RESTART_NEW_WORD_SUGGESTIONS);
-    mKeyboardHandler.sendEmptyMessageDelayed(
-        KeyboardUIStateHandler.MSG_RESTART_NEW_WORD_SUGGESTIONS, 10 * ONE_FRAME_DELAY);
+    if (canRestartWordSuggestion()) {
+      mKeyboardHandler.sendEmptyMessageDelayed(
+          KeyboardUIStateHandler.MSG_RESTART_NEW_WORD_SUGGESTIONS, 10 * ONE_FRAME_DELAY);
+    }
   }
 
   @Override

--- a/ime/app/src/main/java/com/anysoftkeyboard/theme/KeyboardThemeFactory.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/theme/KeyboardThemeFactory.java
@@ -127,7 +127,8 @@ public class KeyboardThemeFactory extends AddOnsFactory.SingleAddOnsFactory<Keyb
               emitter.setCancellable(() -> sp.unregisterOnSharedPreferenceChangeListener(listener));
               sp.registerOnSharedPreferenceChangeListener(listener);
             })
-        .filter(key -> key.startsWith(KeyboardThemeFactory.PREF_ID_PREFIX))
+        .filter(
+            key -> !TextUtils.isEmpty(key) && key.startsWith(KeyboardThemeFactory.PREF_ID_PREFIX))
         .map(key -> factory.getEnabledAddOn())
         .startWith(factory.getEnabledAddOn())
         .distinctUntilChanged();

--- a/ime/app/src/main/java/com/anysoftkeyboard/theme/KeyboardThemeFactory.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/theme/KeyboardThemeFactory.java
@@ -18,6 +18,7 @@ package com.anysoftkeyboard.theme;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import androidx.annotation.NonNull;
 import com.anysoftkeyboard.addons.AddOn;

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardBaseTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardBaseTest.java
@@ -11,6 +11,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethod;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
+import androidx.preference.PreferenceManager;
 import com.anysoftkeyboard.keyboards.AnyKeyboard;
 import com.anysoftkeyboard.keyboards.views.CandidateView;
 import com.anysoftkeyboard.rx.TestRxSchedulers;
@@ -99,7 +100,9 @@ public abstract class AnySoftKeyboardBaseTest {
   }
 
   @After
-  public void tearDownForAnySoftKeyboardBase() throws Exception {}
+  public void tearDownForAnySoftKeyboardBase() throws Exception {
+    PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().clear().commit();
+  }
 
   protected final InputMethodManagerShadow getShadowInputMethodManager() {
     return mInputMethodManagerShadow;

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardPowerSavingTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardPowerSavingTest.java
@@ -13,6 +13,7 @@ import com.anysoftkeyboard.overlay.OverlyDataCreator;
 import com.anysoftkeyboard.test.SharedPrefsHelper;
 import com.anysoftkeyboard.ui.settings.MainSettingsActivity;
 import com.menny.android.anysoftkeyboard.R;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,6 +21,11 @@ import org.mockito.Mockito;
 
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
 public class AnySoftKeyboardPowerSavingTest extends AnySoftKeyboardBaseTest {
+
+  @After
+  public void tearDownPowerSaving() {
+    PowerSavingTest.sendBatteryState(true);
+  }
 
   @Test
   public void testDoesNotAskForSuggestionsIfInLowBattery() {

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
@@ -912,4 +912,47 @@ public class AnySoftKeyboardSuggestionsTest extends AnySoftKeyboardBaseTest {
         "Should be predicting when typing", mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
     verifySuggestions(true, "hell", "hello");
   }
+
+  @Test
+  public void testSuggestionsDisabledOnStartInputView() {
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, false);
+    simulateFinishInputFlow();
+
+    final EditorInfo editorInfo =
+        createEditorInfo(EditorInfo.IME_ACTION_NONE, EditorInfo.TYPE_CLASS_TEXT);
+    simulateOnStartInputFlow(false, editorInfo);
+
+    Assert.assertFalse(
+        "Prediction should be off when show suggestions preference is false",
+        mAnySoftKeyboardUnderTest.isPredictionOn());
+
+    mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+
+    Assert.assertFalse(
+        "Should not be predicting when show suggestions preference is false",
+        mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
+    verifySuggestions(false);
+  }
+
+  @Test
+  public void testNoAutoCorrectionOnDeleteWhenWordCorrectionOff() {
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, true);
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
+
+    simulateFinishInputFlow();
+    final EditorInfo editorInfo =
+        createEditorInfo(EditorInfo.IME_ACTION_NONE, EditorInfo.TYPE_CLASS_TEXT);
+    simulateOnStartInputFlow(false, editorInfo);
+
+    mAnySoftKeyboardUnderTest.simulateTextTyping("hello ");
+    Assert.assertEquals(
+        "hello ", getCurrentTestInputConnection().getCurrentTextInInputConnection());
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+    TestRxSchedulers.drainAllTasks();
+
+    Assert.assertEquals("hello", getCurrentTestInputConnection().getCurrentTextInInputConnection());
+  }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
@@ -914,45 +914,35 @@ public class AnySoftKeyboardSuggestionsTest extends AnySoftKeyboardBaseTest {
   }
 
   @Test
-  public void testSuggestionsDisabledOnStartInputView() {
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, false);
+  public void testCandidateStripClearedWhenSuggestionsDisabledDynamically() {
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
     simulateFinishInputFlow();
+    simulateOnStartInputFlow();
 
-    final EditorInfo editorInfo =
-        createEditorInfo(EditorInfo.IME_ACTION_NONE, EditorInfo.TYPE_CLASS_TEXT);
-    simulateOnStartInputFlow(false, editorInfo);
+    mAnySoftKeyboardUnderTest.simulateTextTyping("hell");
+    verifySuggestions(true, "hell", "hello");
 
-    Assert.assertFalse(
-        "Prediction should be off when show suggestions preference is false",
-        mAnySoftKeyboardUnderTest.isPredictionOn());
+    // Dynamically disable suggestions while active
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, false);
+    TestRxSchedulers.drainAllTasks();
 
-    mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
-
-    Assert.assertFalse(
-        "Should not be predicting when show suggestions preference is false",
-        mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
+    // Bug: mCandidateView is not cleared/hidden when settings_key_show_suggestions toggles to false
     verifySuggestions(false);
   }
 
   @Test
-  public void testNoAutoCorrectionOnDeleteWhenWordCorrectionOff() {
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, true);
-    SharedPrefsHelper.setPrefsValue(
-        R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
-
+  public void testNextWordSuggestionsNotShownWhenShowSuggestionsIsFalse() {
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, false);
     simulateFinishInputFlow();
-    final EditorInfo editorInfo =
-        createEditorInfo(EditorInfo.IME_ACTION_NONE, EditorInfo.TYPE_CLASS_TEXT);
-    simulateOnStartInputFlow(false, editorInfo);
+    simulateOnStartInputFlow();
 
+    // Type a word and space
     mAnySoftKeyboardUnderTest.simulateTextTyping("hello ");
-    Assert.assertEquals(
-        "hello ", getCurrentTestInputConnection().getCurrentTextInInputConnection());
-
-    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
     TestRxSchedulers.drainAllTasks();
 
-    Assert.assertEquals("hello", getCurrentTestInputConnection().getCurrentTextInInputConnection());
+    // Bug: setSuggestions(mSuggest.getNextSuggestions(...)) is called unconditionally in
+    // commitWordToInput
+    // rendering next words/punctuations to CandidateView even when show_suggestions is false
+    verifySuggestions(false);
   }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
@@ -945,4 +945,28 @@ public class AnySoftKeyboardSuggestionsTest extends AnySoftKeyboardBaseTest {
     // rendering next words/punctuations to CandidateView even when show_suggestions is false
     verifySuggestions(false);
   }
+
+  @Test
+  public void testSuggestionsRestartNotAllowedWhenAutoCorrectIsOff() {
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, true);
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
+
+    simulateFinishInputFlow();
+    simulateOnStartInputFlow();
+
+    mAnySoftKeyboardUnderTest.simulateTextTyping("hello ");
+    Assert.assertFalse(mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
+
+    // Press delete after space
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
+    TestRxSchedulers.drainAllTasks();
+
+    // Bug: canRestartWordSuggestion() returns true even when auto-correct aggressiveness is "none",
+    // restarting word prediction and setting a composing region on delete.
+    Assert.assertFalse(
+        "Should not restart word prediction on delete when auto-correct is OFF",
+        mAnySoftKeyboardUnderTest.isCurrentlyPredicting());
+  }
 }

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestionsTest.java
@@ -651,7 +651,7 @@ public class AnySoftKeyboardSuggestionsTest extends AnySoftKeyboardBaseTest {
     mAnySoftKeyboardUnderTest.simulateKeyPress('r');
     Assert.assertEquals(
         "herll yes", getCurrentTestInputConnection().getCurrentTextInInputConnection());
-    verifySuggestions(true);
+    verifySuggestions(true, "r");
     Assert.assertEquals(3, getCurrentTestInputConnection().getCurrentStartPosition());
     Assert.assertEquals(
         "r", mAnySoftKeyboardUnderTest.getCurrentComposedWord().getTypedWord().toString());
@@ -952,6 +952,7 @@ public class AnySoftKeyboardSuggestionsTest extends AnySoftKeyboardBaseTest {
     SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, true);
     SharedPrefsHelper.setPrefsValue(
         R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
+    TestRxSchedulers.drainAllTasks();
 
     simulateFinishInputFlow();
     simulateOnStartInputFlow();


### PR DESCRIPTION
Fixes #4550
Fixes #4426

### Summary of Changes

This PR addresses issues where word suggestions remain visible when disabled, or where text gets auto-corrected on backspace / deletion when auto-correct is turned off in settings.

#### Fixes Included
1. **Centralized `setSuggestions(...)` Guard** (`AnySoftKeyboardSuggestions.java`):
   - Prevents populating candidate views when `mShowSuggestions` or `isPredictionOn()` is `false`.

2. **Rx Preference Stream State Reset**:
   - Immediately clears candidate views and resets prediction state when `settings_key_show_suggestions` is toggled off dynamically at runtime.

3. **Restricted Word Suggestion Restart on Backspace**:
   - Requires `mAutoComplete` to be `true` in `canRestartWordSuggestion()` and `postRestartWordSuggestion()`. When auto-correct is disabled (`"none"`), backspacing inside or after words will no longer set composing spans or auto-correct typed text.

#### Unit Tests Added
- Added Robolectric unit tests in `AnySoftKeyboardSuggestionsTest.java` verifying each bug scenario.