### PR TITLE
[LLM] Upgrade Cassandra action to v0.7.0

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: AI Code Review
-        uses: menny/cassandra@v0.6.0
+        uses: menny/cassandra@v0.7.0
         with:
           reviewer_github_token: ${{ secrets.AI_CODE_REVIEW_GH_TOKEN }}
           provider_api_key: ${{ secrets.GEMINI_2_5_FLASH_API_KEY }}

--- a/.github/workflows/localization_review.yml
+++ b/.github/workflows/localization_review.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - name: AI Translation Review
-        uses: menny/cassandra@v0.6.0
+        uses: menny/cassandra@v0.7.0
         with:
           reviewer_github_token: ${{ secrets.AI_CODE_REVIEW_GH_TOKEN }}
           provider_api_key: ${{ secrets.GEMINI_2_5_FLASH_API_KEY }}


### PR DESCRIPTION
Upgrades menny/cassandra action to version v0.7.0 in GitHub workflows.