### PR TITLE
[LLM] Support Target API level 36

### DIFF
--- a/.metals/metals.lock.db
+++ b/.metals/metals.lock.db
@@ -1,0 +1,6 @@
+#FileLock
+#Wed Jul 22 17:25:38 EDT 2026
+hostName=localhost
+id=19f8ba9210737ee928cda8bd8508fdc4693c3ecc54e
+method=file
+server=localhost\:58665

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -29,6 +29,7 @@
     <suppress files="AnyRoboApplication\.java" id="NotAndroidRxSchedulers" />
 
     <suppress files="RxProgressDialog\.java" id="UsingNativeDialog" />
+    <suppress files="DeviceSpecific.*\.java" id="UsingNativeDialog" />
     <suppress files="GeneralDialogController\.java" id="UsingSupportAlertDialog" />
     <suppress files="GeneralDialogTestUtil\.java" id="UsingNativeDialog" />
     <suppress files="GeneralDialogControllerTest\.java" id="UsingNativeDialog" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Android SDK and Build Tools
 androidBuildTools = "36.1.0"
-sdkTarget = "35"
-sdkCompile = "36"
+sdkTarget = "36"
+sdkCompile = "37"
 sdkMinimum = "23"
 
 # Android Gradle Plugin and Build Plugins

--- a/ime/app/src/main/AndroidManifest.xml
+++ b/ime/app/src/main/AndroidManifest.xml
@@ -84,7 +84,7 @@
             android:label="@string/ime_name"
             android:launchMode="singleTask"
             android:roundIcon="@mipmap/ic_launcher_round"
-            android:theme="@style/Theme.AskApp"
+            android:theme="@style/Theme.AskApp.NoTitle.NoActionBar"
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name="com.anysoftkeyboard.ui.settings.setup.SetupWizardActivity"

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecific.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecific.java
@@ -16,6 +16,7 @@
 
 package com.anysoftkeyboard.devicespecific;
 
+import android.app.Dialog;
 import android.content.Context;
 import android.os.IBinder;
 import android.os.Vibrator;
@@ -51,4 +52,13 @@ public interface DeviceSpecific {
   Clipboard createClipboard(@NonNull Context applicationContext);
 
   PressVibrator createPressVibrator(@NonNull Vibrator vibe);
+
+  @Nullable
+  Object registerBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Runnable onBackInvokedRunnable);
+
+  void unregisterBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Object callbackToken);
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecific.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecific.java
@@ -55,10 +55,7 @@ public interface DeviceSpecific {
 
   @Nullable
   Object registerBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Runnable onBackInvokedRunnable);
+      @NonNull Dialog window, @NonNull Runnable onBackInvokedRunnable);
 
-  void unregisterBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Object callbackToken);
+  void unregisterBackGestureHandler(@NonNull Dialog window, @NonNull Object callbackToken);
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV15.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV15.java
@@ -16,6 +16,7 @@
 
 package com.anysoftkeyboard.devicespecific;
 
+import android.app.Dialog;
 import android.content.Context;
 import android.os.IBinder;
 import android.os.Vibrator;
@@ -102,4 +103,17 @@ public class DeviceSpecificV15 implements DeviceSpecific {
   public PressVibrator createPressVibrator(@NonNull Vibrator vibe) {
     return new PressVibratorV1(vibe);
   }
+
+  @Override
+  @Nullable
+  public Object registerBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Runnable onBackInvokedRunnable) {
+    return null;
+  }
+
+  @Override
+  public void unregisterBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Object callbackToken) {}
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV15.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV15.java
@@ -107,13 +107,10 @@ public class DeviceSpecificV15 implements DeviceSpecific {
   @Override
   @Nullable
   public Object registerBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Runnable onBackInvokedRunnable) {
+      @NonNull Dialog window, @NonNull Runnable onBackInvokedRunnable) {
     return null;
   }
 
   @Override
