### PR TITLE
[LLM] Add final sigma to s-key popups and Greek layouts

### DIFF
--- a/addons/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty.xml
+++ b/addons/languages/brazilian/pack/src/main/res/xml/brazilian_qwerty.xml
@@ -34,7 +34,7 @@
     <Row>
         <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãāäåæąăαª"
              android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσ"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσς"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="ϕ"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/english/pack/src/main/res/xml/colemak.xml
+++ b/addons/languages/english/pack/src/main/res/xml/colemak.xml
@@ -20,7 +20,7 @@
     <Row>
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="!àáâãāäåæąăαª" ask:hintLabel="!" android:keyEdgeFlags="left"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="\@řŕρ" ask:hintLabel="\@"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="#§ßśŝšșσ" ask:hintLabel="#"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="#§ßśŝšșσς" ask:hintLabel="#"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="$țť\u0163τ" ask:hintLabel="$"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="%đďδ" ask:hintLabel="%"/>
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="\u0026ĥθ" ask:hintLabel="\u0026"/>

--- a/addons/languages/english/pack/src/main/res/xml/dvorak.xml
+++ b/addons/languages/english/pack/src/main/res/xml/dvorak.xml
@@ -26,7 +26,7 @@
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥθ"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="țť\u0163τ"/>
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñńν"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝšșσ" android:keyEdgeFlags="right"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝšșσς" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/english/pack/src/main/res/xml/halmak.xml
+++ b/addons/languages/english/pack/src/main/res/xml/halmak.xml
@@ -73,7 +73,7 @@
 
         <Key
             android:codes="115"
-            android:popupCharacters="§ßśŝšșσ"
+            android:popupCharacters="§ßśŝšșσς"
             android:keyEdgeFlags="left"
             android:keyLabel="s" />
 

--- a/addons/languages/english/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/english/pack/src/main/res/xml/qwerty.xml
@@ -34,7 +34,7 @@
     <Row>
         <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâǎãāäåæąăαª"
              android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσ"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσς"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="ϕ"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/english/pack/src/main/res/xml/workman.xml
+++ b/addons/languages/english/pack/src/main/res/xml/workman.xml
@@ -24,7 +24,7 @@ www.workmanlayout.com
 
     <Row>
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="!àáâãāäåæąăαª" ask:hintLabel="!" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\@§ßśŝšșσ" ask:hintLabel="\@"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\@§ßśŝšșσς" ask:hintLabel="\@"/>
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="#ĥθ" ask:hintLabel="#"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="$țť\u0163τ" ask:hintLabel="$"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="%ĝ" ask:hintLabel="%"/>

--- a/addons/languages/esperanto/pack/src/main/res/xml/esperanto_dvorak.xml
+++ b/addons/languages/esperanto/pack/src/main/res/xml/esperanto_dvorak.xml
@@ -26,7 +26,7 @@
         <Key android:codes="107" android:keyLabel="k" android:popupCharacters="θ"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="τ"/>
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ν"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="σ" android:keyEdgeFlags="right"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="σς" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/german/pack/src/main/res/xml/de_adnw.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_adnw.xml
@@ -38,7 +38,7 @@
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="{α∀"/>
     <Key android:codes="97" android:keyLabel="a" android:popupCharacters="}ε∃"/>
     <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
-    <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\?¿σΣ"/>
+    <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\?¿σςΣ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="(4νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="-6τ∂"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_adnw_koy.xml
@@ -37,7 +37,7 @@
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="{α∀"/>
     <Key android:codes="105" android:keyLabel="i" android:popupCharacters="}ε∃"/>
     <Key android:codes="117" android:keyLabel="u" android:popupCharacters="*ο∈"/>
-    <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\?¿σΣ"/>
+    <Key android:codes="100" android:keyLabel="d" android:popupCharacters="\?¿σςΣ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="(4νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="-6τ∂"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_neo2.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_neo2.xml
@@ -52,7 +52,7 @@
     <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
     <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
-    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σΣſ"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σςΣſ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(4νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")5ρℝ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-6τ∂"/>

--- a/addons/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
+++ b/addons/languages/german/pack/src/main/res/xml/de_neo2_simple.xml
@@ -50,7 +50,7 @@
     <Key android:codes="97" android:keyLabel="a" android:popupCharacters="{α∀"/>
     <Key android:codes="101" android:keyLabel="e" android:popupCharacters="}ε∃"/>
     <Key android:codes="111" android:keyLabel="o" android:popupCharacters="*ο∈"/>
-    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σſ"/>
+    <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\?¿σςſ"/>
     <Key android:codes="110" android:keyLabel="n" android:popupCharacters="(νℕ"/>
     <Key android:codes="114" android:keyLabel="r" android:popupCharacters=")ρℝ"/>
     <Key android:codes="116" android:keyLabel="t" android:popupCharacters="-τ∂"/>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty.xml
@@ -27,7 +27,7 @@
 
     <Row>
         <Key android:horizontalGap="5%p" android:codes="945" android:popupCharacters="ά" android:keyEdgeFlags="left"/>
-        <Key android:codes="963" />
+        <Key android:codes="963" android:popupCharacters="ς" />
         <Key android:codes="948"/>
         <Key android:codes="966"/>
         <Key android:codes="947"/>

--- a/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
+++ b/addons/languages/greek/pack/src/main/res/xml/greek_qwerty_polytonic.xml
@@ -39,7 +39,7 @@
 
     <Row>
         <Key android:horizontalGap="5%p" android:codes="945" android:keyEdgeFlags="left"/>
