### PR TITLE
[LLM] Hide add-on launcher icon and fix AnySoftKeyboard detection

### DIFF
--- a/addons/StoreStuff/assets/AndroidManifest.xml.addon.template
+++ b/addons/StoreStuff/assets/AndroidManifest.xml.addon.template
@@ -9,10 +9,18 @@
             android:exported="true"
             android:name=".MainActivity"
             android:theme="@style/Theme.AskApp">
+        </activity>
+
+        <activity-alias
+            android:name=".LauncherAlias"
+            android:targetActivity=".MainActivity"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name">
                 <intent-filter>
                     <action android:name="android.intent.action.MAIN" />
                     <category android:name="android.intent.category.LAUNCHER" />
                 </intent-filter>
-        </activity>
+        </activity-alias>
     </application>
 </manifest>

--- a/addons/base/apk/src/main/java/com/anysoftkeyboard/addon/apk/MainActivity.kt
+++ b/addons/base/apk/src/main/java/com/anysoftkeyboard/addon/apk/MainActivity.kt
@@ -1,11 +1,9 @@
 package com.anysoftkeyboard.addon.apk
 
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
-import android.view.inputmethod.InputMethodManager
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -70,13 +68,10 @@ abstract class MainActivityBase(
     }
   }
 
-  private fun isAnySoftKeyboardInstalled(): Boolean =
+  internal fun isAnySoftKeyboardInstalled(): Boolean =
       try {
-        val inputMethodManager =
-            getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        inputMethodManager.inputMethodList.any { inputMethodInfo ->
-          inputMethodInfo.packageName == ASK_PACKAGE_NAME
-        }
+        packageManager.getPackageInfo(ASK_PACKAGE_NAME, 0)
+        true
       } catch (e: Exception) {
         false
       }

--- a/addons/base/apk/src/main/java/com/anysoftkeyboard/addon/apk/MainActivity.kt
+++ b/addons/base/apk/src/main/java/com/anysoftkeyboard/addon/apk/MainActivity.kt
@@ -1,9 +1,12 @@
 package com.anysoftkeyboard.addon.apk
 
+import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -64,6 +67,26 @@ abstract class MainActivityBase(
         } catch (ex: Exception) {
           Log.e("ASK_ADD_ON", "Could not launch Store search!", ex)
         }
+      }
+    }
+
+    binding.hideLauncherIconButton.setOnClickListener {
+      try {
+        val launcherComponent = ComponentName(packageName, "$packageName.LauncherAlias")
+        packageManager.setComponentEnabledSetting(
+            launcherComponent,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP,
+        )
+        Toast.makeText(
+                this,
+                R.string.launcher_icon_hidden_toast,
+                Toast.LENGTH_SHORT,
+            )
+            .show()
+        finish()
+      } catch (ex: Exception) {
+        Log.e("ASK_ADD_ON", "Could not hide launcher icon!", ex)
       }
     }
   }

--- a/addons/base/apk/src/main/res/layout/activity_main.xml
+++ b/addons/base/apk/src/main/res/layout/activity_main.xml
@@ -100,6 +100,16 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/action_description" />
 
+        <Button
+            android:id="@+id/hide_launcher_icon_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/hide_launcher_icon_action"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/action_button" />
+
         <TextView
             android:id="@+id/release_notes"
             style="@style/Ask.Text.Normal"
@@ -109,7 +119,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:text="@string/release_notes_template"
-            app:layout_constraintTop_toBottomOf="@+id/action_button" />
+            app:layout_constraintTop_toBottomOf="@+id/hide_launcher_icon_button" />
     </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </layout>

--- a/addons/base/apk/src/main/res/values/strings.xml
+++ b/addons/base/apk/src/main/res/values/strings.xml
@@ -11,5 +11,7 @@
     <string name="open_ask_in_vending">Go to Play Store</string>
     <string name="ask_installed">AnySoftKeyboard is installed. You may need to set it up to start using this expansion pack.</string>
     <string name="open_ask_main_settings">Open AnySoftKeyboard</string>
+    <string name="hide_launcher_icon_action">Hide icon from launcher</string>
+    <string name="launcher_icon_hidden_toast">Add-on launcher icon hidden.</string>
     <string name="test_add_on_description">This is a test add on description, it can be anything</string>
 </resources>

