### PR TITLE
[LLM] Fix duplicated text on Enter / digit-in-word with suggestions enabled

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -732,8 +732,13 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
     }
 
     if (!handledOutputToInputConnection) {
-      for (char c : Character.toChars(primaryCode)) {
-        sendKeyChar(c);
+      if (ic != null) {
+        // sendKeyChar's KeyEvent makes some editors re-insert the just-committed word.
+        ic.commitText(new String(Character.toChars(primaryCode)), 1);
+      } else {
+        for (char c : Character.toChars(primaryCode)) {
+          sendKeyChar(c);
+        }
       }
     }
 

--- a/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/ime/AnySoftKeyboardSuggestions.java
@@ -1135,7 +1135,11 @@ public abstract class AnySoftKeyboardSuggestions extends AnySoftKeyboardKeyboard
 
       // Follow it with a space
       if (withAutoSpaceEnabled && (index == 0 || !typedWord.isAtTagsSearchState())) {
-        sendKeyChar((char) KeyCodes.SPACE);
+        if (ic != null) {
+          ic.commitText(" ", 1);
+        } else {
+          sendKeyChar((char) KeyCodes.SPACE);
+        }
         setSpaceTimeStamp(true);
       }
       // Add the word to the auto dictionary if it's not a known word

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardGimmicksTest.java
@@ -407,46 +407,29 @@ public class AnySoftKeyboardGimmicksTest extends AnySoftKeyboardBaseTest {
   }
 
   @Test
-  public void testSendsENTERKeyEventIfShiftIsNotPressedAndImeDoesNotHaveAction() {
+  public void testCommitsNewlineForPlainEnterWithoutAction() {
+    // Plain ENTER (no shift, no IME action) must be committed via commitText("\n", 1) and NOT via
+    // sendKeyEvent(KEYCODE_ENTER). Some editors handle KEYCODE_ENTER by re-inserting the just-
+    // committed composing text, producing a duplicate word on the new line.
     TestInputConnection inputConnection = getCurrentTestInputConnection();
     mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.ENTER);
 
-    ArgumentCaptor<KeyEvent> keyEventArgumentCaptor = ArgumentCaptor.forClass(KeyEvent.class);
-    Mockito.verify(inputConnection, Mockito.times(2))
-        .sendKeyEvent(keyEventArgumentCaptor.capture());
-
-    Assert.assertEquals(2 /* down and up */, keyEventArgumentCaptor.getAllValues().size());
-    Assert.assertEquals(
-        KeyEvent.KEYCODE_ENTER, keyEventArgumentCaptor.getAllValues().get(0).getKeyCode());
-    Assert.assertEquals(
-        KeyEvent.ACTION_DOWN, keyEventArgumentCaptor.getAllValues().get(0).getAction());
-    Assert.assertEquals(
-        KeyEvent.KEYCODE_ENTER, keyEventArgumentCaptor.getAllValues().get(1).getKeyCode());
-    Assert.assertEquals(
-        KeyEvent.ACTION_UP, keyEventArgumentCaptor.getAllValues().get(1).getAction());
-    // and never the ENTER character
+    Mockito.verify(inputConnection, Mockito.never()).sendKeyEvent(Mockito.any(KeyEvent.class));
+    Mockito.verify(inputConnection).commitText("\n", 1);
     Assert.assertEquals("\n", inputConnection.getCurrentTextInInputConnection());
   }
 
   @Test
-  public void testSendsENTERKeyEventIfShiftIsPressedAndImeDoesNotHaveAction() {
+  public void testCommitsNewlineWhenShiftHeldButNoImeAction() {
+    // Shift alone without an IME action still means "insert a newline". The Shift+Enter
+    // KeyEvent path in AnySoftKeyboard.onNonFunctionKey requires mShiftKeyState.isPressed(); a
+    // simulateKeyPress here does not press shift, so we fall through to handleSeparator and must
+    // commit "\n" — same reason as the plain-ENTER case above.
     TestInputConnection inputConnection = getCurrentTestInputConnection();
     mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.ENTER);
 
-    ArgumentCaptor<KeyEvent> keyEventArgumentCaptor = ArgumentCaptor.forClass(KeyEvent.class);
-    Mockito.verify(inputConnection, Mockito.times(2))
-        .sendKeyEvent(keyEventArgumentCaptor.capture());
-
-    Assert.assertEquals(2 /* down and up */, keyEventArgumentCaptor.getAllValues().size());
-    Assert.assertEquals(
-        KeyEvent.KEYCODE_ENTER, keyEventArgumentCaptor.getAllValues().get(0).getKeyCode());
-    Assert.assertEquals(
-        KeyEvent.ACTION_DOWN, keyEventArgumentCaptor.getAllValues().get(0).getAction());
-    Assert.assertEquals(
-        KeyEvent.KEYCODE_ENTER, keyEventArgumentCaptor.getAllValues().get(1).getKeyCode());
-    Assert.assertEquals(
-        KeyEvent.ACTION_UP, keyEventArgumentCaptor.getAllValues().get(1).getAction());
-    // and we have ENTER in the input-connection
+    Mockito.verify(inputConnection, Mockito.never()).sendKeyEvent(Mockito.any(KeyEvent.class));
+    Mockito.verify(inputConnection).commitText("\n", 1);
     Assert.assertEquals("\n", inputConnection.getCurrentTextInInputConnection());
   }
 

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
@@ -1,0 +1,266 @@
+package com.anysoftkeyboard;
+
+import android.view.inputmethod.EditorInfo;
+import com.anysoftkeyboard.api.KeyCodes;
+import com.anysoftkeyboard.rx.TestRxSchedulers;
+import com.anysoftkeyboard.test.SharedPrefsHelper;
+import com.menny.android.anysoftkeyboard.R;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Static repro for two reported ASK bugs (evidence-gathering pass, no fix):
+ * - typing letter+digit(+letter) can produce an extra letter (k8 -> k8k, k8s -> k8ks)
+ * - typing a word then Enter can duplicate the word on the new line
+ *
+ * <p>Each scenario dumps every InputConnection call ASK emits, plus WordComposer state and
+ * the resulting editor text/composing range after each key, then asserts the final text.
+ */
+@RunWith(AnySoftKeyboardRobolectricTestRunner.class)
+public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest {
+
+  private final List<String> mTrace = new ArrayList<>();
+  private TestInputConnection mIc;
+
+  @Before
+  public void configurePrefs() {
+    // Match the reporter's real config: suggestions on, autocorrect off,
+    // auto-pick aggressiveness off, next-word suggestions on, no suggestion restart.
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_next_word_suggestion_aggressiveness, "medium_aggressiveness");
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, false);
+    SharedPrefsHelper.setPrefsValue(R.string.settings_key_quick_fix, false);
+    TestRxSchedulers.drainAllTasks();
+
+    mIc = getCurrentTestInputConnection();
+    installIcTracers(mIc);
+  }
+
+  private void installIcTracers(TestInputConnection ic) {
+    Mockito.doAnswer(recording("setComposingText", ic)).when(ic)
+        .setComposingText(Mockito.any(), Mockito.anyInt());
+    Mockito.doAnswer(recording("commitText", ic)).when(ic)
+        .commitText(Mockito.any(), Mockito.anyInt());
+    Mockito.doAnswer(recording("finishComposingText", ic)).when(ic).finishComposingText();
+    Mockito.doAnswer(recording("setComposingRegion", ic)).when(ic)
+        .setComposingRegion(Mockito.anyInt(), Mockito.anyInt());
+    Mockito.doAnswer(recording("beginBatchEdit", ic)).when(ic).beginBatchEdit();
+    Mockito.doAnswer(recording("endBatchEdit", ic)).when(ic).endBatchEdit();
+    Mockito.doAnswer(recording("sendKeyEvent", ic)).when(ic).sendKeyEvent(Mockito.any());
+    Mockito.doAnswer(recording("deleteSurroundingText", ic)).when(ic)
+        .deleteSurroundingText(Mockito.anyInt(), Mockito.anyInt());
+    Mockito.doAnswer(recording("setSelection", ic)).when(ic)
+        .setSelection(Mockito.anyInt(), Mockito.anyInt());
+  }
+
+  private org.mockito.stubbing.Answer<Object> recording(String label, TestInputConnection ic) {
+    return (InvocationOnMock inv) -> {
+      Object result = inv.callRealMethod();
+      String args = Arrays.toString(inv.getArguments());
+      TestInputConnection.CompleteState st = ic.getCurrentState();
+      mTrace.add(
+          String.format(
+              "  IC %-22s args=%s -> text=%s sel=[%d,%d] composing=[%d,%d]",
+              label,
+              args,
+              quote(st.text),
+              st.selectionStart,
+              st.selectionEnd,
+              st.candidateStart,
+              st.candidateEnd));
+      return result;
+    };
+  }
+
+  private void mark(String label) {
+    mTrace.add("== " + label + " ==");
+  }
+
+  private void afterKey(String key) {
+    TestInputConnection.CompleteState st = mIc.getCurrentState();
+    mTrace.add(
+        String.format(
+            "  after key '%s' -> text=%s sel=[%d,%d] composing=[%d,%d] predictionOn=%s",
+            key,
+            quote(st.text),
+            st.selectionStart,
+            st.selectionEnd,
+            st.candidateStart,
+            st.candidateEnd,
+            mAnySoftKeyboardUnderTest.isPredictionOn()));
+  }
+
+  private static String quote(CharSequence s) {
+    if (s == null) return "null";
+    return "\"" + s.toString().replace("\n", "\\n") + "\"";
+  }
+
+  private void dumpTraceOnFailure(String scenario) {
+    System.out.println("---- TRACE: " + scenario + " ----");
+    for (String line : mTrace) System.out.println(line);
+    System.out.println("---- END TRACE ----");
+  }
+
+  private void typeChars(String s) {
+    for (char c : s.toCharArray()) {
+      mark("key '" + c + "'");
+      mAnySoftKeyboardUnderTest.simulateKeyPress(c);
+      afterKey(String.valueOf(c));
+    }
+  }
+
+  private void pressEnter() {
+    mark("key ENTER");
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.ENTER);
+    afterKey("ENTER");
+  }
+
+  private void pressSpace() {
+    mark("key SPACE");
+    mAnySoftKeyboardUnderTest.simulateKeyPress(KeyCodes.SPACE);
+    afterKey("SPACE");
+  }
+
+  private void assertEditorText(String scenario, String expected) {
+    String actual = mIc.getCurrentTextInInputConnection();
+    if (!expected.equals(actual)) {
+      dumpTraceOnFailure(scenario);
+      Assert.fail(
+          "scenario=" + scenario + " expected=" + quote(expected) + " actual=" + quote(actual));
+    } else {
+      // Even on pass, dump the trace so we can see what ASK emitted.
+      dumpTraceOnFailure(scenario + " (PASS)");
+    }
+  }
+
+  @Test
+  public void a_k_then_8_then_s_should_produce_k8s() {
+    typeChars("k8s");
+    assertEditorText("k8s", "k8s");
+  }
+
+  @Test
+  public void b_k_then_8_should_produce_k8() {
+    typeChars("k8");
+    assertEditorText("k8", "k8");
+  }
+
+  @Test
+  public void c_a_then_1_should_produce_a1() {
+    typeChars("a1");
+    assertEditorText("a1", "a1");
+  }
+
+  @Test
+  public void d_b_then_1_should_produce_b1() {
+    typeChars("b1");
+    assertEditorText("b1", "b1");
+  }
+
+  @Test
+  public void e_i_then_1_should_produce_i1() {
+    typeChars("i1");
+    assertEditorText("i1", "i1");
+  }
+
+  @Test
+  public void f_o_then_1_should_produce_o1() {
+    typeChars("o1");
+    assertEditorText("o1", "o1");
+  }
+
+  @Test
+  public void g_hello_then_enter_should_produce_hello_newline() {
+    typeChars("hello");
+    pressEnter();
+    assertEditorText("hello+ENTER", "hello\n");
+  }
+
+  @Test
+  public void h_gibberish_then_enter_should_produce_gibberish_newline() {
+    typeChars("qzxv");
+    pressEnter();
+    assertEditorText("qzxv+ENTER", "qzxv\n");
+  }
+
+  @Test
+  public void i_hello_then_space_should_produce_hello_space() {
+    typeChars("hello");
+    pressSpace();
+    assertEditorText("hello+SPACE", "hello ");
+  }
+
+  // --- Post-fix regression: separator must be committed via commitText, not sendKeyEvent. ---
+
+  private long countTraceMatches(String needle) {
+    return mTrace.stream().filter(line -> line.contains(needle)).count();
+  }
+
+  @Test
+  public void j_digit_separator_uses_commitText_not_sendKeyEvent() {
+    typeChars("k8s");
+    dumpTraceOnFailure("k8s trace check");
+    Assert.assertEquals(
+        "digit separator '8' must be committed via commitText",
+        1L,
+        countTraceMatches("IC commitText             args=[8, 1]"));
+    Assert.assertEquals(
+        "no sendKeyEvent should fire for the digit separator",
+        0L,
+        countTraceMatches("IC sendKeyEvent"));
+  }
+
+  @Test
+  public void k_enter_as_newline_uses_commitText_not_sendKeyEvent() {
+    typeChars("hello");
+    pressEnter();
+    dumpTraceOnFailure("hello+ENTER trace check");
+    Assert.assertEquals(
+        "ENTER-as-newline must be committed via commitText(\"\\n\", 1)",
+        1L,
+        countTraceMatches("IC commitText             args=[\n, 1]"));
+    Assert.assertEquals(
+        "no sendKeyEvent should fire for ENTER-as-newline",
+        0L,
+        countTraceMatches("IC sendKeyEvent"));
+  }
+
+  @Test
+  public void l_enter_with_ime_action_send_calls_performEditorAction_not_commitText_newline() {
+    // Restart the input as a SEND-action field.
+    EditorInfo editorInfo = createEditorInfoTextWithSuggestionsForSetUp();
+    editorInfo.imeOptions = EditorInfo.IME_ACTION_SEND;
+    mAnySoftKeyboardUnderTest.onFinishInputView(true);
+    mAnySoftKeyboardUnderTest.onFinishInput();
+    mAnySoftKeyboardUnderTest.onStartInput(editorInfo, false);
+    mAnySoftKeyboardUnderTest.onStartInputView(editorInfo, false);
+    mIc = getCurrentTestInputConnection();
+    mTrace.clear();
+    installIcTracers(mIc);
+    Mockito.doAnswer(recording("performEditorAction", mIc))
+        .when(mIc)
+        .performEditorAction(Mockito.anyInt());
+
+    typeChars("hello");
+    pressEnter();
+
+    dumpTraceOnFailure("hello+ENTER with IME_ACTION_SEND");
+    Assert.assertEquals(
+        "ENTER with IME_ACTION_SEND must call performEditorAction",
+        1L,
+        countTraceMatches("IC performEditorAction"));
+    Assert.assertEquals(
+        "ENTER with IME_ACTION_SEND must NOT commit a newline",
+        0L,
+        countTraceMatches("IC commitText             args=[\n, 1]"));
+  }
+}

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
@@ -110,12 +110,6 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
     return "\"" + s.toString().replace("\n", "\\n") + "\"";
   }
 
