### PR TITLE
[LLM] Add workflow_dispatch trigger to checks, localization, emoji, and deployment_promote workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,7 @@ on:
       - deployment/halt_deployment_marker
     branches:
       - '*'
+  workflow_dispatch:
 env:
   TERM: dumb
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/.github/workflows/deployment_promote.yml
+++ b/.github/workflows/deployment_promote.yml
@@ -3,6 +3,7 @@ name: deployment-promote
 on:
   schedule:
     - cron: '04 04 * * *'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/localization_update.yml
+++ b/.github/workflows/localization_update.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/localization_update.yml'
       - 'js/localization_tools/**'
       - 'crowdin.yml'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update_emoji_layouts.yml
+++ b/.github/workflows/update_emoji_layouts.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/workflows/update_emoji_layouts.yml'
       - 'emojis/**'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Description

Adds `workflow_dispatch` trigger to the following GitHub workflows:
- `.github/workflows/checks.yml`
- `.github/workflows/deployment_promote.yml`
- `.github/workflows/localization_update.yml`
- `.github/workflows/update_emoji_layouts.yml`

This allows maintainers to manually trigger these workflow jobs directly from GitHub UI or via the GitHub API on demand.