### PR TITLE
[addons.languages.russian2] 'Ш' and 'Щ' size fix

### DIFF
--- a/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
@@ -3,7 +3,7 @@
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
           android:keyWidth="10%p">
 
-    <Row android:keyWidth="8.33%p">
+    <Row android:keyWidth="9.09%p">
         <!-- йцукенгшщзхъ    -->
         <Key android:codes="1081" android:keyLabel="й" android:popupCharacters="1їӣӥ" android:keyEdgeFlags="left"/>
         <Key android:codes="1094" android:keyLabel="ц" android:popupCharacters="2ћџҵ"/>

--- a/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
@@ -12,11 +12,11 @@
         <Key android:codes="1077" android:keyLabel="е" android:popupCharacters="5ёјҽҿӗәӛ"/>
         <Key android:codes="1085" android:keyLabel="н" android:popupCharacters="6њңҥӈ"/>
         <Key android:codes="1075" android:keyLabel="г" android:popupCharacters="7ґѓғҕ"/>
-        <Key android:codes="1096" android:keyLabel="ш" android:popupCharacters="8һѡѽѿ"/>
-        <Key android:codes="1097" android:keyLabel="щ" android:popupCharacters="9"/>
-        <Key android:codes="1079" android:keyLabel="з" android:popupCharacters="0ѕҙӟӡѯ"/>
-        <Key android:codes="1093" android:keyLabel="х" android:popupCharacters="ҩҳ"/>
-        <Key android:codes="1098" android:keyLabel="ъ" android:popupCharacters="ѣ҂҃҄҅҆" android:keyEdgeFlags="right"/>
+        <Key android:codes="1096" android:keyLabel="ш" android:popupCharacters="8һѡѽѿ" android:keyWidth="8.95%p"/>
+        <Key android:codes="1097" android:keyLabel="щ" android:popupCharacters="9" android:keyWidth="8.95%p"/>
+        <Key android:codes="1079" android:keyLabel="з" android:popupCharacters="0ѕҙӟӡѯ" android:keyWidth="7.92%p"/>
+        <Key android:codes="1093" android:keyLabel="х" android:popupCharacters="ҩҳ" android:keyWidth="7.92%p"/>
+        <Key android:codes="1098" android:keyLabel="ъ" android:popupCharacters="ѣ҂҃҄҅҆" android:keyWidth="7.92%p" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/cyrillic_qwerty.xml
@@ -3,7 +3,7 @@
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
           android:keyWidth="10%p">
 
-    <Row android:keyWidth="9.09%p">
+    <Row android:keyWidth="8.33%p">
         <!-- йцукенгшщзхъ    -->
         <Key android:codes="1081" android:keyLabel="й" android:popupCharacters="1їӣӥ" android:keyEdgeFlags="left"/>
         <Key android:codes="1094" android:keyLabel="ц" android:popupCharacters="2ћџҵ"/>

--- a/addons/languages/russian2/pack/src/main/res/xml/russian_english_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/russian_english_qwerty.xml
@@ -10,11 +10,11 @@
         <Key android:codes="е" android:popupCharacters="tеё"/>
         <Key android:codes="н" android:popupCharacters="yн"/>
         <Key android:codes="г" android:popupCharacters="uг"/>
-        <Key android:codes="ш" android:popupCharacters="iш"/>
-        <Key android:codes="щ" android:popupCharacters="oщ"/>
-        <Key android:codes="з" android:popupCharacters="pз"/>
-        <Key android:codes="х" android:popupCharacters="[{х"/>
-        <Key android:codes="ъ" android:popupCharacters="]}ъ" android:keyEdgeFlags="right"/>
+        <Key android:codes="ш" android:popupCharacters="iш" android:keyWidth="8.95%p"/>
+        <Key android:codes="щ" android:popupCharacters="oщ" android:keyWidth="8.95%p"/>
+        <Key android:codes="з" android:popupCharacters="pз" android:keyWidth="7.92%p"/>
+        <Key android:codes="х" android:popupCharacters="[{х" android:keyWidth="7.92%p"/>
+        <Key android:codes="ъ" android:popupCharacters="]}ъ" android:keyWidth="7.92%p" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
@@ -16,9 +16,9 @@
         <Key android:codes="1075" android:keyLabel="" android:popupCharacters="7" ask:hintLabel="7"/>
         <Key android:codes="1096" android:keyLabel="" android:popupCharacters="8" ask:hintLabel="8" android:keyWidth="8.95%p"/>
         <Key android:codes="1097" android:keyLabel="" android:popupCharacters="9" ask:hintLabel="9" android:keyWidth="8.95%p"/>
-        <Key android:codes="1079" android:keyLabel="" android:popupCharacters="0" android:keyWidth="7.92%p" ask:hintLabel="0"/>
-        <Key android:codes="1093" android:keyLabel="" android:popupCharacters="" android:keyWidth="7.92%p" ask:hintLabel=""/>
-        <Key android:codes="1098" android:keyLabel="" android:popupCharacters="" android:keyWidth="7.92%p" android:keyEdgeFlags="right"/>
+        <Key android:codes="1079" android:keyLabel="" android:popupCharacters="0" ask:hintLabel="0" android:keyWidth="7.92%p"/>
+        <Key android:codes="1093" android:keyLabel="" android:popupCharacters="" ask:hintLabel="" android:keyWidth="7.92%p"/>
+        <Key android:codes="1098" android:keyLabel="" android:popupCharacters="" android:keyEdgeFlags="right" android:keyWidth="7.92%p"/>
     </Row>
 
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
@@ -5,7 +5,7 @@
     android:keyWidth="10%p"
     >
 
