### PR TITLE
[LLM] Fix null pointer exception in ResourceBinaryDictionary.getWordsNative (#4763)

### DIFF
--- a/ime/dictionaries/jnidictionaryv2/src/main/java/com/anysoftkeyboard/dictionaries/jni/ResourceBinaryDictionary.java
+++ b/ime/dictionaries/jnidictionaryv2/src/main/java/com/anysoftkeyboard/dictionaries/jni/ResourceBinaryDictionary.java
@@ -101,7 +101,7 @@ public class ResourceBinaryDictionary extends Dictionary {
       @Nullable int[] nextLettersFrequencies,
       int nextLettersSize);
 
-  private native void getWordsNative(long dictPointer, GetWordsCallback callback);
+  private native boolean getWordsNative(long dictPointer, GetWordsCallback callback);
 
   @Override
   protected void loadAllResources() {
@@ -292,10 +292,8 @@ public class ResourceBinaryDictionary extends Dictionary {
   @Override
   public void getLoadedWords(@NonNull GetWordsCallback callback) {
     final long ptr = mNativeDictPointer.get();
-    if (isClosed() || isLoading() || ptr == 0L) {
+    if (isClosed() || isLoading() || ptr == 0L || !getWordsNative(ptr, callback)) {
       callback.onGetWordsFinished(new char[0][0], new int[0]);
-      return;
     }
-    getWordsNative(ptr, callback);
   }
 }

--- a/ime/dictionaries/jnidictionaryv2/src/main/java/com/anysoftkeyboard/dictionaries/jni/ResourceBinaryDictionary.java
+++ b/ime/dictionaries/jnidictionaryv2/src/main/java/com/anysoftkeyboard/dictionaries/jni/ResourceBinaryDictionary.java
@@ -291,6 +291,11 @@ public class ResourceBinaryDictionary extends Dictionary {
 
   @Override
   public void getLoadedWords(@NonNull GetWordsCallback callback) {
-    getWordsNative(mNativeDictPointer.get(), callback);
+    final long ptr = mNativeDictPointer.get();
+    if (isClosed() || isLoading() || ptr == 0L) {
+      callback.onGetWordsFinished(new char[0][0], new int[0]);
+      return;
+    }
+    getWordsNative(ptr, callback);
   }
 }

--- a/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
+++ b/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
@@ -59,12 +59,21 @@ static int nativeime_ResourceBinaryDictionary_getSuggestions(
         jint maxAlternatives, jint skipPos, jintArray nextLettersArray, jint nextLettersSize) {
     auto *dictionary = reinterpret_cast<Dictionary *>(dict);
     if (dictionary == nullptr) return 0;
+    if (frequencyArray == nullptr || inputArray == nullptr || outputArray == nullptr) return 0;
 
     int *frequencies = env->GetIntArrayElements(frequencyArray, nullptr);
     int *inputCodes = env->GetIntArrayElements(inputArray, nullptr);
     jchar *outputChars = env->GetCharArrayElements(outputArray, nullptr);
     int *nextLetters = nextLettersArray != nullptr ? env->GetIntArrayElements(nextLettersArray, nullptr)
                                                 : nullptr;
+
+    if (!frequencies || !inputCodes || !outputChars) {
+        if (frequencies) env->ReleaseIntArrayElements(frequencyArray, frequencies, 0);
+        if (inputCodes) env->ReleaseIntArrayElements(inputArray, inputCodes, JNI_ABORT);
+        if (outputChars) env->ReleaseCharArrayElements(outputArray, outputChars, 0);
+        if (nextLetters) env->ReleaseIntArrayElements(nextLettersArray, nextLetters, 0);
+        return 0;
+    }
 
     int count = dictionary->getSuggestions(inputCodes, arraySize, outputChars,
                                            frequencies, maxWordLength, maxWords, maxAlternatives,
@@ -84,9 +93,11 @@ static int nativeime_ResourceBinaryDictionary_getSuggestions(
 static jboolean nativeime_ResourceBinaryDictionary_isValidWord
         (JNIEnv *env, jobject object, jlong dict, jcharArray wordArray, jint wordLength) {
     Dictionary *dictionary = reinterpret_cast<Dictionary *>(dict);
-    if (dictionary == NULL) return (jboolean) false;
+    if (dictionary == NULL || wordArray == NULL) return (jboolean) false;
 
     jchar *word = env->GetCharArrayElements(wordArray, NULL);
+    if (!word) return (jboolean) false;
+
     jboolean result = static_cast<jboolean>(dictionary->isValidWord(word, wordLength));
     env->ReleaseCharArrayElements(wordArray, word, JNI_ABORT);
 
@@ -96,25 +107,63 @@ static jboolean nativeime_ResourceBinaryDictionary_isValidWord
 static void nativeime_ResourceBinaryDictionary_getWords
         (JNIEnv *env, jobject object, jlong dict, jobject getWordsCallback) {
     Dictionary *dictionary = reinterpret_cast<Dictionary *>(dict);
-    if (!dictionary) return;
+    if (!dictionary || !getWordsCallback) return;
 
     int wordCount = 0, wordsCharsCount = 0;
     dictionary->countWordsChars(wordCount, wordsCharsCount);
+    if (wordCount <= 0 || wordsCharsCount <= 0) return;
+
     unsigned short *words = new unsigned short[wordsCharsCount];
     jintArray frequencyArray = env->NewIntArray(wordCount);
+    if (!frequencyArray) {
+        env->ExceptionClear();
+        delete[] words;
+        return;
+    }
+
     int *frequencies = env->GetIntArrayElements(frequencyArray, NULL);
+    if (!frequencies) {
+        env->ExceptionClear();
+        delete[] words;
+        return;
+    }
+
     dictionary->getWords(words, frequencies);
     env->ReleaseIntArrayElements(frequencyArray, frequencies, 0);
 
-    jobjectArray javaLandChars = env->NewObjectArray(wordCount, env->FindClass("[C"), NULL);
+    jclass charArrayClass = env->FindClass("[C");
+    if (!charArrayClass) {
+        env->ExceptionClear();
+        delete[] words;
+        return;
+    }
+
+    jobjectArray javaLandChars = env->NewObjectArray(wordCount, charArrayClass, NULL);
+    if (!javaLandChars) {
+        env->ExceptionClear();
+        delete[] words;
+        return;
+    }
 
     unsigned short *pos = words;
-    for (int i = 0; i < wordCount; ++i) {
+    const unsigned short *endPos = words + wordsCharsCount;
+
+    for (int i = 0; i < wordCount && pos < endPos; ++i) {
         size_t count = 0;
-        while (pos[count] != 0x00) ++count;
+        while (pos + count < endPos && pos[count] != 0x00) ++count;
 
         jcharArray jchr = env->NewCharArray((jsize) count);
+        if (!jchr) {
+            env->ExceptionClear();
+            break;
+        }
+
         jchar *chr = env->GetCharArrayElements(jchr, NULL);
+        if (!chr) {
+            env->ExceptionClear();
+            env->DeleteLocalRef(jchr);
+            break;
+        }
 
         memcpy(chr, pos, count * sizeof(unsigned short));
 
@@ -126,7 +175,9 @@ static void nativeime_ResourceBinaryDictionary_getWords
 
     delete[] words;
 
-    env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, javaLandChars, frequencyArray);
+    if (!env->ExceptionCheck()) {
+        env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, javaLandChars, frequencyArray);
+    }
 }
 
 static void nativeime_ResourceBinaryDictionary_close

--- a/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
+++ b/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
@@ -68,7 +68,7 @@ static int nativeime_ResourceBinaryDictionary_getSuggestions(
     int *nextLetters = nextLettersArray != nullptr ? env->GetIntArrayElements(nextLettersArray, nullptr)
                                                 : nullptr;
 
-    if (!frequencies || !inputCodes || !outputChars) {
+    if (!frequencies || !inputCodes || !outputChars || (nextLettersArray != nullptr && !nextLetters)) {
         if (frequencies) env->ReleaseIntArrayElements(frequencyArray, frequencies, 0);
         if (inputCodes) env->ReleaseIntArrayElements(inputArray, inputCodes, JNI_ABORT);
         if (outputChars) env->ReleaseCharArrayElements(outputArray, outputChars, 0);
@@ -145,6 +145,7 @@ static jboolean nativeime_ResourceBinaryDictionary_getWords
     unsigned short *pos = words.get();
     const unsigned short *endPos = words.get() + wordsCharsCount;
     bool allocationFailed = false;
+    int wordsProcessed = 0;
 
     for (int i = 0; i < wordCount && pos < endPos; ++i) {
         size_t count = 0;
@@ -171,9 +172,10 @@ static jboolean nativeime_ResourceBinaryDictionary_getWords
         env->SetObjectArrayElement(javaLandChars, i, jchr);
         pos += count + 1;
         env->DeleteLocalRef(jchr);
+        wordsProcessed++;
     }
 
-    if (allocationFailed || env->ExceptionCheck()) {
+    if (allocationFailed || wordsProcessed < wordCount || env->ExceptionCheck()) {
         env->ExceptionClear();
         return (jboolean) false;
     }

--- a/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
+++ b/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
@@ -109,15 +109,35 @@ static void nativeime_ResourceBinaryDictionary_getWords
     Dictionary *dictionary = reinterpret_cast<Dictionary *>(dict);
     if (!dictionary || !getWordsCallback) return;
 
+    jclass charArrayClass = env->FindClass("[C");
+    if (!charArrayClass) {
+        env->ExceptionClear();
+        return;
+    }
+
+    auto sendEmptyResult = [env, getWordsCallback, charArrayClass]() {
+        jobjectArray emptyWords = env->NewObjectArray(0, charArrayClass, NULL);
+        jintArray emptyFreqs = env->NewIntArray(0);
+        if (emptyWords && emptyFreqs) {
+            env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, emptyWords, emptyFreqs);
+        }
+        if (emptyWords) env->DeleteLocalRef(emptyWords);
+        if (emptyFreqs) env->DeleteLocalRef(emptyFreqs);
+    };
+
     int wordCount = 0, wordsCharsCount = 0;
     dictionary->countWordsChars(wordCount, wordsCharsCount);
-    if (wordCount <= 0 || wordsCharsCount <= 0) return;
+    if (wordCount <= 0 || wordsCharsCount <= 0) {
+        sendEmptyResult();
+        return;
+    }
 
     unsigned short *words = new unsigned short[wordsCharsCount];
     jintArray frequencyArray = env->NewIntArray(wordCount);
     if (!frequencyArray) {
         env->ExceptionClear();
         delete[] words;
+        sendEmptyResult();
         return;
     }
 
@@ -125,28 +145,26 @@ static void nativeime_ResourceBinaryDictionary_getWords
     if (!frequencies) {
         env->ExceptionClear();
         delete[] words;
+        env->DeleteLocalRef(frequencyArray);
+        sendEmptyResult();
         return;
     }
 
     dictionary->getWords(words, frequencies);
     env->ReleaseIntArrayElements(frequencyArray, frequencies, 0);
 
-    jclass charArrayClass = env->FindClass("[C");
-    if (!charArrayClass) {
-        env->ExceptionClear();
-        delete[] words;
-        return;
-    }
-
     jobjectArray javaLandChars = env->NewObjectArray(wordCount, charArrayClass, NULL);
     if (!javaLandChars) {
         env->ExceptionClear();
         delete[] words;
+        env->DeleteLocalRef(frequencyArray);
+        sendEmptyResult();
         return;
     }
 
     unsigned short *pos = words;
     const unsigned short *endPos = words + wordsCharsCount;
+    bool allocationFailed = false;
 
     for (int i = 0; i < wordCount && pos < endPos; ++i) {
         size_t count = 0;
@@ -155,6 +173,7 @@ static void nativeime_ResourceBinaryDictionary_getWords
         jcharArray jchr = env->NewCharArray((jsize) count);
         if (!jchr) {
             env->ExceptionClear();
+            allocationFailed = true;
             break;
         }
 
@@ -162,6 +181,7 @@ static void nativeime_ResourceBinaryDictionary_getWords
         if (!chr) {
             env->ExceptionClear();
             env->DeleteLocalRef(jchr);
+            allocationFailed = true;
             break;
         }
 
@@ -175,8 +195,15 @@ static void nativeime_ResourceBinaryDictionary_getWords
 
     delete[] words;
 
-    if (!env->ExceptionCheck()) {
+    if (allocationFailed || env->ExceptionCheck()) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(javaLandChars);
+        env->DeleteLocalRef(frequencyArray);
+        sendEmptyResult();
+    } else {
         env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, javaLandChars, frequencyArray);
+        env->DeleteLocalRef(javaLandChars);
+        env->DeleteLocalRef(frequencyArray);
     }
 }
 

--- a/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
+++ b/ime/dictionaries/jnidictionaryv2/src/main/jni/source/com_anysoftkeyboard_dictionaries_ResourceBinaryDictionary.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <memory>
 
 #include <jni.h>
 #include <string.h>
@@ -104,66 +105,45 @@ static jboolean nativeime_ResourceBinaryDictionary_isValidWord
     return result;
 }
 
-static void nativeime_ResourceBinaryDictionary_getWords
+static jboolean nativeime_ResourceBinaryDictionary_getWords
         (JNIEnv *env, jobject object, jlong dict, jobject getWordsCallback) {
     Dictionary *dictionary = reinterpret_cast<Dictionary *>(dict);
-    if (!dictionary || !getWordsCallback) return;
+    if (!dictionary || !getWordsCallback) return (jboolean) false;
+
+    int wordCount = 0, wordsCharsCount = 0;
+    dictionary->countWordsChars(wordCount, wordsCharsCount);
+    if (wordCount <= 0 || wordsCharsCount <= 0) return (jboolean) false;
 
     jclass charArrayClass = env->FindClass("[C");
     if (!charArrayClass) {
         env->ExceptionClear();
-        return;
+        return (jboolean) false;
     }
 
-    auto sendEmptyResult = [env, getWordsCallback, charArrayClass]() {
-        jobjectArray emptyWords = env->NewObjectArray(0, charArrayClass, NULL);
-        jintArray emptyFreqs = env->NewIntArray(0);
-        if (emptyWords && emptyFreqs) {
-            env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, emptyWords, emptyFreqs);
-        }
-        if (emptyWords) env->DeleteLocalRef(emptyWords);
-        if (emptyFreqs) env->DeleteLocalRef(emptyFreqs);
-    };
-
-    int wordCount = 0, wordsCharsCount = 0;
-    dictionary->countWordsChars(wordCount, wordsCharsCount);
-    if (wordCount <= 0 || wordsCharsCount <= 0) {
-        sendEmptyResult();
-        return;
-    }
-
-    unsigned short *words = new unsigned short[wordsCharsCount];
+    std::unique_ptr<unsigned short[]> words(new unsigned short[wordsCharsCount]);
     jintArray frequencyArray = env->NewIntArray(wordCount);
     if (!frequencyArray) {
         env->ExceptionClear();
-        delete[] words;
-        sendEmptyResult();
-        return;
+        return (jboolean) false;
+    }
+
+    jobjectArray javaLandChars = env->NewObjectArray(wordCount, charArrayClass, NULL);
+    if (!javaLandChars) {
+        env->ExceptionClear();
+        return (jboolean) false;
     }
 
     int *frequencies = env->GetIntArrayElements(frequencyArray, NULL);
     if (!frequencies) {
         env->ExceptionClear();
-        delete[] words;
-        env->DeleteLocalRef(frequencyArray);
-        sendEmptyResult();
-        return;
+        return (jboolean) false;
     }
 
-    dictionary->getWords(words, frequencies);
+    dictionary->getWords(words.get(), frequencies);
     env->ReleaseIntArrayElements(frequencyArray, frequencies, 0);
 
-    jobjectArray javaLandChars = env->NewObjectArray(wordCount, charArrayClass, NULL);
-    if (!javaLandChars) {
-        env->ExceptionClear();
-        delete[] words;
-        env->DeleteLocalRef(frequencyArray);
-        sendEmptyResult();
-        return;
-    }
-
-    unsigned short *pos = words;
-    const unsigned short *endPos = words + wordsCharsCount;
+    unsigned short *pos = words.get();
+    const unsigned short *endPos = words.get() + wordsCharsCount;
     bool allocationFailed = false;
 
     for (int i = 0; i < wordCount && pos < endPos; ++i) {
@@ -193,18 +173,13 @@ static void nativeime_ResourceBinaryDictionary_getWords
         env->DeleteLocalRef(jchr);
     }
 
-    delete[] words;
-
     if (allocationFailed || env->ExceptionCheck()) {
         env->ExceptionClear();
-        env->DeleteLocalRef(javaLandChars);
-        env->DeleteLocalRef(frequencyArray);
-        sendEmptyResult();
-    } else {
-        env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, javaLandChars, frequencyArray);
-        env->DeleteLocalRef(javaLandChars);
-        env->DeleteLocalRef(frequencyArray);
+        return (jboolean) false;
     }
+
+    env->CallVoidMethod(getWordsCallback, sGetWordsCallbackMethodId, javaLandChars, frequencyArray);
+    return (jboolean) true;
 }
 
 static void nativeime_ResourceBinaryDictionary_close
@@ -220,7 +195,7 @@ static JNINativeMethod gMethods[] = {
         {"closeNative",          "(J)V",                                                    (void *) nativeime_ResourceBinaryDictionary_close},
         {"getSuggestionsNative", "(J[II[C[IIIII[II)I",                                      (void *) nativeime_ResourceBinaryDictionary_getSuggestions},
         {"isValidWordNative",    "(J[CI)Z",                                                 (void *) nativeime_ResourceBinaryDictionary_isValidWord},
-        {"getWordsNative",       "(JLcom/anysoftkeyboard/dictionaries/GetWordsCallback;)V", (void *) nativeime_ResourceBinaryDictionary_getWords}
+        {"getWordsNative",       "(JLcom/anysoftkeyboard/dictionaries/GetWordsCallback;)Z", (void *) nativeime_ResourceBinaryDictionary_getWords}
 };
 
 static int registerNativeMethods(JNIEnv *env, const char *className,


### PR DESCRIPTION
Fixes #4763

### Summary of Changes
1. **Java Layer ()**: Guard  against uninitialized or closed native pointers (, , ) and return empty array fallbacks to the callback to maintain the async listener contract.
2. **Native C++ JNI Layer ()**: Add defensive JNI allocation null checks (, , , , ), clear pending exceptions with , enforce memory bounds (), and guarantee memory cleanup ().