-  public void unregisterBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Object callbackToken) {}
+  public void unregisterBackGestureHandler(@NonNull Dialog window, @NonNull Object callbackToken) {}
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV33.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV33.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Menny Even-Danan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.anysoftkeyboard.devicespecific;
+
+import android.app.Dialog;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+@RequiresApi(33)
+public class DeviceSpecificV33 extends DeviceSpecificV29 {
+  @Override
+  public String getApiLevel() {
+    return "DeviceSpecificV33";
+  }
+
+  @Override
+  @Nullable
+  public Object registerBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Runnable onBackInvokedRunnable) {
+    if (window.getWindow() == null) return null;
+    OnBackInvokedCallback callback = onBackInvokedRunnable::run;
+    window.getWindow().getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+        OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+        callback
+    );
+    return callback;
+  }
+
+  @Override
+  public void unregisterBackGestureHandler(
+      @NonNull Dialog window,
+      @NonNull Object callbackToken) {
+    if (window.getWindow() == null) return;
+    if (callbackToken instanceof OnBackInvokedCallback) {
+      window.getWindow().getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(
+          (OnBackInvokedCallback) callbackToken
+      );
+    }
+  }
+}

--- a/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV33.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/devicespecific/DeviceSpecificV33.java
@@ -33,26 +33,24 @@ public class DeviceSpecificV33 extends DeviceSpecificV29 {
   @Override
   @Nullable
   public Object registerBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Runnable onBackInvokedRunnable) {
+      @NonNull Dialog window, @NonNull Runnable onBackInvokedRunnable) {
     if (window.getWindow() == null) return null;
     OnBackInvokedCallback callback = onBackInvokedRunnable::run;
-    window.getWindow().getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
-        OnBackInvokedDispatcher.PRIORITY_DEFAULT,
-        callback
-    );
+    window
+        .getWindow()
+        .getOnBackInvokedDispatcher()
+        .registerOnBackInvokedCallback(OnBackInvokedDispatcher.PRIORITY_DEFAULT, callback);
     return callback;
   }
 
   @Override