-    <Row android:keyWidth="9.09%p">
+    <Row android:keyWidth="8.33%p">
         <!-- &#1081;&#1094;&#1091;&#1082;&#1077;&#1085;&#1075;&#1096;&#1097;&#1079;&#1093;&#1098; -->
         <Key android:codes="1081" android:keyLabel="" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="1094" android:keyLabel="" android:popupCharacters="2²₂" ask:hintLabel="2"/>
@@ -14,11 +14,11 @@
         <Key android:codes="1077" android:keyLabel="" android:popupCharacters="ё5" ask:hintLabel="ё5"/>
         <Key android:codes="1085" android:keyLabel="" android:popupCharacters="6" ask:hintLabel="6"/>
         <Key android:codes="1075" android:keyLabel="" android:popupCharacters="7" ask:hintLabel="7"/>
-        <Key android:codes="1096" android:keyLabel="" android:popupCharacters="8" ask:hintLabel="8"/>
-        <Key android:codes="1097" android:keyLabel="" android:popupCharacters="9" ask:hintLabel="9"/>
-        <Key android:codes="1079" android:keyLabel="" android:popupCharacters="0" ask:hintLabel="0"/>
-        <Key android:codes="1093" android:keyLabel="" android:popupCharacters="" ask:hintLabel=""/>
-        <Key android:codes="1098" android:keyLabel="" android:popupCharacters="" android:keyEdgeFlags="right"/>
+        <Key android:codes="1096" android:keyLabel="" android:popupCharacters="8" ask:hintLabel="8" android:keyWidth="8.95%p"/>
+        <Key android:codes="1097" android:keyLabel="" android:popupCharacters="9" ask:hintLabel="9" android:keyWidth="8.95%p"/>
+        <Key android:codes="1079" android:keyLabel="" android:popupCharacters="0" android:keyWidth="7.92%p" ask:hintLabel="0"/>
+        <Key android:codes="1093" android:keyLabel="" android:popupCharacters="" android:keyWidth="7.92%p" ask:hintLabel=""/>
+        <Key android:codes="1098" android:keyLabel="" android:popupCharacters="" android:keyWidth="7.92%p" android:keyEdgeFlags="right"/>
     </Row>
 
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
@@ -6,7 +6,7 @@
     >
 
     <Row android:keyWidth="8.33%p">
-        <!-- &#1081;&#1094;&#1091;&#1082;&#1077;&#1085;&#1075;&#1096;&#1097;&#1079;&#1093;&#1098; -->
+        <!-- йцукенгшщзхъ    -->
         <Key android:codes="1081" android:keyLabel="" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="1094" android:keyLabel="" android:popupCharacters="2²₂" ask:hintLabel="2"/>
         <Key android:codes="1091" android:keyLabel="" android:popupCharacters="3³₃" ask:hintLabel="3"/>
@@ -22,7 +22,7 @@
     </Row>
 
     <Row android:keyWidth="9.09%p">
-        <!-- &#1092;&#1099;&#1074;&#1072;&#1087;&#1088;&#1086;&#1083;&#1076;&#1078;&#1101; -->
+        <!-- фывапролджэ -->
         <Key android:codes="1092" android:keyLabel="" android:popupCharacters="\@" ask:hintLabel="\@" android:keyEdgeFlags="left"/>
         <Key android:codes="1099" android:keyLabel="" android:popupCharacters="$" ask:hintLabel="$"/>
         <Key android:codes="1074" android:keyLabel="" android:popupCharacters="#%" ask:hintLabel="# %"/>
@@ -37,7 +37,7 @@
     </Row>
 
     <Row android:keyWidth="9.09%p">
-        <!-- &#1103;&#1095;&#1089;&#1084;&#1080;&#1090;&#1100;&#1073;&#1102; -->
+        <!-- ячсмитьбю -->
         <Key android:codes="-1" android:isModifier="true" android:isSticky="true" android:keyEdgeFlags="left"/>
         <Key android:codes="1103" android:keyLabel="" android:popupCharacters="/÷" ask:hintLabel="/"/>
         <Key android:codes="1095" android:keyLabel="" android:popupCharacters="*·×" ask:hintLabel="*"/>

--- a/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
+++ b/addons/languages/russian2/pack/src/main/res/xml/russian_qwerty.xml
@@ -5,7 +5,7 @@
     android:keyWidth="10%p"
     >
 
-    <Row android:keyWidth="8.33%p">
+    <Row android:keyWidth="9.09%p">
         <!-- &#1081;&#1094;&#1091;&#1082;&#1077;&#1085;&#1075;&#1096;&#1097;&#1079;&#1093;&#1098; -->
         <Key android:codes="1081" android:keyLabel="" android:popupCharacters="1¹₁" ask:hintLabel="1" android:keyEdgeFlags="left"/>
         <Key android:codes="1094" android:keyLabel="" android:popupCharacters="2²₂" ask:hintLabel="2"/>


### PR DESCRIPTION
Fix #4874 

Change android:keyWidth from "8.33%p" to "8.95%p" to fix 'small' keys 'Ш' and 'Щ' while Shift pressed

More details:
1. Restore original keyWidth of topmost row to 8.33%p
2. Set 'Ш' and 'Щ' keys' keyWidth to 8.95%p (8.90%p causes only 'Щ' to 'shrink', 9.00%p moves 'Ъ' halfway behind the screen)
3. To compensate extra 1.24%p row width, divide it and subtract from next keys (1.24%p / 3 ~ 0.41%p)

<details>
<summary>Before</summary>
<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/25d557ef-d575-4023-9f0c-a7127dc291ca" />
</details>



<details>
<summary>After</summary>
<img width="720" height="1280" alt="image" src="https://github.com/user-attachments/assets/257bed7c-e0fe-447f-bf7f-d21887938df1" />
</details>