-  private void dumpTraceOnFailure(String scenario) {
-    System.out.println("---- TRACE: " + scenario + " ----");
-    for (String line : mTrace) System.out.println(line);
-    System.out.println("---- END TRACE ----");
-  }
-
   private void typeChars(String s) {
     for (char c : s.toCharArray()) {
       mark("key '" + c + "'");
@@ -138,14 +132,7 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
 
   private void assertEditorText(String scenario, String expected) {
     String actual = mIc.getCurrentTextInInputConnection();
-    if (!expected.equals(actual)) {
-      dumpTraceOnFailure(scenario);
-      Assert.fail(
-          "scenario=" + scenario + " expected=" + quote(expected) + " actual=" + quote(actual));
-    } else {
-      // Even on pass, dump the trace so we can see what ASK emitted.
-      dumpTraceOnFailure(scenario + " (PASS)");
-    }
+    Assert.assertEquals("scenario=" + scenario, expected, actual);
   }
 
   @Test
@@ -214,7 +201,6 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
   @Test
   public void j_digit_separator_uses_commitText_not_sendKeyEvent() {
     typeChars("k8s");
-    dumpTraceOnFailure("k8s trace check");
     Assert.assertEquals(
         "digit separator '8' must be committed via commitText",
         1L,
@@ -229,7 +215,6 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
   public void k_enter_as_newline_uses_commitText_not_sendKeyEvent() {
     typeChars("hello");
     pressEnter();
-    dumpTraceOnFailure("hello+ENTER trace check");
     Assert.assertEquals(
         "ENTER-as-newline must be committed via commitText(\"\\n\", 1)",
         1L,
@@ -259,7 +244,6 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
     typeChars("hello");
     pressEnter();
 
-    dumpTraceOnFailure("hello+ENTER with IME_ACTION_SEND");
     Assert.assertEquals(
         "ENTER with IME_ACTION_SEND must call performEditorAction",
         1L,
@@ -276,7 +260,6 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
     mTrace.clear();
     mAnySoftKeyboardUnderTest.pickSuggestionManually(0, "hello", true);
 
-    dumpTraceOnFailure("pickSuggestionManually auto-space check");
     Assert.assertEquals(
         "auto-space after suggestion pick must be committed via commitText(\" \", 1)",
         1L,

--- a/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/AnySoftKeyboardTypingCorruptionTest.java
@@ -16,12 +16,12 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
 /**
- * Static repro for two reported ASK bugs (evidence-gathering pass, no fix):
- * - typing letter+digit(+letter) can produce an extra letter (k8 -> k8k, k8s -> k8ks)
- * - typing a word then Enter can duplicate the word on the new line
+ * Static repro for two reported ASK bugs (evidence-gathering pass, no fix): - typing
+ * letter+digit(+letter) can produce an extra letter (k8 -> k8k, k8s -> k8ks) - typing a word then
+ * Enter can duplicate the word on the new line
  *
- * <p>Each scenario dumps every InputConnection call ASK emits, plus WordComposer state and
- * the resulting editor text/composing range after each key, then asserts the final text.
+ * <p>Each scenario dumps every InputConnection call ASK emits, plus WordComposer state and the
+ * resulting editor text/composing range after each key, then asserts the final text.
  */
 @RunWith(AnySoftKeyboardRobolectricTestRunner.class)
 public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest {
@@ -34,7 +34,8 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
     // Match the reporter's real config: suggestions on, autocorrect off,
     // auto-pick aggressiveness off, next-word suggestions on, no suggestion restart.
     SharedPrefsHelper.setPrefsValue(R.string.settings_key_show_suggestions, true);
-    SharedPrefsHelper.setPrefsValue(R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
+    SharedPrefsHelper.setPrefsValue(
+        R.string.settings_key_auto_pick_suggestion_aggressiveness, "none");
     SharedPrefsHelper.setPrefsValue(
         R.string.settings_key_next_word_suggestion_aggressiveness, "medium_aggressiveness");
     SharedPrefsHelper.setPrefsValue(R.string.settings_key_allow_suggestions_restart, false);
@@ -46,19 +47,24 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
   }
 
   private void installIcTracers(TestInputConnection ic) {
-    Mockito.doAnswer(recording("setComposingText", ic)).when(ic)
+    Mockito.doAnswer(recording("setComposingText", ic))
+        .when(ic)
         .setComposingText(Mockito.any(), Mockito.anyInt());
-    Mockito.doAnswer(recording("commitText", ic)).when(ic)
+    Mockito.doAnswer(recording("commitText", ic))
+        .when(ic)
         .commitText(Mockito.any(), Mockito.anyInt());
     Mockito.doAnswer(recording("finishComposingText", ic)).when(ic).finishComposingText();
-    Mockito.doAnswer(recording("setComposingRegion", ic)).when(ic)
+    Mockito.doAnswer(recording("setComposingRegion", ic))
+        .when(ic)
         .setComposingRegion(Mockito.anyInt(), Mockito.anyInt());
     Mockito.doAnswer(recording("beginBatchEdit", ic)).when(ic).beginBatchEdit();
     Mockito.doAnswer(recording("endBatchEdit", ic)).when(ic).endBatchEdit();
     Mockito.doAnswer(recording("sendKeyEvent", ic)).when(ic).sendKeyEvent(Mockito.any());
-    Mockito.doAnswer(recording("deleteSurroundingText", ic)).when(ic)
+    Mockito.doAnswer(recording("deleteSurroundingText", ic))
+        .when(ic)
         .deleteSurroundingText(Mockito.anyInt(), Mockito.anyInt());
-    Mockito.doAnswer(recording("setSelection", ic)).when(ic)
+    Mockito.doAnswer(recording("setSelection", ic))
+        .when(ic)
         .setSelection(Mockito.anyInt(), Mockito.anyInt());
   }
 
@@ -262,5 +268,22 @@ public class AnySoftKeyboardTypingCorruptionTest extends AnySoftKeyboardBaseTest
         "ENTER with IME_ACTION_SEND must NOT commit a newline",
         0L,
         countTraceMatches("IC commitText             args=[\n, 1]"));
+  }
+
+  @Test
+  public void m_manual_suggestion_pick_uses_commitText_for_autospace_not_sendKeyEvent() {
+    typeChars("hel");
+    mTrace.clear();
+    mAnySoftKeyboardUnderTest.pickSuggestionManually(0, "hello", true);
+
+    dumpTraceOnFailure("pickSuggestionManually auto-space check");
+    Assert.assertEquals(
+        "auto-space after suggestion pick must be committed via commitText(\" \", 1)",
+        1L,
+        countTraceMatches("IC commitText             args=[ , 1]"));
+    Assert.assertEquals(
+        "no sendKeyEvent should fire for the auto-space after suggestion pick",
+        0L,
+        countTraceMatches("IC sendKeyEvent"));
   }
 }


### PR DESCRIPTION
Fixes #4877.

`handleSeparator` commits the current word via `commitText`, then emits the separator via `sendKeyChar`. `sendKeyChar` delivers a real `KeyEvent`; on modern editors that re-inserts the just-committed text, producing `k8` → `k8k` and `hello`+Enter → `hellohello`. Space is unaffected because it uses `commitText` directly.

Fix: route the separator through `commitText` when IC is available; keep `sendKeyChar` as fallback. IME actions (Send/Go/Search) unchanged.

Tests: new `AnySoftKeyboardTypingCorruptionTest` covers text output and IC call sequence, plus a regression case for `IME_ACTION_SEND`. Two `AnySoftKeyboardGimmicksTest` tests that encoded the old behavior are updated. Verified on Pixel 9a / Android 17 across Messages, Chrome, Gmail (Send still fires), Slack, Hebrew, gesture typing.