-        <Key android:codes="963" />
+        <Key android:codes="963" android:popupCharacters="ς" />
         <Key android:codes="948"/>
         <Key android:codes="966"/>
         <Key android:codes="947"/>

--- a/addons/languages/kachin/pack/src/main/res/xml/colemak.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/colemak.xml
@@ -20,7 +20,7 @@
     <Row>
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="!àáâãāäåæąăα" ask:hintLabel="!" android:keyEdgeFlags="left"/>
         <Key android:codes="114" android:keyLabel="r" android:popupCharacters="\@řŕρ" ask:hintLabel="\@"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="#§ßśŝšșσ" ask:hintLabel="#"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="#§ßśŝšșσς" ask:hintLabel="#"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="$țť\u0163τ" ask:hintLabel="$"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="%đďδ" ask:hintLabel="%"/>
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="\u0026ĥθ" ask:hintLabel="\u0026"/>

--- a/addons/languages/kachin/pack/src/main/res/xml/dvorak.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/dvorak.xml
@@ -26,7 +26,7 @@
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="ĥθ"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="țť\u0163τþ"/>
         <Key android:codes="110" android:keyLabel="n" android:popupCharacters="ñńν"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝšșσ" android:keyEdgeFlags="right"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ßśŝšșσς" android:keyEdgeFlags="right"/>
     </Row>
     
     <Row android:keyWidth="9.09%p">

--- a/addons/languages/kachin/pack/src/main/res/xml/halmak.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/halmak.xml
@@ -73,7 +73,7 @@
 
         <Key
             android:codes="115"
-            android:popupCharacters="§ßśŝšșσ"
+            android:popupCharacters="§ßśŝšșσς"
             android:keyEdgeFlags="left"
             android:keyLabel="s" />
 

--- a/addons/languages/kachin/pack/src/main/res/xml/qwerty.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/qwerty.xml
@@ -34,7 +34,7 @@
     <Row>
         <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="àáâãāäåæąăα"
              android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσ"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="§ßśŝšșσς"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="ϕ"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/kachin/pack/src/main/res/xml/workman.xml
+++ b/addons/languages/kachin/pack/src/main/res/xml/workman.xml
@@ -24,7 +24,7 @@ www.workmanlayout.com
 
     <Row>
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="!àáâãāäåæąăα" ask:hintLabel="!" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\@§ßśŝšșσ" ask:hintLabel="\@"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="\@§ßśŝšșσς" ask:hintLabel="\@"/>
         <Key android:codes="104" android:keyLabel="h" android:popupCharacters="#ĥθ" ask:hintLabel="#"/>
         <Key android:codes="116" android:keyLabel="t" android:popupCharacters="$țť\u0163τ" ask:hintLabel="$"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="%ĝ" ask:hintLabel="%"/>

--- a/addons/languages/romanian/pack/src/main/res/xml/romanian_qwerty.xml
+++ b/addons/languages/romanian/pack/src/main/res/xml/romanian_qwerty.xml
@@ -19,7 +19,7 @@
     <Row>
         <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:popupCharacters="ăâàáãāäåæąα"
              android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ș§ßśŝšσ"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="ș§ßśŝšσς"/>
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="ϕ"/>
         <Key android:codes="103" android:keyLabel="g" android:popupCharacters="ĝ"/>

--- a/addons/languages/songhay/pack/src/main/res/xml/songhay_layout.xml
+++ b/addons/languages/songhay/pack/src/main/res/xml/songhay_layout.xml
@@ -20,7 +20,7 @@
     <Row>
         <Key android:codes="97" android:keyLabel="a" android:popupCharacters="ãqàáâäåæą"
              android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="šŝśșσ§ß"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="šŝśșσς§ß"/>
         <Key android:codes="353" android:keyLabel="š" />
         <Key android:codes="100" android:keyLabel="d" android:popupCharacters="đďδ"/>
         <Key android:codes="102" android:keyLabel="f" android:popupCharacters="ϕ"/>

--- a/addons/languages/swedish/pack/src/main/res/xml/svorak.xml
+++ b/addons/languages/swedish/pack/src/main/res/xml/svorak.xml
@@ -89,7 +89,7 @@
             android:codes="115"
             android:keyEdgeFlags="right"
             android:keyLabel="s"
-            android:popupCharacters="ßśŝšșσ" />
+            android:popupCharacters="ßśŝšșσς" />
     </Row>
 
     <Row android:keyWidth="9.09%p">

--- a/ime/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
+++ b/ime/app/src/main/java/com/anysoftkeyboard/keyboards/ExternalAnyKeyboard.java
@@ -497,7 +497,7 @@ public class ExternalAnyKeyboard extends AnyKeyboard implements HardKeyboardTran
           key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
           break;
         case 's':
-          key.popupCharacters = "§ßśŝšșσ";
+          key.popupCharacters = "§ßśŝšșσς";
           key.popupResId = com.menny.android.anysoftkeyboard.R.xml.popup_one_row;
           break;
         case 't':


### PR DESCRIPTION
Fixes #4863.

Long-press s offered Greek sigma (U+03C3) but not final sigma (U+03C2), so e.g. Νταλας could not be typed.

Change: appends ς to every popupCharacters containing σ (english qwerty/dvorak/colemak/workman/halmak + kachin copies, brazilian, romanian, songhay, swedish svorak, esperanto, german neo/adnw), adds ς popup to Greek σ keys (greek_qwerty.xml, greek_qwerty_polytonic.xml), updates ExternalAnyKeyboard s fallback. No separate upper/lower handling needed: AnyPopupKeyboard auto-uppercases popups on Shift (σ,ς -> Σ).