### PR TITLE
[LLM] Setup versioning and deployment promotion for AddOns v5.2-r1

### DIFF
--- a/.github/workflows/deployment_promote.yml
+++ b/.github/workflows/deployment_promote.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        refname: [main, release-branch-addons-v5.1-r2, release-branch-ime-v1.13-r1]
+        refname: [main, release-branch-addons-v5.2-r1, release-branch-ime-v1.13-r1]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6.0.3

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Sign up to beta-channel [here](https://play.google.com/apps/testing/com.menny.an
 - Each new commit to the release-branch will be published to 10% of the users.
 - Each day - if no new commit was pushed to the release-branch - we will increase the roll-out.
 
+### How to Start a New Release
+
+1. Cut a release branch from `main`: `release-branch-addons-vX.X-rX` (or `release-branch-ime-vX.X-rX`).
+2. In `addons/build.gradle` (or `ime/build.gradle`), bump `minor` and update `patchOffset` by appending `-<last_patch_number_of_previous_release>` to reset the patch counter.
+3. In `.github/workflows/deployment_promote.yml`, update `refname` in the matrix strategy to point to the new release branch.
+4. Submit a PR with these updates targeting the new `release-branch-...` base branch.
+
 ## Read more
 
 - Our fancy [web-site](https://anysoftkeyboard.github.io/)

--- a/addons/build.gradle
+++ b/addons/build.gradle
@@ -4,10 +4,10 @@ autoVersioning {
     enabled = rootProject.hasProperty("withAutoVersioning")
     buildCounterEnvKey = "BUILD_COUNT_FOR_VERSION"
     major = 5
-    minor = 1
+    minor = 2
     /*decrementing due to minor, every minor/major bump, this should be decremented*/
     /*the decrementing value should be similar to the last patch value of the previous version*/
-    patchOffset = -1512-1730-1196-455
+    patchOffset = -1512-1730-1196-455-101
     /*adding to build-counter value. Should NEVER change (unless build-counter resets).*/
     buildCounterOffset = 2590
     


### PR DESCRIPTION
Updates `addons/build.gradle` and `.github/workflows/deployment_promote.yml` to set up versioning (minor 2, patchOffset -101) and automated promotions for the AddOns v5.2-r1 release branch.