--- a/addons/base/apk/src/test/java/com/anysoftkeyboard/addon/apk/MainActivityBaseTest.kt
+++ b/addons/base/apk/src/test/java/com/anysoftkeyboard/addon/apk/MainActivityBaseTest.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.view.inputmethod.InputMethodInfo
 import android.widget.Button
 import android.widget.ImageView
@@ -194,6 +195,31 @@ class MainActivityBaseTest {
               text,
           )
         }
+      }
+    }
+  }
+
+  @Test
+  fun testHideLauncherIconFlow() {
+    ActivityScenario.launch(TestMainActivity::class.java).use { scenario ->
+      scenario.moveToState(Lifecycle.State.RESUMED).onActivity { activity ->
+        val launcherComponent =
+            ComponentName(activity.packageName, "${activity.packageName}.LauncherAlias")
+        Assert.assertNotEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            activity.packageManager.getComponentEnabledSetting(launcherComponent),
+        )
+
+        activity.findViewById<Button>(R.id.hide_launcher_icon_button).let { button ->
+          Assert.assertEquals("Hide icon from launcher", button.text)
+          Shadows.shadowOf(button).onClickListener.onClick(button)
+        }
+
+        Assert.assertEquals(
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            activity.packageManager.getComponentEnabledSetting(launcherComponent),
+        )
+        Assert.assertTrue(activity.isFinishing)
       }
     }
   }

--- a/addons/base/apk/src/test/java/com/anysoftkeyboard/addon/apk/MainActivityBaseTest.kt
+++ b/addons/base/apk/src/test/java/com/anysoftkeyboard/addon/apk/MainActivityBaseTest.kt
@@ -155,6 +155,48 @@ class MainActivityBaseTest {
       }
     }
   }
+
+  @Test
+  fun testIsAnySoftKeyboardInstalledReturnsFalseWhenNotInstalled() {
+    Shadows.shadowOf(RuntimeEnvironment.getApplication().packageManager)
+        .deletePackage(ASK_PACKAGE_NAME)
+
+    ActivityScenario.launch(TestMainActivity::class.java).use { scenario ->
+      scenario.moveToState(Lifecycle.State.RESUMED).onActivity { activity ->
+        Assert.assertFalse(activity.isAnySoftKeyboardInstalled())
+        activity.findViewById<TextView>(R.id.action_description).run {
+          Assert.assertEquals(
+              "AnySoftKeyboard is not installed on your device.\n" +
+                  "In order to use this expansion pack, " +
+                  "you must first install AnySoftKeyboard.",
+              text,
+          )
+        }
+      }
+    }
+  }
+
+  @Test
+  fun testIsAnySoftKeyboardInstalledReturnsTrueWhenInstalledButNotEnabled() {
+    Shadows.shadowOf(RuntimeEnvironment.getApplication().packageManager).let { pm ->
+      PackageInfo().let { info ->
+        info.packageName = ASK_PACKAGE_NAME
+        pm.installPackage(info)
+      }
+    }
+
+    ActivityScenario.launch(TestMainActivity::class.java).use { scenario ->
+      scenario.moveToState(Lifecycle.State.RESUMED).onActivity { activity ->
+        Assert.assertTrue(activity.isAnySoftKeyboardInstalled())
+        activity.findViewById<TextView>(R.id.action_description).run {
+          Assert.assertEquals(
+              "AnySoftKeyboard is installed. You may need to set it up to start using this expansion pack.",
+              text,
+          )
+        }
+      }
+    }
+  }
 }
 
 class TestMainActivity :


### PR DESCRIPTION
Fixes #4814

### Summary
1. **Fix AnySoftKeyboard Installation Detection:** Updated `isAnySoftKeyboardInstalled()` in add-on APK `MainActivity` to check package installation via `PackageManager` (`packageManager.getPackageInfo`) instead of checking only active enabled input methods.
2. **Launcher Icon Hiding:** Separated the `LAUNCHER` intent filter into a `.LauncherAlias` `<activity-alias>` in `AndroidManifest.xml.addon.template` and added a "Hide icon from launcher" button in the add-on UI that disables `.LauncherAlias` via `PackageManager.setComponentEnabledSetting`.
3. **Unit Tests:** Added unit tests verifying both false and true installation detection states as well as the launcher icon hiding flow.