### PR TITLE
[LLM] Update default bottom extra padding to 24dp and increase max range to 200

### DIFF
--- a/ime/app/src/main/res/values/integers.xml
+++ b/ime/app/src/main/res/values/integers.xml
@@ -12,5 +12,5 @@
     <integer name="maximum_instances_of_preview_popups">5</integer>
     <integer name="maximum_dictionary_words_to_load">5000</integer>
     <integer name="settings_bottom_padding_min">0</integer>
-    <integer name="settings_bottom_padding_max">100</integer>
+    <integer name="settings_bottom_padding_max">200</integer>
 </resources>

--- a/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
+++ b/ime/app/src/main/res/values/settings_defaults_dont_translate.xml
@@ -141,5 +141,5 @@
     <integer name="settings_default_zoom_percent_in_portrait">100</integer>
     <integer name="settings_default_zoom_percent_in_landscape">100</integer>
 
-    <integer name="settings_default_bottom_extra_padding_in_portrait">0</integer>
+    <integer name="settings_default_bottom_extra_padding_in_portrait">24</integer>
 </resources>


### PR DESCRIPTION
### Description
This PR updates the default portrait extra bottom padding setting for the keyboard from 0dp to 24dp and increases the maximum value on the slider setting range from 100dp to 200dp.

### Changes
- Updated `settings_default_bottom_extra_padding_in_portrait` default value to 24dp in `settings_defaults_dont_translate.xml`
- Updated `settings_bottom_padding_max` upper limit to 200 in `integers.xml`