### PR TITLE
[LLM] Fix suggestions cancelled by taps below keyboard

### DIFF
--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardView.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardView.java
@@ -77,6 +77,7 @@ public class AnyKeyboardView extends AnyKeyboardViewWithExtraDraw
   private int mExtraBottomOffset;
   private int mWatermarkEdgeX = 0;
   private long mExtensionKeyboardAreaEntranceTime = -1;
+  private boolean mDismissTriggeredByCurrentTouch;
 
   public AnyKeyboardView(Context context, AttributeSet attrs) {
     this(context, attrs, 0);
@@ -255,6 +256,7 @@ public class AnyKeyboardView extends AnyKeyboardViewWithExtraDraw
 
     if (action == MotionEvent.ACTION_DOWN) {
       mGestureTypingPathShouldBeDrawn = false;
+      mDismissTriggeredByCurrentTouch = false;
 
       mFirstTouchPoint.x = (int) me.getX();
       mFirstTouchPoint.y = (int) me.getY();
@@ -265,8 +267,16 @@ public class AnyKeyboardView extends AnyKeyboardViewWithExtraDraw
     }
 
     // If the motion event is outside (up or down) the keyboard and it's a MOVE event
-    // coming even before the first MOVE event into the extension/bottom area
-    if (action == MotionEvent.ACTION_MOVE && me.getY() > mDismissYValue) {
+    // coming even before the first MOVE event into the extension/bottom area.
+    // The touch must have started on the keyboard itself (at or above the dismiss
+    // line): touches starting in the bottom system-padding area are taps on dead
+    // space, not swipe-down-to-hide gestures. Only fire once per touch, since a
+    // single swipe generates many MOVE events.
+    if (action == MotionEvent.ACTION_MOVE
+        && !mDismissTriggeredByCurrentTouch
+        && me.getY() > mDismissYValue
+        && mFirstTouchPoint.y <= mDismissYValue) {
+      mDismissTriggeredByCurrentTouch = true;
       MotionEvent cancel =
           MotionEvent.obtain(
               me.getDownTime(),

--- a/ime/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewTest.java
+++ b/ime/app/src/test/java/com/anysoftkeyboard/keyboards/views/AnyKeyboardViewTest.java
@@ -812,6 +812,62 @@ public class AnyKeyboardViewTest extends AnyKeyboardViewWithMiniKeyboardTest {
   }
 
   @Test
+  public void testTapInBottomPaddingDoesNotSwipeDown() {
+    // simulates the colorized nav-bar bottom padding: touches entirely below the
+    // keyboard must not be treated as swipe-down-to-hide.
+    mViewUnderTest.setBottomOffset(300);
+    final int keyboardHeight = mEnglishKeyboard.getHeight();
+    final int x = mViewUnderTest.getThemedKeyboardDimens().getKeyboardMaxWidth() / 2;
+    final int y = mViewUnderTest.getPaddingTop() + keyboardHeight + 100;
+
+    final long downTime = 1000;
+    MotionEvent down = MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, x, y, 0);
+    mViewUnderTest.onTouchEvent(down);
+    down.recycle();
+    for (int i = 1; i <= 4; i++) {
+      MotionEvent move =
+          MotionEvent.obtain(downTime, downTime + i * 150, MotionEvent.ACTION_MOVE, x, y, 0);
+      mViewUnderTest.onTouchEvent(move);
+      move.recycle();
+    }
+    MotionEvent up = MotionEvent.obtain(downTime, downTime + 800, MotionEvent.ACTION_UP, x, y, 0);
+    mViewUnderTest.onTouchEvent(up);
+    up.recycle();
+
+    Mockito.verify(mMockKeyboardListener, Mockito.never()).onSwipeDown();
+  }
+
+  @Test
+  public void testSwipeDownFromKeyFiresOnlyOnce() {
+    // a real swipe starting on a key and sliding into the bottom padding must
+    // trigger swipe-down exactly once, no matter how many MOVE events follow.
+    mViewUnderTest.setBottomOffset(300);
+    final Point start = getKeyCenterPoint(requireFindKey('a'));
+    final int endY = mViewUnderTest.getPaddingTop() + mEnglishKeyboard.getHeight() + 100;
+
+    final long downTime = 2000;
+    MotionEvent down =
+        MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, start.x, start.y, 0);
+    mViewUnderTest.onTouchEvent(down);
+    down.recycle();
+    // first move leaves the key quickly (cancels long-press), the rest linger
+    // in the padding with no movement so no fling is detected.
+    final long[] moveTimes = {downTime + 50, downTime + 200, downTime + 350, downTime + 500};
+    for (long eventTime : moveTimes) {
+      MotionEvent move =
+          MotionEvent.obtain(downTime, eventTime, MotionEvent.ACTION_MOVE, start.x, endY, 0);
+      mViewUnderTest.onTouchEvent(move);
+      move.recycle();
+    }
+    MotionEvent up =
+        MotionEvent.obtain(downTime, downTime + 800, MotionEvent.ACTION_UP, start.x, endY, 0);
+    mViewUnderTest.onTouchEvent(up);
+    up.recycle();
+
+    Mockito.verify(mMockKeyboardListener, Mockito.times(1)).onSwipeDown();
+  }
+
+  @Test
   public void testStaticBoundaryCheckSlowTouch() {
     SharedPrefsHelper.setPrefsValue(R.string.settings_key_touch_trajectory_correction, true);
     AnyKeyboard.AnyKey gKey = findKey('g');


### PR DESCRIPTION
Fixes #4884.

Taps in the bottom nav-bar padding triggered swipe-down-to-hide once per MOVE event, spamming CANCEL/hide requests and aborting correction forever for the input session.

The dismiss-on-MOVE path in AnyKeyboardView now requires the touch to have started on the keyboard itself and fires at most once per touch.

Regression tests: testTapInBottomPaddingDoesNotSwipeDown, testSwipeDownFromKeyFiresOnlyOnce in AnyKeyboardViewTest.