### PR TITLE
[LLM] Skip deployment requests when halt_deployment_marker is present

### DIFF
--- a/.github/actions/deploy-request/action.yml
+++ b/.github/actions/deploy-request/action.yml
@@ -26,12 +26,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check deployment halt marker
+      id: check_halt
+      shell: bash
+      run: |
+        if [[ -f "deployment/halt_deployment_marker" ]]; then
+          echo "Halt marker file found (deployment/halt_deployment_marker). Skipping deployment request."
+          echo "skip=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "skip=false" >> "${GITHUB_OUTPUT}"
+        fi
     - uses: bazel-contrib/setup-bazel@0.19.0
+      if: steps.check_halt.outputs.skip != 'true'
       with:
         bazelisk-cache: true
         disk-cache: ${{ github.workflow }}
         repository-cache: true
     - name: Request IME Deployment
+      if: steps.check_halt.outputs.skip != 'true'
       shell: bash
       run: |
         bazel run //js/github_deployments -- deploy \
@@ -44,6 +56,7 @@ runs:
           --shardName=ime \
           --deployMode="${{ inputs.deploy_mode }}"
     - name: Request add-ons Deployment
+      if: steps.check_halt.outputs.skip != 'true'
       shell: bash
       run: |
         bazel run //js/github_deployments -- deploy \


### PR DESCRIPTION
When a release branch reaches 100% rollout, a halt_deployment_marker file is pushed to the branch. Subsequent automated promotion runs on that branch fail with 409 Conflict because bot commits lack status checks.

This adds a check in .github/actions/deploy-request/action.yml to detect deployment/halt_deployment_marker and skip Bazel setup and deployment requests when present.