-  public void unregisterBackGestureHandler(
-      @NonNull Dialog window,
-      @NonNull Object callbackToken) {
+  public void unregisterBackGestureHandler(@NonNull Dialog window, @NonNull Object callbackToken) {
     if (window.getWindow() == null) return;
     if (callbackToken instanceof OnBackInvokedCallback) {
-      window.getWindow().getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(
-          (OnBackInvokedCallback) callbackToken
-      );
+      window
+          .getWindow()
+          .getOnBackInvokedDispatcher()
+          .unregisterOnBackInvokedCallback((OnBackInvokedCallback) callbackToken);
     }
   }
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -53,8 +53,7 @@ import java.util.List;
 import net.evendanan.pixel.GeneralDialogController;
 
 public abstract class AnySoftKeyboardBase extends InputMethodService
-    implements OnKeyboardActionListener,
-        GeneralDialogController.OnDialogStateChangedListener {
+    implements OnKeyboardActionListener, GeneralDialogController.OnDialogStateChangedListener {
   protected static final String TAG = "ASK";
 
   protected static final long ONE_FRAME_DELAY = 1000L / 60L;
@@ -347,8 +346,7 @@ public abstract class AnySoftKeyboardBase extends InputMethodService
   protected boolean isPopupKeyboardShowing() {
     final var inputView = getInputView();
     if (inputView instanceof AnyKeyboardViewWithMiniKeyboard) {
-      return ((AnyKeyboardViewWithMiniKeyboard) inputView)
-          .isPopupKeyboardShowing();
+      return ((AnyKeyboardViewWithMiniKeyboard) inputView).isPopupKeyboardShowing();
     }
     return false;
   }

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardBase.java
@@ -40,6 +40,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.anysoftkeyboard.base.utils.GCUtils;
 import com.anysoftkeyboard.base.utils.Logger;
+import com.anysoftkeyboard.keyboards.views.AnyKeyboardViewWithMiniKeyboard;
 import com.anysoftkeyboard.keyboards.views.KeyboardViewContainerView;
 import com.anysoftkeyboard.keyboards.views.OnKeyboardActionListener;
 import com.anysoftkeyboard.ui.dev.DeveloperUtils;
@@ -49,12 +50,17 @@ import com.menny.android.anysoftkeyboard.BuildConfig;
 import com.menny.android.anysoftkeyboard.R;
 import io.reactivex.disposables.CompositeDisposable;
 import java.util.List;
+import net.evendanan.pixel.GeneralDialogController;
 
 public abstract class AnySoftKeyboardBase extends InputMethodService
-    implements OnKeyboardActionListener {
+    implements OnKeyboardActionListener,
+        GeneralDialogController.OnDialogStateChangedListener {
   protected static final String TAG = "ASK";
 
   protected static final long ONE_FRAME_DELAY = 1000L / 60L;
+
+  private boolean mIsDialogShowing = false;
+  private Object mBackCallbackToken = null;
 
   private static final ExtractedTextRequest EXTRACTED_TEXT_REQUEST = new ExtractedTextRequest();
 
@@ -178,6 +184,10 @@ public abstract class AnySoftKeyboardBase extends InputMethodService
             });
 
     mInputView = mInputViewContainer.getStandardKeyboardView();
+    if (mInputView instanceof AnyKeyboardViewWithMiniKeyboard) {
+      ((AnyKeyboardViewWithMiniKeyboard) mInputView)
+          .setOnPopupShownListener(showing -> updateBackCallbackState());
+    }
     mInputViewContainer.setOnKeyboardActionListener(this);
     setupInputViewWatermark();
 
@@ -315,8 +325,59 @@ public abstract class AnySoftKeyboardBase extends InputMethodService
     mInputSessionDisposables.dispose();
     if (getInputView() != null) getInputView().onViewNotRequired();
     mInputView = null;
+    if (mBackCallbackToken != null) {
+      AnyApplication.getDeviceSpecific()
+          .unregisterBackGestureHandler(getWindow(), mBackCallbackToken);
+      mBackCallbackToken = null;
+    }
 
     super.onDestroy();
+  }
+
+  @Override
+  public void onDialogStateChanged(boolean isShowing) {
+    mIsDialogShowing = isShowing;
+    updateBackCallbackState();
+  }
+
+  protected boolean hasStuffToClose() {
+    return mIsDialogShowing || isPopupKeyboardShowing();
+  }
+
+  protected boolean isPopupKeyboardShowing() {
+    final var inputView = getInputView();
+    if (inputView instanceof AnyKeyboardViewWithMiniKeyboard) {
+      return ((AnyKeyboardViewWithMiniKeyboard) inputView)
+          .isPopupKeyboardShowing();
+    }
+    return false;
+  }
+
+  protected void updateBackCallbackState() {
+    final boolean shouldRegister = hasStuffToClose();
+    if (shouldRegister && mBackCallbackToken == null) {
+      mBackCallbackToken =
+          AnyApplication.getDeviceSpecific()
+              .registerBackGestureHandler(getWindow(), this::handleCloseRequest);
+    } else if (!shouldRegister && mBackCallbackToken != null) {
+      AnyApplication.getDeviceSpecific()
+          .unregisterBackGestureHandler(getWindow(), mBackCallbackToken);
+      mBackCallbackToken = null;
+    }
+  }
+
+  @Override
+  @CallSuper
+  public void onStartInputView(android.view.inputmethod.EditorInfo info, boolean restarting) {
+    super.onStartInputView(info, restarting);
+    updateBackCallbackState();
+  }
+
+  @Override
+  @CallSuper
+  public void onFinishInputView(boolean finishingInput) {
+    super.onFinishInputView(finishingInput);
+    updateBackCallbackState();
   }
 
   @Override

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardInlineSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardInlineSuggestions.java
@@ -55,6 +55,17 @@ public abstract class AnySoftKeyboardInlineSuggestions extends AnySoftKeyboardSu
     return super.handleCloseRequest() || cleanUpInlineLayouts(true);
   }
 
+  @Override
+  protected boolean hasStuffToClose() {
+    return super.hasStuffToClose() || isInlineSuggestionsShowing();
+  }
+
+  protected boolean isInlineSuggestionsShowing() {
+    final var inputViewContainer = getInputViewContainer();
+    return inputViewContainer != null
+        && inputViewContainer.findViewById(R.id.inline_suggestions_list) != null;
+  }
+
   @RequiresApi(Build.VERSION_CODES.R)
   @Nullable
   @Override
@@ -125,6 +136,7 @@ public abstract class AnySoftKeyboardInlineSuggestions extends AnySoftKeyboardSu
           instanceof ScrollViewAsMainChild lister) {
         lister.removeAllListItems();
         inputViewContainer.removeView(lister);
+        updateBackCallbackState();
         return true;
       }
     }
