### PR TITLE
[LLM] Setup versioning and deployment promotion for IME v1.13-r2

### DIFF
--- a/.github/workflows/deployment_promote.yml
+++ b/.github/workflows/deployment_promote.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        refname: [main, release-branch-addons-v5.2-r1, release-branch-ime-v1.13-r1]
+        refname: [main, release-branch-addons-v5.2-r1, release-branch-ime-v1.13-r2]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6.0.3


### PR DESCRIPTION
Starting stable patch release v1.13-r2 from main.

Changes:
- deployment_promote.yml: point IME entry to release-branch-ime-v1.13-r2 (replacing v1.13-r1).
- ime/build.gradle: unchanged (same minor 1.13, patch counter continues from 1.13.547).

Follows README How to Start a New Release.