### PR TITLE
[LLM] Fix NullPointerException in BTreeDictionary traversal during concurrent updates

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
@@ -149,10 +149,13 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   private boolean deleteWordRec(
       final NodeArray children, final CharSequence word, final int offset, final int length) {
-    final int count = children.length;
+    if (children == null) return false;
+    final Node[] localData = children.data;
+    if (localData == null) return false;
+    final int count = Math.min(children.length, localData.length);
     final char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
-      final Node node = children.data[j];
+      final Node node = localData[j];
       if (node == null) continue;
       if (node.code == currentChar) {
         if (offset == length - 1) { // last character in the word to delete
@@ -232,10 +235,13 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   private int getWordFrequencyRec(
       final NodeArray children, final CharSequence word, final int offset, final int length) {
-    final int count = children.length;
+    if (children == null) return 0;
+    final Node[] localData = children.data;
+    if (localData == null) return 0;
+    final int count = Math.min(children.length, localData.length);
     char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
-      final Node node = children.data[j];
+      final Node node = localData[j];
       if (node == null) continue;
       if (node.code == currentChar) {
         if (offset == length - 1) {
@@ -282,7 +288,10 @@ public abstract class BTreeDictionary extends EditableDictionary {
       float snr,
       int inputIndex,
       WordCallback callback) {
-    final int count = roots.length;
+    if (roots == null) return;
+    final Node[] localData = roots.data;
+    if (localData == null) return;
+    final int count = Math.min(roots.length, localData.length);
     final int codeSize = mInputLength;
     // Optimization: Prune out words that are too long compared to how much
     // was typed.
@@ -297,7 +306,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     for (int i = 0; i < count; i++) {
-      final Node node = roots.data[i];
+      final Node node = localData[i];
       if (node == null) continue;
       final char nodeC = node.code;
       final char nodeLowerC = toLowerCase(nodeC);
@@ -375,14 +384,17 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   private void addWordRec(
       NodeArray children, final String word, final int depth, final int frequency) {
+    if (children == null) return;
+    final Node[] localData = children.data;
+    if (localData == null) return;
     final int wordLength = word.length();
     final char c = word.charAt(depth);
     // Does children have the current character?
-    final int childrenLength = children.length;
+    final int childrenLength = Math.min(children.length, localData.length);
     Node childNode = null;
     boolean found = false;
     for (int i = 0; i < childrenLength; i++) {
-      childNode = children.data[i];
+      childNode = localData[i];
       if (childNode == null) continue;
       if (childNode.code == c) {
         found = true;
@@ -423,7 +435,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   static class NodeArray {
     private static final int INCREMENT = 2;
-    Node[] data;
+    volatile Node[] data;
     int length = 0;
 
     NodeArray(int initialCapacity) {
@@ -449,6 +461,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     public void deleteNode(int nodeIndexToDelete) {
+      if (length <= 0 || nodeIndexToDelete < 0 || nodeIndexToDelete >= length) return;
       length--;
       if (length - nodeIndexToDelete > 0) {
         System.arraycopy(

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
@@ -41,7 +41,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
   protected final Context mContext;
   private final int mMaxWordsToRead;
 
-  private volatile NodeArray mRoots;
+  private NodeArray mRoots;
   private int mMaxDepth;
   private int mInputLength;
   private final char[] mWordBuilder = new char[MAX_WORD_LENGTH];
@@ -149,14 +149,10 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   private boolean deleteWordRec(
       final NodeArray children, final CharSequence word, final int offset, final int length) {
-    if (children == null) return false;
-    final Node[] localData = children.data;
-    if (localData == null) return false;
-    final int count = Math.min(children.length, localData.length);
+    final int count = children.length;
     final char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
-      final Node node = localData[j];
-      if (node == null) continue;
+      final Node node = children.data[j];
       if (node.code == currentChar) {
         if (offset == length - 1) { // last character in the word to delete
           // we need to delete this node. But only if it terminal
@@ -212,9 +208,11 @@ public abstract class BTreeDictionary extends EditableDictionary {
   @Override
   public void getSuggestions(final KeyCodesProvider codes, final Dictionary.WordCallback callback) {
     if (isLoading() || isClosed()) return;
-    mInputLength = codes.codePointCount();
-    mMaxDepth = mInputLength * 2;
-    getWordsRec(mRoots, codes, mWordBuilder, 0, false, 1.0f, 0, callback);
+    synchronized (mResourceMonitor) {
+      mInputLength = codes.codePointCount();
+      mMaxDepth = mInputLength * 2;
+      getWordsRec(mRoots, codes, mWordBuilder, 0, false, 1.0f, 0, callback);
+    }
   }
 
   @Override
@@ -230,19 +228,17 @@ public abstract class BTreeDictionary extends EditableDictionary {
    */
   public final int getWordFrequency(CharSequence word) {
     if (isLoading() || isClosed()) return 0;
-    return getWordFrequencyRec(mRoots, word, 0, word.length());
+    synchronized (mResourceMonitor) {
+      return getWordFrequencyRec(mRoots, word, 0, word.length());
+    }
   }
 
   private int getWordFrequencyRec(
       final NodeArray children, final CharSequence word, final int offset, final int length) {
-    if (children == null) return 0;
-    final Node[] localData = children.data;
-    if (localData == null) return 0;
-    final int count = Math.min(children.length, localData.length);
+    final int count = children.length;
     char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
-      final Node node = localData[j];
-      if (node == null) continue;
+      final Node node = children.data[j];
       if (node.code == currentChar) {
         if (offset == length - 1) {
           if (node.terminal) {
@@ -288,10 +284,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
       float snr,
       int inputIndex,
       WordCallback callback) {
-    if (roots == null) return;
-    final Node[] localData = roots.data;
-    if (localData == null) return;
-    final int count = Math.min(roots.length, localData.length);
+    final int count = roots.length;
     final int codeSize = mInputLength;
     // Optimization: Prune out words that are too long compared to how much
     // was typed.
@@ -306,8 +299,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     for (int i = 0; i < count; i++) {
-      final Node node = localData[i];
-      if (node == null) continue;
+      final Node node = roots.data[i];
       final char nodeC = node.code;
       final char nodeLowerC = toLowerCase(nodeC);
       boolean terminal = node.terminal;
@@ -384,18 +376,14 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   private void addWordRec(
       NodeArray children, final String word, final int depth, final int frequency) {
-    if (children == null) return;
-    final Node[] localData = children.data;
-    if (localData == null) return;
     final int wordLength = word.length();
     final char c = word.charAt(depth);
     // Does children have the current character?
-    final int childrenLength = Math.min(children.length, localData.length);
+    final int childrenLength = children.length;
     Node childNode = null;
     boolean found = false;
     for (int i = 0; i < childrenLength; i++) {
-      childNode = localData[i];
-      if (childNode == null) continue;
+      childNode = children.data[i];
       if (childNode.code == c) {
         found = true;
         break;
@@ -435,7 +423,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
   static class NodeArray {
     private static final int INCREMENT = 2;
-    volatile Node[] data;
+    Node[] data;
     int length = 0;
 
     NodeArray(int initialCapacity) {
@@ -447,27 +435,22 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     void add(Node n) {
-      Node[] currentData = data;
-      int currentLength = length;
-      if (currentLength + 1 > currentData.length) {
-        Node[] tempData = new Node[currentLength + 1 + INCREMENT];
-        System.arraycopy(currentData, 0, tempData, 0, currentLength);
-        tempData[currentLength] = n;
+      length++;
+      if (length > data.length) {
+        Node[] tempData = new Node[length + INCREMENT];
+        System.arraycopy(data, 0, tempData, 0, data.length);
         data = tempData;
-      } else {
-        currentData[currentLength] = n;
       }
-      length = currentLength + 1;
+      data[length - 1] = n;
     }
 
     public void deleteNode(int nodeIndexToDelete) {
-      if (length <= 0 || nodeIndexToDelete < 0 || nodeIndexToDelete >= length) return;
       length--;
-      if (length - nodeIndexToDelete > 0) {
-        System.arraycopy(
-            data, nodeIndexToDelete + 1, data, nodeIndexToDelete, length - nodeIndexToDelete);
+      if (length > 0) {
+        if (length - nodeIndexToDelete >= 0)
+          System.arraycopy(
+              data, nodeIndexToDelete + 1, data, nodeIndexToDelete, length - nodeIndexToDelete);
       }
-      data[length] = null;
     }
   }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/dictionaries/BTreeDictionary.java
@@ -41,7 +41,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
   protected final Context mContext;
   private final int mMaxWordsToRead;
 
-  private NodeArray mRoots;
+  private volatile NodeArray mRoots;
   private int mMaxDepth;
   private int mInputLength;
   private final char[] mWordBuilder = new char[MAX_WORD_LENGTH];
@@ -153,6 +153,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     final char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
       final Node node = children.data[j];
+      if (node == null) continue;
       if (node.code == currentChar) {
         if (offset == length - 1) { // last character in the word to delete
           // we need to delete this node. But only if it terminal
@@ -235,6 +236,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     char currentChar = word.charAt(offset);
     for (int j = 0; j < count; j++) {
       final Node node = children.data[j];
+      if (node == null) continue;
       if (node.code == currentChar) {
         if (offset == length - 1) {
           if (node.terminal) {
@@ -296,6 +298,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
 
     for (int i = 0; i < count; i++) {
       final Node node = roots.data[i];
+      if (node == null) continue;
       final char nodeC = node.code;
       final char nodeLowerC = toLowerCase(nodeC);
       boolean terminal = node.terminal;
@@ -380,6 +383,7 @@ public abstract class BTreeDictionary extends EditableDictionary {
     boolean found = false;
     for (int i = 0; i < childrenLength; i++) {
       childNode = children.data[i];
+      if (childNode == null) continue;
       if (childNode.code == c) {
         found = true;
         break;
@@ -431,22 +435,26 @@ public abstract class BTreeDictionary extends EditableDictionary {
     }
 
     void add(Node n) {
-      length++;
-      if (length > data.length) {
-        Node[] tempData = new Node[length + INCREMENT];
-        System.arraycopy(data, 0, tempData, 0, data.length);
+      Node[] currentData = data;
+      int currentLength = length;
+      if (currentLength + 1 > currentData.length) {
+        Node[] tempData = new Node[currentLength + 1 + INCREMENT];
+        System.arraycopy(currentData, 0, tempData, 0, currentLength);
+        tempData[currentLength] = n;
         data = tempData;
+      } else {
+        currentData[currentLength] = n;
       }
-      data[length - 1] = n;
+      length = currentLength + 1;
     }
 
     public void deleteNode(int nodeIndexToDelete) {
       length--;
-      if (length > 0) {
-        if (length - nodeIndexToDelete >= 0)
-          System.arraycopy(
-              data, nodeIndexToDelete + 1, data, nodeIndexToDelete, length - nodeIndexToDelete);
+      if (length - nodeIndexToDelete > 0) {
+        System.arraycopy(
+            data, nodeIndexToDelete + 1, data, nodeIndexToDelete, length - nodeIndexToDelete);
       }
+      data[length] = null;
     }
   }
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/BTreeDictionaryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/BTreeDictionaryTest.java
@@ -362,6 +362,7 @@ public class BTreeDictionaryTest {
                   getWordsFor(mDictionaryUnderTest, "wor");
                   mDictionaryUnderTest.isValidWord("word" + (i % 100));
                 } catch (Throwable t) {
+                  t.printStackTrace();
                   errors.incrementAndGet();
                 }
               }

--- a/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/BTreeDictionaryTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/dictionaries/BTreeDictionaryTest.java
@@ -335,4 +335,44 @@ public class BTreeDictionaryTest {
     Assert.assertFalse(dictionary.isValidWord("invalid"));
     Assert.assertFalse(dictionary.isValidWord("alsoInvalid"));
   }
+
+  @Test
+  public void testConcurrentAddDeleteAndGetSuggestions() throws Exception {
+    mDictionaryUnderTest.loadDictionary();
+    final AtomicInteger errors = new AtomicInteger(0);
+    final int iterations = 500;
+
+    Thread writerThread =
+        new Thread(
+            () -> {
+              for (int i = 0; i < iterations; i++) {
+                String word = "word" + i;
+                mDictionaryUnderTest.addWord(word, 50);
+                if (i % 2 == 0) {
+                  mDictionaryUnderTest.deleteWord(word);
+                }
+              }
+            });
+
+    Thread readerThread =
+        new Thread(
+            () -> {
+              for (int i = 0; i < iterations; i++) {
+                try {
+                  getWordsFor(mDictionaryUnderTest, "wor");
+                  mDictionaryUnderTest.isValidWord("word" + (i % 100));
+                } catch (Throwable t) {
+                  errors.incrementAndGet();
+                }
+              }
+            });
+
+    writerThread.start();
+    readerThread.start();
+
+    writerThread.join();
+    readerThread.join();
+
+    Assert.assertEquals(0, errors.get());
+  }
 }


### PR DESCRIPTION
Fixes #4771

### Problem
In `BTreeDictionary`, `getSuggestions()` reads tree nodes concurrently on the UI thread without synchronization while `addWord()` / `deleteWord()` modify `NodeArray` from background threads. `NodeArray.add()` previously incremented `length` before setting the array element slot, causing concurrent suggestion readers to encounter an uninitialized `null` slot and throw a `NullPointerException` when trying to access `node.code`.

### Solution
- **Lock-Free Safe Array Insertion:** Updated `NodeArray.add()` to assign `data[currentLength] = n` BEFORE updating `length`.
- **Dangling Pointer Removal:** Updated `NodeArray.deleteNode()` to null out `data[length]` after shifting elements.
- **Volatile Root Reference:** Marked `mRoots` as `volatile` in `BTreeDictionary` to ensure immediate visibility of dictionary resets across threads.
- **Defensive Null Guards:** Added `if (node == null) continue;` checks in `getWordsRec()`, `getWordFrequencyRec()`, `deleteWordRec()`, and `addWordRec()`.
- **Concurrency Test:** Added `testConcurrentAddDeleteAndGetSuggestions()` in `BTreeDictionaryTest` to verify that concurrent dictionary reads during word additions and deletions do not crash.