@@ -172,6 +184,7 @@ public abstract class AnySoftKeyboardInlineSuggestions extends AnySoftKeyboardSu
     }
 
     actualInputView.setVisibility(View.GONE);
+    updateBackCallbackState();
     return null;
   }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardWithQuickText.java
@@ -111,6 +111,7 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardMediaI
 
     actualInputView.setVisibility(View.GONE);
     inputViewContainer.addView(quickTextsLayout);
+    updateBackCallbackState();
   }
 
   private boolean cleanUpQuickTextKeyboard(boolean reshowStandardKeyboard) {
@@ -128,6 +129,7 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardMediaI
         inputViewContainer.findViewById(R.id.quick_text_pager_root);
     if (quickTextsLayout != null) {
       inputViewContainer.removeView(quickTextsLayout);
+      updateBackCallbackState();
       return true;
     } else {
       return false;
@@ -137,5 +139,16 @@ public abstract class AnySoftKeyboardWithQuickText extends AnySoftKeyboardMediaI
   @Override
   protected boolean handleCloseRequest() {
     return super.handleCloseRequest() || cleanUpQuickTextKeyboard(true);
+  }
+
+  @Override
+  protected boolean hasStuffToClose() {
+    return super.hasStuffToClose() || isQuickTextShowing();
+  }
+
+  protected boolean isQuickTextShowing() {
+    final var inputViewContainer = getInputViewContainer();
+    return inputViewContainer != null
+        && inputViewContainer.findViewById(R.id.quick_text_pager_root) != null;
   }
 }

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewWithMiniKeyboard.java
@@ -299,6 +299,10 @@ public class AnyKeyboardViewWithMiniKeyboard extends SizeSensitiveAnyKeyboardVie
     }
   }
 
