### PR TITLE
Fix keyboard copy/paste/cut buttons malfunctioning in certain apps (#4846)

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboard.java
@@ -315,21 +315,26 @@ public abstract class AnySoftKeyboardClipboard extends AnySoftKeyboardSwipeListe
     if (mClipboard.isOsClipboardEmpty()) {
       showToastMessage(R.string.clipboard_is_empty_toast, true);
     } else {
-      // let the OS perform the paste (it may be a complex clip, better not handle it)
-      sendDownUpKeyEvents(KeyEvent.KEYCODE_V, KeyEvent.META_CTRL_ON);
+      final InputConnection ic = getCurrentInputConnection();
+      if (ic == null || !ic.performContextMenuAction(android.R.id.paste)) {
+        // let the OS perform the paste (it may be a complex clip, better not handle it)
+        sendDownUpKeyEvents(KeyEvent.KEYCODE_V, KeyEvent.META_CTRL_ON);
+      }
     }
   }
 
   private void performCopy(boolean alsoCut) {
-    if (alsoCut) {
-      sendDownUpKeyEvents(KeyEvent.KEYCODE_X, KeyEvent.META_CTRL_ON);
-    } else {
-      sendDownUpKeyEvents(KeyEvent.KEYCODE_C, KeyEvent.META_CTRL_ON);
-      // showing toast, since there isn't any other UI feedback
-      // starting with Android 33, the OS shows a thing
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-        showToastMessage(R.string.clipboard_copy_done_toast, true);
+    final InputConnection ic = getCurrentInputConnection();
+    final int actionId = alsoCut ? android.R.id.cut : android.R.id.copy;
+    if (ic == null || !ic.performContextMenuAction(actionId)) {
+      if (alsoCut) {
+        sendDownUpKeyEvents(KeyEvent.KEYCODE_X, KeyEvent.META_CTRL_ON);
+      } else {
+        sendDownUpKeyEvents(KeyEvent.KEYCODE_C, KeyEvent.META_CTRL_ON);
       }
+    }
+    if (!alsoCut && Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      showToastMessage(R.string.clipboard_copy_done_toast, true);
     }
   }
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/TestInputConnection.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/TestInputConnection.java
@@ -386,8 +386,44 @@ public class TestInputConnection extends BaseInputConnection {
     return mLastEditorAction;
   }
 
+  private final List<Integer> mPerformedContextMenuActions = new ArrayList<>();
+  private boolean mFailPerformContextMenuAction;
+
+  public void setFailPerformContextMenuAction(boolean fail) {
+    mFailPerformContextMenuAction = fail;
+  }
+
+  public List<Integer> getPerformedContextMenuActions() {
+    return Collections.unmodifiableList(mPerformedContextMenuActions);
+  }
+
   @Override
   public boolean performContextMenuAction(int id) {
+    if (mFailPerformContextMenuAction) return false;
+    mPerformedContextMenuActions.add(id);
+    if (id == android.R.id.copy) {
+      var clipboard = (ClipboardManager) mIme.getSystemService(Context.CLIPBOARD_SERVICE);
+      final CharSequence selectedText = getSelectedText(0);
+      ClipData clipData = ClipData.newPlainText(selectedText, selectedText);
+      clipboard.setPrimaryClip(clipData);
+      return true;
+    } else if (id == android.R.id.cut) {
+      var clipboard = (ClipboardManager) mIme.getSystemService(Context.CLIPBOARD_SERVICE);
+      final CharSequence selectedText = getSelectedText(0);
+      ClipData clipData = ClipData.newPlainText(selectedText, selectedText);
+      clipboard.setPrimaryClip(clipData);
+      mInputText.delete(mCursorPosition, mSelectionEndPosition);
+      notifyTextChange(0);
+      return true;
+    } else if (id == android.R.id.paste) {
+      var clipboard = (ClipboardManager) mIme.getSystemService(Context.CLIPBOARD_SERVICE);
+      var primaryClip = clipboard.getPrimaryClip();
+      if (primaryClip != null && primaryClip.getItemCount() > 0) {
+        var clipboardText = primaryClip.getItemAt(0).coerceToStyledText(mIme);
+        commitTextAs(clipboardText, false, 1);
+      }
+      return true;
+    }
     return false;
   }
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
@@ -350,6 +350,77 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
   }
 
   @Test
