### PR TITLE
[LLM] Upgrade Gradle wrapper to v9.5.1 and configure AGP build options

### DIFF
--- a/addons/gradle/language_pack_lib.gradle
+++ b/addons/gradle/language_pack_lib.gradle
@@ -13,7 +13,7 @@ def languageName = parent.name
 group "com.anysoftkeyboard.language.${languageName}"
 
 android {
-    namespace group
+    namespace "${group}.pack"
 }
 
 def generateIconsTask = tasks.register('generateLanguagePackIcons') {

--- a/addons/gradle/quicktext_pack_lib.gradle
+++ b/addons/gradle/quicktext_pack_lib.gradle
@@ -9,5 +9,5 @@ dependencies {
 group "com.anysoftkeyboard.quicktext.${parent.name}"
 
 android {
-    namespace group
+    namespace "${group}.pack"
 }

--- a/addons/gradle/theme_pack_lib.gradle
+++ b/addons/gradle/theme_pack_lib.gradle
@@ -9,5 +9,5 @@ dependencies {
 group "com.anysoftkeyboard.theme.${parent.name}"
 
 android {
-    namespace group
+    namespace "${group}.pack"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ android.defaults.buildfeatures.buildconfig=false
 android.defaults.buildfeatures.resvalues=false
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.sdk.defaultTargetSdkToCompileSdk=false
 # Can not use `configuration-cache` since we have build-listeners
 #org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 # Can not use `configuration-cache` since we have build-listeners
 #org.gradle.configuration-cache=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ android.defaults.buildfeatures.resvalues=false
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 android.sdk.defaultTargetSdkToCompileSdk=false
+android.enableAppCompileTimeRClass=false
 # Can not use `configuration-cache` since we have build-listeners
 #org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 android.sdk.defaultTargetSdkToCompileSdk=false
 android.enableAppCompileTimeRClass=false
+android.enableR8.resourceShrinking=true
 # Can not use `configuration-cache` since we have build-listeners
 #org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8.fullMode=true
 android.defaults.buildfeatures.buildconfig=false
+android.defaults.buildfeatures.resvalues=false
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 # Can not use `configuration-cache` since we have build-listeners

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ android.nonFinalResIds=false
 android.sdk.defaultTargetSdkToCompileSdk=false
 android.enableAppCompileTimeRClass=false
 android.enableR8.resourceShrinking=true
+android.builtInKotlinSupport=true
 # Can not use `configuration-cache` since we have build-listeners
 #org.gradle.configuration-cache=true
 

--- a/gradle/apk_module.gradle
+++ b/gradle/apk_module.gradle
@@ -29,29 +29,29 @@ static String calculateApplicationId(Project proj) {
 apply from: "${rootDir}/gradle/android_general.gradle"
 
 //copy bundles and APKs to output
-android.applicationVariants.configureEach { variant ->
-    def bundleProvider = tasks.named("sign${variant.name.capitalize()}Bundle")
-    def bundleCopy = tasks.register("copy${variant.name.capitalize()}Aab", Copy)
+androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+    def variantName = variant.name
+    def bundleCopy = tasks.register("copy${variantName.capitalize()}Aab", Copy)
     bundleCopy.configure { copier ->
-        copier.from "${project.buildDir.absolutePath}/outputs/bundle/${variant.name}/${project.name}-${variant.name}.aab"
+        copier.from "${project.buildDir.absolutePath}/outputs/bundle/${variantName}/${project.name}-${variantName}.aab"
         copier.destinationDir file("${rootDir.absolutePath}/outputs/bundle/")
-        copier.rename ".*", "${project.parent.name}_${variant.name}.aab"
-        copier.dependsOn bundleProvider
-    }
-    bundleProvider.configure {
-        finalizedBy(bundleCopy)
+        copier.rename ".*", "${project.parent.name}_${variantName}.aab"
     }
 
-    def assembleProvider = tasks.named("assemble${variant.name.capitalize()}")
-    def apkCopy = tasks.register("copy${variant.name.capitalize()}Apk", Copy)
+    def apkCopy = tasks.register("copy${variantName.capitalize()}Apk", Copy)
     apkCopy.configure { copier ->
-        copier.from "${project.buildDir.absolutePath}/outputs/apk/${variant.name}/${project.name}-${variant.name}.apk"
+        copier.from "${project.buildDir.absolutePath}/outputs/apk/${variantName}/${project.name}-${variantName}.apk"
         copier.destinationDir file("${rootDir.absolutePath}/outputs/apk/")
-        copier.rename ".*", "${project.parent.name}_${variant.name}.apk"
-        copier.dependsOn assembleProvider
+        copier.rename ".*", "${project.parent.name}_${variantName}.apk"
     }
-    assembleProvider.configure {
-        finalizedBy(apkCopy)
+
+    tasks.configureEach { task ->
+        if (task.name == "sign${variantName.capitalize()}Bundle") {
+            task.finalizedBy(bundleCopy)
+        }
+        if (task.name == "assemble${variantName.capitalize()}") {
+            task.finalizedBy(apkCopy)
+        }
     }
 }
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -26,22 +26,21 @@ if (project.plugins.hasPlugin('com.android.application') || project.plugins.hasP
     }
 }
 
-project.afterEvaluate {
+plugins.withId('com.android.application') {
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+        def name = variant.name
+        def testTaskName = "test${name.capitalize()}UnitTest"
 
-    if (project.plugins.hasPlugin('com.android.application')) {
-        android.applicationVariants.all { variant ->
-            def name = variant.name
-            def testTaskName = "test${name.capitalize()}UnitTest"
+        createJacocoReportTask(testTaskName, name)
+    }
+}
 
-            createJacocoReportTask(testTaskName, name)
-        }
-    } else if (project.plugins.hasPlugin('com.android.library')) {
-        android.libraryVariants.all { variant ->
-            def name = variant.name
-            def testTaskName = "test${name.capitalize()}UnitTest"
+plugins.withId('com.android.library') {
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+        def name = variant.name
+        def testTaskName = "test${name.capitalize()}UnitTest"
 
-            createJacocoReportTask(testTaskName, name)
-        }
+        createJacocoReportTask(testTaskName, name)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR upgrades the Gradle wrapper to v9.5.1 and modernizes AGP build configuration options across the repository.

### Summary of Changes:
1. **Gradle Wrapper Upgrade**:
   - Upgraded Gradle wrapper to .
2. **AGP Build Options**:
   - Disabled  by default ().
   - Explicitly configured .
   - Explicitly set  for compatibility with app module  statements (tracked in Issue #4837).
   - Enabled R8 optimized resource shrinking ().
   - Enabled AGP built-in Kotlin support ().
3. **AGP DSL Modernization & Unique Package Names**:
   - Migrated  and  from legacy variant APIs to .
   - Appended  to namespaces in , , and  to enforce unique module namespaces across library and APK subprojects.

### Verification:
- `./gradlew spotlessApply` passed cleanly.
- `./gradlew assembleDebug` passed cleanly.
- `./gradlew :ime:app:testDebugUnitTest --tests "com.anysoftkeyboard.keyboards.views.preview.KeyPreviewsManagerTest"` passed cleanly.