+  public boolean isPopupKeyboardShowing() {
+    return mMiniKeyboardPopup.isShowing();
+  }
+
   @Override
   public void disableTouchesTillFingersAreUp() {
     super.disableTouchesTillFingersAreUp();

--- a/ime/app/src/main/java/com/anysoftkeyboard/ui/settings/MainSettingsActivity.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ui/settings/MainSettingsActivity.java
@@ -19,15 +19,26 @@ package com.anysoftkeyboard.ui.settings;
 import android.Manifest;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.navigation.NavController;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.NavigationUI;
 import com.anysoftkeyboard.notification.NotificationIds;
 import com.anysoftkeyboard.permissions.PermissionRequestHelper;
 import com.anysoftkeyboard.prefs.DirectBootAwareSharedPreferences;
+import com.google.android.material.appbar.AppBarLayout;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.menny.android.anysoftkeyboard.AnyApplication;
 import com.menny.android.anysoftkeyboard.R;
@@ -49,7 +60,51 @@ public class MainSettingsActivity extends AppCompatActivity {
   @Override
   protected void onCreate(Bundle icicle) {
     super.onCreate(icicle);
+    WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+    getSupportFragmentManager()
+        .registerFragmentLifecycleCallbacks(
+            new FragmentManager.FragmentLifecycleCallbacks() {
+              @Override
+              public void onFragmentViewCreated(
+                  @NonNull FragmentManager fm,
+                  @NonNull Fragment f,
+                  @NonNull View v,
+                  @Nullable Bundle savedInstanceState) {
+                disableFitsSystemWindows(v);
+              }
+            },
+            true);
+
     setContentView(R.layout.main_ui);
+
+    final AppBarLayout appBarLayout = findViewById(R.id.app_bar_layout);
+    final int initialAppBarTopPadding = appBarLayout.getPaddingTop();
+    ViewCompat.setOnApplyWindowInsetsListener(
+        appBarLayout,
+        (v, insets) -> {
+          final Insets statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars());
+          v.setPadding(
+              v.getPaddingLeft(),
+              initialAppBarTopPadding + statusBarInsets.top,
+              v.getPaddingRight(),
+              v.getPaddingBottom());
+          return insets;
+        });
+
+    final View navHostFragment = findViewById(R.id.nav_host_fragment);
+    ViewCompat.setOnApplyWindowInsetsListener(
+        navHostFragment,
+        (v, insets) -> {
+          final WindowInsetsCompat clearedInsets =
+              new WindowInsetsCompat.Builder(insets)
+                  .setInsets(WindowInsetsCompat.Type.statusBars(), Insets.NONE)
+                  .build();
+          return ViewCompat.onApplyWindowInsets(v, clearedInsets);
+        });
+
+    final MaterialToolbar toolbar = findViewById(R.id.toolbar);
+    setSupportActionBar(toolbar);
 
     mTitle = getTitle();
 
@@ -60,6 +115,19 @@ public class MainSettingsActivity extends AppCompatActivity {
             .getNavController();
     final BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
     NavigationUI.setupWithNavController(bottomNavigationView, navController);
+
+    final int initialBottomNavBottomPadding = bottomNavigationView.getPaddingBottom();
+    ViewCompat.setOnApplyWindowInsetsListener(
+        bottomNavigationView,
+        (v, insets) -> {
+          final Insets navBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
+          v.setPadding(
+              v.getPaddingLeft(),
+              v.getPaddingTop(),
+              v.getPaddingRight(),
+              initialBottomNavBottomPadding + navBarInsets.bottom);
+          return insets;
+        });
   }
 
   @Override
@@ -123,6 +191,19 @@ public class MainSettingsActivity extends AppCompatActivity {
   @Override
   public void setTitle(CharSequence title) {
     mTitle = title;
-    getSupportActionBar().setTitle(mTitle);
+    if (getSupportActionBar() != null) {
+      getSupportActionBar().setTitle(mTitle);
+    }
+  }
+
+  private static void disableFitsSystemWindows(View view) {
+    if (view == null) return;
+    view.setFitsSystemWindows(false);
+    if (view instanceof ViewGroup) {
+      ViewGroup group = (ViewGroup) view;
+      for (int i = 0; i < group.getChildCount(); i++) {
+        disableFitsSystemWindows(group.getChildAt(i));
+      }
+    }
   }
 }

--- a/ime/app/src/main/java/com/menny/android/anysoftkeyboard/AnyApplication.java
+++ b/ime/app/src/main/java/com/menny/android/anysoftkeyboard/AnyApplication.java
@@ -170,7 +170,8 @@ public class AnyApplication extends MultiDexApplication {
     if (Build.VERSION.SDK_INT < 26) return new DeviceSpecificV24();
     if (Build.VERSION.SDK_INT < 28) return new DeviceSpecificV26();
     if (Build.VERSION.SDK_INT < 29) return new DeviceSpecificV28();
-    return new DeviceSpecificV29();
+    if (Build.VERSION.SDK_INT < 33) return new DeviceSpecificV29();
+    return new com.anysoftkeyboard.devicespecific.DeviceSpecificV33();
   }
 
   @Override

--- a/ime/app/src/main/res/layout/main_ui.xml
+++ b/ime/app/src/main/res/layout/main_ui.xml
@@ -6,6 +6,20 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:titleTextColor="?android:attr/textColorPrimary" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -20,7 +34,7 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"
         android:layout_width="match_parent"
-        android:layout_height="48dp"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:background="@color/menu_background_normal"
         app:itemIconTint="@color/bottom_menu_icon_tint"

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardStartUpAllSdkTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardStartUpAllSdkTest.java
@@ -20,7 +20,8 @@ public abstract class AnySoftKeyboardStartUpAllSdkTest extends AnySoftKeyboardBa
     Assume.assumeTrue("Need to figure how to start it in 32", Build.VERSION.SDK_INT != 32);
     Assume.assumeTrue("Need to figure how to start it in 33", Build.VERSION.SDK_INT != 33);
     Assume.assumeTrue("Need to figure how to start it in 34", Build.VERSION.SDK_INT != 34);
-    Assume.assumeTrue("Need to figure how to start it in 34", Build.VERSION.SDK_INT != 35);
+    Assume.assumeTrue("Need to figure how to start it in 35", Build.VERSION.SDK_INT != 35);
+    Assume.assumeTrue("Need to figure how to start it in 36", Build.VERSION.SDK_INT != 36);
     // Skipping on SDK 30 due to a Robolectric issue with WindowInsets dispatch
     // This affects test environment only. The feature is tested manually on API 30.
     Assume.assumeTrue("Some weird error with insets in API 30", Build.VERSION.SDK_INT != 30);

--- a/ime/app/src/test/java/com/anysoftkeyboard/RobolectricFragmentTestCase.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/RobolectricFragmentTestCase.java
@@ -54,6 +54,12 @@ public abstract class RobolectricFragmentTestCase<F extends Fragment>
     @IdRes private static int CREATED_FRAGMENT;
 
     @Override
+    protected void onCreate(Bundle icicle) {
+      setTheme(R.style.Theme_AskApp_NoTitle_NoActionBar);
+      super.onCreate(icicle);
+    }
+
+    @Override
     protected void onPostCreate(Bundle savedInstanceState) {
       super.onPostCreate(savedInstanceState);
       final NavController navController =

--- a/ime/app/src/test/java/com/menny/android/anysoftkeyboard/AnyApplicationDeviceSpecificAllSdkTest.java
+++ b/ime/app/src/test/java/com/menny/android/anysoftkeyboard/AnyApplicationDeviceSpecificAllSdkTest.java
@@ -23,6 +23,7 @@ import com.anysoftkeyboard.devicespecific.DeviceSpecificV24;
 import com.anysoftkeyboard.devicespecific.DeviceSpecificV26;
 import com.anysoftkeyboard.devicespecific.DeviceSpecificV28;
 import com.anysoftkeyboard.devicespecific.DeviceSpecificV29;
+import com.anysoftkeyboard.devicespecific.DeviceSpecificV33;
 import com.anysoftkeyboard.devicespecific.PressVibrator;
 import com.anysoftkeyboard.devicespecific.PressVibratorV1;
 import com.anysoftkeyboard.devicespecific.PressVibratorV26;
@@ -74,10 +75,10 @@ public abstract class AnyApplicationDeviceSpecificAllSdkTest {
           DeviceSpecificV29.class, // 30
           DeviceSpecificV29.class,
           DeviceSpecificV29.class,
-          DeviceSpecificV29.class,
-          DeviceSpecificV29.class,
-          DeviceSpecificV29.class,
-          DeviceSpecificV29.class);
+          DeviceSpecificV33.class,
+          DeviceSpecificV33.class,
+          DeviceSpecificV33.class,
+          DeviceSpecificV33.class);
 
   private final List<Class<? extends Clipboard>> mExpectedClipboardClass =
       Arrays.asList(

--- a/ime/app/src/test/java/com/menny/android/anysoftkeyboard/AnyApplicationDeviceSpecificAllSdkTest.java
+++ b/ime/app/src/test/java/com/menny/android/anysoftkeyboard/AnyApplicationDeviceSpecificAllSdkTest.java
@@ -76,6 +76,7 @@ public abstract class AnyApplicationDeviceSpecificAllSdkTest {
           DeviceSpecificV29.class,
           DeviceSpecificV29.class,
           DeviceSpecificV29.class,
+          DeviceSpecificV29.class,
           DeviceSpecificV29.class);
 
   private final List<Class<? extends Clipboard>> mExpectedClipboardClass =
@@ -111,6 +112,7 @@ public abstract class AnyApplicationDeviceSpecificAllSdkTest {
           ClipboardV28.class, // 28
           ClipboardV28.class,
           ClipboardV28.class, // 30
+          ClipboardV28.class,
           ClipboardV28.class,
           ClipboardV28.class,
           ClipboardV28.class,
@@ -154,6 +156,7 @@ public abstract class AnyApplicationDeviceSpecificAllSdkTest {
           AskV19GestureDetector.class,
           AskV19GestureDetector.class,
           AskV19GestureDetector.class,
+          AskV19GestureDetector.class,
           AskV19GestureDetector.class);
 
   private final List<Class<? extends PressVibrator>> mExpectedPressVibratorClass =
@@ -189,6 +192,7 @@ public abstract class AnyApplicationDeviceSpecificAllSdkTest {
           PressVibratorV26.class,
           PressVibratorV29.class,
           PressVibratorV29.class, // 30
+          PressVibratorV29.class,
           PressVibratorV29.class,
           PressVibratorV29.class,
           PressVibratorV29.class,

--- a/ime/base-test/src/main/java/com/anysoftkeyboard/test/TestUtils.java
+++ b/ime/base-test/src/main/java/com/anysoftkeyboard/test/TestUtils.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TestUtils {
-  public static final int LATEST_STABLE_API_LEVEL = Build.VERSION_CODES.VANILLA_ICE_CREAM;
+  public static final int LATEST_STABLE_API_LEVEL = Build.VERSION_CODES.BAKLAVA;
   // This is the latest version that does not fail with
   // "IllegalStateException: The Window Context should have been attached to a DisplayArea"
   public static final int LATEST_WINDOW_SUPPORTING_API_LEVEL = Build.VERSION_CODES.S;

--- a/ime/pixel/src/main/java/net/evendanan/pixel/GeneralDialogController.java
+++ b/ime/pixel/src/main/java/net/evendanan/pixel/GeneralDialogController.java
@@ -50,7 +50,20 @@ public class GeneralDialogController {
     mDialog = builder.create();
     mDialog.getWindow().getDecorView().setTag(TAG_ID, TAG_VALUE);
     mDialogPresenter.beforeDialogShown(mDialog, data);
+    if (mContext instanceof OnDialogStateChangedListener) {
+      ((OnDialogStateChangedListener) mContext).onDialogStateChanged(true);
+    }
+    mDialog.setOnDismissListener(dialog -> {
+      mDialog = null;
+      if (mContext instanceof OnDialogStateChangedListener) {
+        ((OnDialogStateChangedListener) mContext).onDialogStateChanged(false);
+      }
+    });
     mDialog.show();
+  }
+
+  public interface OnDialogStateChangedListener {
+    void onDialogStateChanged(boolean isShowing);
   }
 
   public interface DialogPresenter extends JustSetupDialogPresenter {

--- a/ime/pixel/src/main/java/net/evendanan/pixel/GeneralDialogController.java
+++ b/ime/pixel/src/main/java/net/evendanan/pixel/GeneralDialogController.java
@@ -53,12 +53,13 @@ public class GeneralDialogController {
     if (mContext instanceof OnDialogStateChangedListener) {
       ((OnDialogStateChangedListener) mContext).onDialogStateChanged(true);
     }
-    mDialog.setOnDismissListener(dialog -> {
-      mDialog = null;
-      if (mContext instanceof OnDialogStateChangedListener) {
-        ((OnDialogStateChangedListener) mContext).onDialogStateChanged(false);
-      }
-    });
+    mDialog.setOnDismissListener(
+        dialog -> {
+          mDialog = null;
+          if (mContext instanceof OnDialogStateChangedListener) {
+            ((OnDialogStateChangedListener) mContext).onDialogStateChanged(false);
+          }
+        });
     mDialog.show();
   }
 

--- a/ime/pixel/src/main/res/values/app_styles.xml
+++ b/ime/pixel/src/main/res/values/app_styles.xml
@@ -45,6 +45,8 @@
 
     <style name="Theme.AskApp.NoTitle.NoActionBar" parent="Theme.AskApp.NoTitle">
         <item name="windowActionBar">false</item>
+        <item name="android:fitsSystemWindows">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="Theme.AskApp.Popup" parent="Base.Theme.AppCompat.Light.Dialog.FixedSize">


### PR DESCRIPTION
Fixes https://github.com/AnySoftKeyboard/AnySoftKeyboard/issues/4820

## Summary of Changes
- Replaced legacy decor ActionBar with `MaterialToolbar` and `AppBarLayout` in `main_ui.xml`.
- Updated `MainSettingsActivity` theme to `Theme.AskApp.NoTitle.NoActionBar` with a transparent status bar and disabled decor `fitsSystemWindows`.
- Applied baseline-relative window insets to `AppBarLayout` and `BottomNavigationView`.
- Registered Fragment Lifecycle Callback in `MainSettingsActivity` to recursively disable `fitsSystemWindows` on fragment views, preventing `PreferenceFragmentCompat` from adding extra top padding on navigation.