+  public void testDirectClipboardCopyFallback() {
+    mAnySoftKeyboardUnderTest
+        .getTestInputConnection()
+        .setFailPerformContextMenuAction(true);
+    final String expectedText = "testing something very long";
+    mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
+    mAnySoftKeyboardUnderTest.setSelectedText(
+        "testing ".length(), "testing something".length(), true);
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_COPY);
+
+    List<KeyEvent> sentKeyEvents =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getSentKeyEvents();
+    KeyEvent releaseEvent = sentKeyEvents.get(sentKeyEvents.size() - 1);
+    KeyEvent downEvent = sentKeyEvents.get(sentKeyEvents.size() - 2);
+    Assert.assertEquals(KeyEvent.KEYCODE_C, downEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, downEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_DOWN, downEvent.getAction());
+    Assert.assertEquals(KeyEvent.KEYCODE_C, releaseEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, releaseEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_UP, releaseEvent.getAction());
+  }
+
+  @Test
+  public void testDirectClipboardCutFallback() {
+    mAnySoftKeyboardUnderTest
+        .getTestInputConnection()
+        .setFailPerformContextMenuAction(true);
+    final String expectedText = "testing something very long";
+    mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
+    mAnySoftKeyboardUnderTest.setSelectedText(
+        "testing ".length(), "testing something".length(), true);
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_CUT);
+
+    List<KeyEvent> sentKeyEvents =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getSentKeyEvents();
+    KeyEvent releaseEvent = sentKeyEvents.get(sentKeyEvents.size() - 1);
+    KeyEvent downEvent = sentKeyEvents.get(sentKeyEvents.size() - 2);
+    Assert.assertEquals(KeyEvent.KEYCODE_X, downEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, downEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_DOWN, downEvent.getAction());
+    Assert.assertEquals(KeyEvent.KEYCODE_X, releaseEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, releaseEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_UP, releaseEvent.getAction());
+  }
+
+  @Test
+  public void testDirectClipboardPasteFallback() {
+    mAnySoftKeyboardUnderTest
+        .getTestInputConnection()
+        .setFailPerformContextMenuAction(true);
+    final String expectedText = "some text";
+    mClipboardManager.setPrimaryClip(
+        new ClipData("ask", new String[] {"text"}, new ClipData.Item(expectedText)));
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_PASTE);
+
+    List<KeyEvent> sentKeyEvents =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getSentKeyEvents();
+    KeyEvent releaseEvent = sentKeyEvents.get(sentKeyEvents.size() - 1);
+    KeyEvent downEvent = sentKeyEvents.get(sentKeyEvents.size() - 2);
+    Assert.assertEquals(KeyEvent.KEYCODE_V, downEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, downEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_DOWN, downEvent.getAction());
+    Assert.assertEquals(KeyEvent.KEYCODE_V, releaseEvent.getKeyCode());
+    Assert.assertEquals(KeyEvent.META_CTRL_ON, releaseEvent.getMetaState());
+    Assert.assertEquals(KeyEvent.ACTION_UP, releaseEvent.getAction());
+  }
+
+  @Test
   @Config(sdk = Build.VERSION_CODES.Q)
   public void testClipboardShowsOptionsPasteFirstItemWhenOsClipboardIsEmpty() {
     final String expectedText = "testing something very long";

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
@@ -351,9 +351,7 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
 
   @Test
   public void testDirectClipboardCopyFallback() {
-    mAnySoftKeyboardUnderTest
-        .getTestInputConnection()
-        .setFailPerformContextMenuAction(true);
+    mAnySoftKeyboardUnderTest.getTestInputConnection().setFailPerformContextMenuAction(true);
     final String expectedText = "testing something very long";
     mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
     mAnySoftKeyboardUnderTest.setSelectedText(
@@ -375,9 +373,7 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
 
   @Test
   public void testDirectClipboardCutFallback() {
-    mAnySoftKeyboardUnderTest
-        .getTestInputConnection()
-        .setFailPerformContextMenuAction(true);
+    mAnySoftKeyboardUnderTest.getTestInputConnection().setFailPerformContextMenuAction(true);
     final String expectedText = "testing something very long";
     mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
     mAnySoftKeyboardUnderTest.setSelectedText(
@@ -399,9 +395,7 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
 
   @Test
   public void testDirectClipboardPasteFallback() {
-    mAnySoftKeyboardUnderTest
-        .getTestInputConnection()
-        .setFailPerformContextMenuAction(true);
+    mAnySoftKeyboardUnderTest.getTestInputConnection().setFailPerformContextMenuAction(true);
     final String expectedText = "some text";
     mClipboardManager.setPrimaryClip(
         new ClipData("ask", new String[] {"text"}, new ClipData.Item(expectedText)));

--- a/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/ime/AnySoftKeyboardClipboardTest.java
@@ -288,6 +288,35 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
     Assert.assertEquals(2, latestAlertDialog.getListView().getAdapter().getCount());
     Assert.assertTrue(Shadows.shadowOf(latestAlertDialog.getListView()).performItemClick(0));
 
+    List<Integer> contextMenuActions =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getPerformedContextMenuActions();
+    Assert.assertEquals(3, contextMenuActions.size());
+    Assert.assertEquals(
+        android.R.id.paste, contextMenuActions.get(contextMenuActions.size() - 1).intValue());
+  }
+
+  @Test
+  public void testClipboardShowsOptionsPasteFirstItemFallback() {
+    mAnySoftKeyboardUnderTest.getTestInputConnection().setFailPerformContextMenuAction(true);
+    final String expectedText = "testing something very long";
+    mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
+    mAnySoftKeyboardUnderTest.setSelectedText(
+        "testing ".length(), "testing something very".length(), true);
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_COPY);
+    mAnySoftKeyboardUnderTest.setSelectedText(0, "testing ".length(), true);
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_COPY);
+
+    // moving the cursor to the end of the textbox.
+    mAnySoftKeyboardUnderTest.setSelectedText(expectedText.length(), expectedText.length(), true);
+
+    // now, we'll do long-press
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_PASTE_POPUP);
+
+    final AlertDialog latestAlertDialog = GeneralDialogTestUtil.getLatestShownDialog();
+    Assert.assertNotNull(latestAlertDialog);
+    Assert.assertEquals(2, latestAlertDialog.getListView().getAdapter().getCount());
+    Assert.assertTrue(Shadows.shadowOf(latestAlertDialog.getListView()).performItemClick(0));
+
     List<KeyEvent> sentKeyEvents =
         mAnySoftKeyboardUnderTest.getTestInputConnection().getSentKeyEvents();
     KeyEvent releaseEvent = sentKeyEvents.get(sentKeyEvents.size() - 1);
@@ -298,6 +327,26 @@ public class AnySoftKeyboardClipboardTest extends AnySoftKeyboardBaseTest {
     Assert.assertEquals(KeyEvent.KEYCODE_V, releaseEvent.getKeyCode());
     Assert.assertEquals(KeyEvent.META_CTRL_ON, releaseEvent.getMetaState());
     Assert.assertEquals(KeyEvent.ACTION_UP, releaseEvent.getAction());
+  }
+
+  @Test
+  public void testClipboardCopyAndCutUseContextMenuAction() {
+    final String expectedText = "testing something very long";
+    mAnySoftKeyboardUnderTest.simulateTextTyping(expectedText);
+    mAnySoftKeyboardUnderTest.setSelectedText(
+        "testing ".length(), "testing something".length(), true);
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_COPY);
+    List<Integer> contextMenuActions =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getPerformedContextMenuActions();
+    Assert.assertEquals(1, contextMenuActions.size());
+    Assert.assertEquals(android.R.id.copy, contextMenuActions.get(0).intValue());
+
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.CLIPBOARD_CUT);
+    contextMenuActions =
+        mAnySoftKeyboardUnderTest.getTestInputConnection().getPerformedContextMenuActions();
+    Assert.assertEquals(2, contextMenuActions.size());
+    Assert.assertEquals(android.R.id.cut, contextMenuActions.get(1).intValue());
   }
 
   @Test


### PR DESCRIPTION
Fixes #4846

### Problem
Copy, Cut, and Paste keyboard operations malfunctioned in certain applications (such as Obtainium) and on modern Android versions because sending synthetic `Ctrl+V`, `Ctrl+C`, and `Ctrl+X` hardware key events is ignored by custom text views or frameworks.

### Solution
- Updated `AnySoftKeyboardClipboard.java` to invoke `InputConnection.performContextMenuAction(android.R.id.paste / copy / cut)` as the primary mechanism for clipboard actions.
- Preserved fallback to sending synthetic `Ctrl+V / Ctrl+C / Ctrl+X` key events if `performContextMenuAction` returns `false` (supporting terminal emulators or custom views expecting physical key shortcuts).
- Updated `TestInputConnection` and `AnySoftKeyboardClipboardTest` to verify context menu actions and fallback behavior.