### PR TITLE
[LLM] Re-evaluate auto-capitalization when releasing Shift modifier key

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1200,8 +1200,14 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     super.onRelease(primaryCode);
     InputConnection ic = getCurrentInputConnection();
     if (primaryCode == KeyCodes.SHIFT) {
+      // Re-evaluate auto-capitalization if Shift was held as a momentary modifier (e.g., Shift+Delete, Shift+Enter)
+      final boolean isMomentary = mShiftKeyState.isMomentary();
       mShiftKeyState.onRelease(mMultiTapTimeout, mLongPressTimeout);
-      handleShift();
+      if (isMomentary) {
+        updateShiftStateNow();
+      } else {
+        handleShift();
+      }
     } else {
       if (mShiftKeyState.onOtherKeyReleased()) {
         updateShiftStateNow();

--- a/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/AnySoftKeyboard.java
@@ -1200,7 +1200,8 @@ public abstract class AnySoftKeyboard extends AnySoftKeyboardColorizeNavBar {
     super.onRelease(primaryCode);
     InputConnection ic = getCurrentInputConnection();
     if (primaryCode == KeyCodes.SHIFT) {
-      // Re-evaluate auto-capitalization if Shift was held as a momentary modifier (e.g., Shift+Delete, Shift+Enter)
+      // Re-evaluate auto-capitalization if Shift was held as a momentary modifier (e.g.,
+      // Shift+Delete, Shift+Enter)
       final boolean isMomentary = mShiftKeyState.isMomentary();
       mShiftKeyState.onRelease(mMultiTapTimeout, mLongPressTimeout);
       if (isMomentary) {

--- a/ime/app/src/main/java/com/anysoftkeyboard/utils/ModifierKeyState.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/utils/ModifierKeyState.java
@@ -118,6 +118,10 @@ public class ModifierKeyState {
     mConsumed = false;
   }
 
+  public boolean isMomentary() {
+    return mMomentaryPress;
+  }
+
   public boolean isPressed() {
     return mPhysicalState == PRESSING;
   }

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -517,6 +517,24 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
     mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.DELETE);
 
     Assert.assertEquals("", inputConnection.getCurrentTextInInputConnection());
+
+    mAnySoftKeyboardUnderTest.onRelease(KeyCodes.SHIFT);
+    Assert.assertTrue(mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().isShifted());
+  }
+
+  @Test
+  public void testShiftEnterRestoresAutoCaps() {
+    TestInputConnection inputConnection = getCurrentTestInputConnection();
+
+    mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
+    Assert.assertEquals("hello", inputConnection.getCurrentTextInInputConnection());
+
+    mAnySoftKeyboardUnderTest.onPress(KeyCodes.SHIFT);
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.ENTER);
+    mAnySoftKeyboardUnderTest.onRelease(KeyCodes.SHIFT);
+
+    Assert.assertEquals("hello\n", inputConnection.getCurrentTextInInputConnection());
+    Assert.assertTrue(mAnySoftKeyboardUnderTest.getCurrentKeyboardForTests().isShifted());
   }
 
   @Test

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -6,6 +6,7 @@ import static com.anysoftkeyboard.keyboards.ExternalAnyKeyboardTest.SIMPLE_Keybo
 import android.content.res.Configuration;
 import android.os.SystemClock;
 import android.text.InputType;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 import androidx.test.core.app.ApplicationProvider;
@@ -508,6 +509,9 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
 
   @Test
   public void testDeleteWholeWordWhenShiftAndBackSpaceArePressed() {
+    EditorInfo editorInfo = createEditorInfoTextWithSuggestionsForSetUp();
+    editorInfo.inputType |= TextUtils.CAP_MODE_SENTENCES;
+    simulateOnStartInputFlow(false, editorInfo);
     TestInputConnection inputConnection = getCurrentTestInputConnection();
     inputConnection.setRealCapsMode(true);
 
@@ -525,6 +529,9 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
 
   @Test
   public void testShiftEnterRestoresAutoCaps() {
+    EditorInfo editorInfo = createEditorInfoTextWithSuggestionsForSetUp();
+    editorInfo.inputType |= TextUtils.CAP_MODE_SENTENCES;
+    simulateOnStartInputFlow(false, editorInfo);
     TestInputConnection inputConnection = getCurrentTestInputConnection();
     inputConnection.setRealCapsMode(true);
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -509,6 +509,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
   @Test
   public void testDeleteWholeWordWhenShiftAndBackSpaceArePressed() {
     TestInputConnection inputConnection = getCurrentTestInputConnection();
+    inputConnection.setRealCapsMode(true);
 
     mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
     Assert.assertEquals("hello", inputConnection.getCurrentTextInInputConnection());
@@ -525,6 +526,7 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
   @Test
   public void testShiftEnterRestoresAutoCaps() {
     TestInputConnection inputConnection = getCurrentTestInputConnection();
+    inputConnection.setRealCapsMode(true);
 
     mAnySoftKeyboardUnderTest.simulateTextTyping("hello");
     Assert.assertEquals("hello", inputConnection.getCurrentTextInInputConnection());


### PR DESCRIPTION
Fixes shift state after momentary Shift key combinations such as Shift+Delete and Shift+Enter.

Fixes #2626